### PR TITLE
Slice 1: business date, party, accounts, RecordEvent, PostEvent, Teller API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
+      - name: Zeitwerk check
+        run: bin/rails zeitwerk:check
+
       - name: Run tests
         run: |
           bin/rails db:test:prepare

--- a/app/controllers/teller/application_controller.rb
+++ b/app/controllers/teller/application_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Teller
+  # Style-A JSON workspace. CSRF is not applied on ActionController::API; protect this
+  # surface in production with mutual TLS, network policy, and/or API authentication.
+  class ApplicationController < ActionController::API
+  end
+end

--- a/app/controllers/teller/deposit_accounts_controller.rb
+++ b/app/controllers/teller/deposit_accounts_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Teller
+  class DepositAccountsController < ApplicationController
+    def create
+      party_record_id = params.require(:deposit_account).permit(:party_record_id).fetch(:party_record_id).to_i
+      account = Accounts::Commands::OpenAccount.call(party_record_id: party_record_id)
+      render json: {
+        id: account.id,
+        account_number: account.account_number,
+        product_code: account.product_code,
+        status: account.status
+      }, status: :created
+    rescue Accounts::Commands::OpenAccount::PartyNotFound
+      render json: { error: "party_not_found" }, status: :not_found
+    rescue Core::BusinessDate::Errors::NotSet
+      render json: { error: "business_date_not_set" }, status: :unprocessable_entity
+    end
+  end
+end

--- a/app/controllers/teller/operational_event_posts_controller.rb
+++ b/app/controllers/teller/operational_event_posts_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Teller
+  class OperationalEventPostsController < ApplicationController
+    def create
+      result = Core::Posting::Commands::PostEvent.call(operational_event_id: params[:id].to_i)
+      status = result[:outcome] == :posted ? :created : :ok
+      render json: {
+        outcome: result[:outcome],
+        operational_event_id: result[:event].id
+      }, status: status
+    rescue Core::Posting::Commands::PostEvent::NotFound
+      render json: { error: "not_found" }, status: :not_found
+    rescue Core::Posting::Commands::PostEvent::InvalidState => e
+      render json: { error: "invalid_state", message: e.message }, status: :unprocessable_entity
+    end
+  end
+end

--- a/app/controllers/teller/operational_events_controller.rb
+++ b/app/controllers/teller/operational_events_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Teller
+  class OperationalEventsController < ApplicationController
+    def create
+      attrs = params.require(:operational_event).permit(
+        :event_type, :channel, :idempotency_key, :amount_minor_units, :currency, :source_account_id, :business_date
+      ).to_h.symbolize_keys
+      attrs[:amount_minor_units] = attrs[:amount_minor_units].to_i
+      attrs[:source_account_id] = attrs[:source_account_id].to_i
+      if attrs[:business_date].present?
+        attrs[:business_date] = Date.iso8601(attrs[:business_date].to_s)
+      else
+        attrs.delete(:business_date)
+      end
+
+      result = Core::OperationalEvents::Commands::RecordEvent.call(**attrs)
+      status = result[:outcome] == :created ? :created : :ok
+      render json: {
+        id: result[:event].id,
+        outcome: result[:outcome],
+        operational_event_id: result[:event].id
+      }, status: status
+    rescue Core::OperationalEvents::Commands::RecordEvent::InvalidRequest => e
+      render json: { error: "invalid_request", message: e.message }, status: :unprocessable_entity
+    rescue Core::OperationalEvents::Commands::RecordEvent::MismatchedIdempotency => e
+      render json: { error: "idempotency_conflict", fingerprint: e.fingerprint }, status: :conflict
+    rescue Core::OperationalEvents::Commands::RecordEvent::PostedReplay => e
+      render json: { error: "posted_replay", message: e.message.presence || "already posted" }, status: :conflict
+    end
+  end
+end

--- a/app/controllers/teller/parties_controller.rb
+++ b/app/controllers/teller/parties_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Teller
+  class PartiesController < ApplicationController
+    def create
+      record = Party::Commands::CreateParty.call(**create_params)
+      render json: { id: record.id, name: record.name, party_type: record.party_type }, status: :created
+    rescue Party::Commands::CreateParty::UnsupportedPartyType => e
+      render json: { error: e.class.name, message: e.message }, status: :unprocessable_entity
+    end
+
+    private
+
+    def create_params
+      params.permit(:party_type, :first_name, :middle_name, :last_name, :name_suffix).to_h.symbolize_keys
+    end
+  end
+end

--- a/app/domains/accounts.rb
+++ b/app/domains/accounts.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Accounts
+  # ADR-0011 — canonical stub until Products domain exists.
+  SLICE1_PRODUCT_CODE = "slice1_demand_deposit"
+end

--- a/app/domains/accounts/commands/open_account.rb
+++ b/app/domains/accounts/commands/open_account.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Commands
+    class OpenAccount
+      class PartyNotFound < StandardError; end
+
+      # @param party_record_id [Integer]
+      # @param effective_on [Date, nil] defaults to Core::BusinessDate
+      def self.call(party_record_id:, effective_on: nil)
+        begin
+          Party::Queries::FindParty.by_id(party_record_id)
+        rescue ActiveRecord::RecordNotFound
+          raise PartyNotFound, "party_record_id=#{party_record_id} not found"
+        end
+
+        on_date = effective_on || Core::BusinessDate::Services::CurrentBusinessDate.call
+
+        Models::DepositAccount.transaction do
+          account = Models::DepositAccount.create!(
+            account_number: generate_account_number,
+            currency: "USD",
+            status: Models::DepositAccount::STATUS_OPEN,
+            product_code: Accounts::SLICE1_PRODUCT_CODE
+          )
+
+          Models::DepositAccountParty.create!(
+            deposit_account: account,
+            party_record_id: party_record_id,
+            role: Models::DepositAccountParty::ROLE_OWNER,
+            status: Models::DepositAccountParty::STATUS_ACTIVE,
+            effective_on: on_date,
+            ended_on: nil
+          )
+
+          account.reload
+        end
+      end
+
+      def self.generate_account_number
+        "DA#{SecureRandom.hex(8).upcase}"
+      end
+      private_class_method :generate_account_number
+    end
+  end
+end

--- a/app/domains/accounts/models/deposit_account.rb
+++ b/app/domains/accounts/models/deposit_account.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Models
+    class DepositAccount < ApplicationRecord
+      self.table_name = "deposit_accounts"
+
+      STATUS_OPEN = "open"
+      STATUS_CLOSED = "closed"
+
+      has_many :deposit_account_parties, class_name: "Accounts::Models::DepositAccountParty", dependent: :restrict_with_exception,
+        inverse_of: :deposit_account
+
+      validates :account_number, presence: true, uniqueness: true
+      validates :currency, presence: true
+      validates :status, presence: true, inclusion: { in: [STATUS_OPEN, STATUS_CLOSED] }
+      validates :product_code, presence: true
+    end
+  end
+end

--- a/app/domains/accounts/models/deposit_account_party.rb
+++ b/app/domains/accounts/models/deposit_account_party.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Models
+    class DepositAccountParty < ApplicationRecord
+      self.table_name = "deposit_account_parties"
+
+      ROLE_OWNER = "owner"
+      STATUS_ACTIVE = "active"
+      STATUS_PENDING = "pending"
+      STATUS_INACTIVE = "inactive"
+
+      belongs_to :deposit_account, class_name: "Accounts::Models::DepositAccount"
+      belongs_to :party_record, class_name: "Party::Models::PartyRecord"
+
+      validates :role, presence: true
+      validates :status, presence: true
+      validates :effective_on, presence: true
+    end
+  end
+end

--- a/app/domains/core/business_date/commands/advance_business_date.rb
+++ b/app/domains/core/business_date/commands/advance_business_date.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Core
+  module BusinessDate
+    module Commands
+      # Moves the singleton processing date forward by one calendar day.
+      class AdvanceBusinessDate
+        def self.call
+          setting = Models::BusinessDateSetting.singleton
+          setting.update!(current_business_on: setting.current_business_on + 1.day)
+          setting
+        end
+      end
+    end
+  end
+end

--- a/app/domains/core/business_date/commands/set_business_date.rb
+++ b/app/domains/core/business_date/commands/set_business_date.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Core
+  module BusinessDate
+    module Commands
+      # Sets or replaces the singleton processing date (bootstrap / ops / tests).
+      class SetBusinessDate
+        def self.call(on:)
+          date = on.is_a?(Date) ? on : Date.iso8601(on.to_s)
+          setting = Models::BusinessDateSetting.first_or_initialize
+          setting.current_business_on = date
+          setting.save!
+          setting
+        end
+      end
+    end
+  end
+end

--- a/app/domains/core/business_date/errors.rb
+++ b/app/domains/core/business_date/errors.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Core
+  module BusinessDate
+    module Errors
+      class NotSet < StandardError; end
+    end
+  end
+end

--- a/app/domains/core/business_date/models/business_date_setting.rb
+++ b/app/domains/core/business_date/models/business_date_setting.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Core
+  module BusinessDate
+    module Models
+      # Single-row institution processing calendar (slice 1). See GitHub Slice 1 #2.
+      class BusinessDateSetting < ApplicationRecord
+        self.table_name = "core_business_date_settings"
+
+        validates :current_business_on, presence: true
+
+        def self.singleton
+          first || raise(Core::BusinessDate::Errors::NotSet, "core_business_date_settings has no row; run seeds or SetBusinessDate")
+        end
+      end
+    end
+  end
+end

--- a/app/domains/core/business_date/services/current_business_date.rb
+++ b/app/domains/core/business_date/services/current_business_date.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Core
+  module BusinessDate
+    module Services
+      class CurrentBusinessDate
+        def self.call
+          row = Models::BusinessDateSetting.first
+          return row.current_business_on if row
+
+          raise Errors::NotSet, "No core_business_date_settings row; seed or run SetBusinessDate"
+        end
+      end
+    end
+  end
+end

--- a/app/domains/core/operational_events/commands/record_event.rb
+++ b/app/domains/core/operational_events/commands/record_event.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "digest"
+
+module Core
+  module OperationalEvents
+    module Commands
+      class RecordEvent
+        class Error < StandardError; end
+        class InvalidRequest < Error; end
+        class MismatchedIdempotency < Error
+          attr_reader :fingerprint
+
+          def initialize(fingerprint)
+            @fingerprint = fingerprint
+            super("idempotency_key replay does not match original request fingerprint=#{fingerprint}")
+          end
+        end
+
+        class PostedReplay < Error
+          def initialize(message = "operational event already posted for this idempotency key")
+            super(message)
+          end
+        end
+
+        SLICE_EVENT_TYPES = %w[deposit.accepted].freeze
+        CHANNELS = %w[teller api batch system].freeze
+
+        # @return [Hash] `{ outcome: :created|:replay, event: OperationalEvent }`
+        def self.call(
+          event_type:,
+          channel:,
+          idempotency_key:,
+          amount_minor_units:,
+          currency:,
+          source_account_id:,
+          business_date: nil
+        )
+          validate_channel!(channel)
+          validate_event_type!(event_type)
+          validate_deposit_accepted!(amount_minor_units, currency, source_account_id)
+          validate_source_account!(source_account_id)
+
+          on_date = business_date || Core::BusinessDate::Services::CurrentBusinessDate.call
+          incoming_fp = fingerprint(
+            event_type: event_type,
+            channel: channel,
+            idempotency_key: idempotency_key,
+            amount_minor_units: amount_minor_units,
+            currency: currency,
+            source_account_id: source_account_id
+          )
+
+          begin
+            Models::OperationalEvent.transaction(requires_new: true) do
+              existing = Models::OperationalEvent.lock.find_by(channel: channel, idempotency_key: idempotency_key)
+              if existing
+                return handle_existing(existing, incoming_fp)
+              end
+
+              event = Models::OperationalEvent.create!(
+                event_type: event_type,
+                status: Models::OperationalEvent::STATUS_PENDING,
+                business_date: on_date,
+                channel: channel,
+                idempotency_key: idempotency_key,
+                amount_minor_units: amount_minor_units,
+                currency: currency,
+                source_account_id: source_account_id
+              )
+              { outcome: :created, event: event }
+            end
+          rescue ActiveRecord::RecordNotUnique
+            existing = Models::OperationalEvent.find_by!(channel: channel, idempotency_key: idempotency_key)
+            handle_existing(existing, incoming_fp)
+          end
+        end
+
+        def self.fingerprint(event_type:, channel:, idempotency_key:, amount_minor_units:, currency:, source_account_id:)
+          payload = {
+            event_type: event_type,
+            channel: channel,
+            idempotency_key: idempotency_key,
+            amount_minor_units: amount_minor_units.to_i,
+            currency: currency.to_s,
+            source_account_id: source_account_id.to_i
+          }
+          Digest::SHA256.hexdigest(payload.to_json)
+        end
+
+        def self.validate_channel!(channel)
+          return if CHANNELS.include?(channel.to_s)
+
+          raise InvalidRequest, "channel must be one of: #{CHANNELS.join(", ")}"
+        end
+
+        def self.validate_event_type!(event_type)
+          return if SLICE_EVENT_TYPES.include?(event_type.to_s)
+
+          raise InvalidRequest, "event_type not supported in slice 1: #{event_type.inspect}"
+        end
+
+        def self.validate_deposit_accepted!(amount_minor_units, currency, source_account_id)
+          if amount_minor_units.nil? || amount_minor_units.to_i <= 0
+            raise InvalidRequest, "amount_minor_units must be a positive integer"
+          end
+          raise InvalidRequest, "currency is required" if currency.blank?
+          raise InvalidRequest, "currency must be USD for slice 1" unless currency.to_s == "USD"
+          raise InvalidRequest, "source_account_id is required for deposit.accepted" if source_account_id.blank?
+        end
+
+        def self.validate_source_account!(source_account_id)
+          acc = Accounts::Models::DepositAccount.find_by(id: source_account_id)
+          raise InvalidRequest, "source_account_id not found" if acc.nil?
+          raise InvalidRequest, "source account must be open" unless acc.status == Accounts::Models::DepositAccount::STATUS_OPEN
+        end
+
+        def self.handle_existing(existing, incoming_fp)
+          existing_fp = fingerprint(
+            event_type: existing.event_type,
+            channel: existing.channel,
+            idempotency_key: existing.idempotency_key,
+            amount_minor_units: existing.amount_minor_units,
+            currency: existing.currency,
+            source_account_id: existing.source_account_id
+          )
+          raise MismatchedIdempotency.new(incoming_fp) if existing_fp != incoming_fp
+          raise PostedReplay if existing.status == Models::OperationalEvent::STATUS_POSTED
+
+          { outcome: :replay, event: existing }
+        end
+        private_class_method :handle_existing
+      end
+    end
+  end
+end

--- a/app/domains/core/operational_events/models/operational_event.rb
+++ b/app/domains/core/operational_events/models/operational_event.rb
@@ -6,6 +6,11 @@ module Core
       class OperationalEvent < ApplicationRecord
         self.table_name = "operational_events"
 
+        STATUS_PENDING = "pending"
+        STATUS_POSTED = "posted"
+
+        belongs_to :source_account, class_name: "Accounts::Models::DepositAccount", optional: true
+
         has_many :posting_batches, class_name: "Core::Posting::Models::PostingBatch", dependent: :restrict_with_exception
         has_many :journal_entries, class_name: "Core::Ledger::Models::JournalEntry", dependent: :restrict_with_exception
       end

--- a/app/domains/core/posting/commands/post_event.rb
+++ b/app/domains/core/posting/commands/post_event.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Core
+  module Posting
+    module Commands
+      class PostEvent
+        class Error < StandardError; end
+        class NotFound < Error; end
+        class InvalidState < Error; end
+
+        # @return [Hash] `{ outcome: :posted|:already_posted, event: OperationalEvent }`
+        def self.call(operational_event_id:)
+          Core::OperationalEvents::Models::OperationalEvent.transaction do
+            event = Core::OperationalEvents::Models::OperationalEvent.lock.find_by(id: operational_event_id)
+            raise NotFound, "operational_event_id=#{operational_event_id}" if event.nil?
+
+            if event.status == Core::OperationalEvents::Models::OperationalEvent::STATUS_POSTED
+              return { outcome: :already_posted, event: event }
+            end
+
+            unless event.status == Core::OperationalEvents::Models::OperationalEvent::STATUS_PENDING
+              raise InvalidState, "operational event must be pending, was #{event.status.inspect}"
+            end
+
+            raise InvalidState, "unsupported event_type for slice 1 posting" unless event.event_type == "deposit.accepted"
+
+            amount = event.amount_minor_units
+            raise InvalidState, "amount_minor_units required" if amount.nil? || amount <= 0
+
+            cash = Core::Ledger::Models::GlAccount.find_by!(account_number: "1110")
+            dda = Core::Ledger::Models::GlAccount.find_by!(account_number: "2110")
+
+            legs_balanced!(amount)
+
+            batch = Core::Posting::Models::PostingBatch.create!(
+              operational_event: event,
+              status: "pending"
+            )
+
+            entry = Core::Ledger::Models::JournalEntry.create!(
+              posting_batch: batch,
+              operational_event: event,
+              business_date: event.business_date,
+              currency: event.currency,
+              narrative: event.event_type,
+              effective_at: Time.current
+            )
+
+            Core::Ledger::Models::JournalLine.create!(
+              journal_entry: entry,
+              sequence_no: 1,
+              side: "debit",
+              gl_account: cash,
+              amount_minor_units: amount
+            )
+            Core::Ledger::Models::JournalLine.create!(
+              journal_entry: entry,
+              sequence_no: 2,
+              side: "credit",
+              gl_account: dda,
+              amount_minor_units: amount
+            )
+
+            ActiveRecord::Base.connection.execute("SET CONSTRAINTS ALL IMMEDIATE")
+
+            batch.update!(status: "posted")
+            event.update!(status: Core::OperationalEvents::Models::OperationalEvent::STATUS_POSTED)
+
+            { outcome: :posted, event: event }
+          end
+        end
+
+        def self.legs_balanced!(amount_minor_units)
+          debit = amount_minor_units
+          credit = amount_minor_units
+          raise InvalidState, "unbalanced legs" unless debit == credit
+        end
+        private_class_method :legs_balanced!
+      end
+    end
+  end
+end

--- a/app/domains/party/commands/create_party.rb
+++ b/app/domains/party/commands/create_party.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Party
+  module Commands
+    class CreateParty
+      class UnsupportedPartyType < StandardError; end
+
+      # Slice 1: individual + profile only (GitHub #3).
+      def self.call(party_type:, first_name:, last_name:, middle_name: nil, name_suffix: nil, **profile_attrs)
+        type = party_type.to_s
+        raise UnsupportedPartyType, "slice 1 supports #{Models::PartyRecord::INDIVIDUAL} only" if type != Models::PartyRecord::INDIVIDUAL
+
+        Models::PartyRecord.transaction do
+          name = Services::IndividualDisplayName.build(
+            first_name: first_name,
+            last_name: last_name,
+            middle_name: middle_name,
+            name_suffix: name_suffix
+          )
+          record = Models::PartyRecord.create!(party_type: type, name: name)
+          Models::PartyIndividualProfile.create!(
+            { party_record: record, first_name: first_name, last_name: last_name, middle_name: middle_name,
+              name_suffix: name_suffix }.merge(profile_attrs.slice(:preferred_first_name, :preferred_last_name, :date_of_birth, :occupation, :employer))
+          )
+          record.reload
+        end
+      end
+    end
+  end
+end

--- a/app/domains/party/models/party_individual_profile.rb
+++ b/app/domains/party/models/party_individual_profile.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Party
+  module Models
+    class PartyIndividualProfile < ApplicationRecord
+      self.table_name = "party_individual_profiles"
+
+      belongs_to :party_record, class_name: "Party::Models::PartyRecord"
+    end
+  end
+end

--- a/app/domains/party/models/party_record.rb
+++ b/app/domains/party/models/party_record.rb
@@ -2,9 +2,16 @@
 
 module Party
   module Models
-    # Aggregate root for Party; physical schema in docs/adr/0009-initial-party-persistence-schema.md.
-    # Replace with ApplicationRecord subclass when party_records migration exists.
-    class PartyRecord
+    class PartyRecord < ApplicationRecord
+      self.table_name = "party_records"
+
+      INDIVIDUAL = "individual"
+
+      has_one :individual_profile, class_name: "Party::Models::PartyIndividualProfile", dependent: :restrict_with_exception,
+        inverse_of: :party_record
+
+      validates :name, presence: true
+      validates :party_type, presence: true
     end
   end
 end

--- a/app/domains/party/queries/find_party.rb
+++ b/app/domains/party/queries/find_party.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Party
+  module Queries
+    class FindParty
+      def self.by_id(id)
+        Models::PartyRecord.find(id)
+      end
+    end
+  end
+end

--- a/app/domains/party/services/individual_display_name.rb
+++ b/app/domains/party/services/individual_display_name.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Party
+  module Services
+    # ADR-0009 §2.3 — display `party_records.name` for individuals (not preferred_* fields).
+    class IndividualDisplayName
+      def self.build(first_name:, last_name:, middle_name: nil, name_suffix: nil)
+        parts = [first_name, middle_name.presence, last_name].compact
+        base = parts.join(" ")
+        name_suffix.present? ? "#{base}, #{name_suffix}" : base
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,13 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
+  scope path: "teller", defaults: { format: :json }, module: :teller do
+    post "parties", to: "parties#create"
+    post "deposit_accounts", to: "deposit_accounts#create"
+    post "operational_events", to: "operational_events#create"
+    post "operational_events/:id/post", to: "operational_event_posts#create"
+  end
+
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/migrate/20260422130001_create_core_business_date_settings.rb
+++ b/db/migrate/20260422130001_create_core_business_date_settings.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CreateCoreBusinessDateSettings < ActiveRecord::Migration[8.1]
+  def change
+    create_table :core_business_date_settings do |t|
+      t.date :current_business_on, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260422130002_create_party_records.rb
+++ b/db/migrate/20260422130002_create_party_records.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreatePartyRecords < ActiveRecord::Migration[8.1]
+  def change
+    create_table :party_records do |t|
+      t.string :name, null: false
+      t.string :party_type, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260422130003_create_party_individual_profiles.rb
+++ b/db/migrate/20260422130003_create_party_individual_profiles.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreatePartyIndividualProfiles < ActiveRecord::Migration[8.1]
+  def change
+    create_table :party_individual_profiles do |t|
+      t.bigint :party_record_id, null: false
+      t.string :first_name, null: false
+      t.string :middle_name
+      t.string :last_name, null: false
+      t.string :name_suffix
+      t.string :preferred_first_name
+      t.string :preferred_last_name
+      t.date :date_of_birth
+      t.string :occupation
+      t.string :employer
+      t.timestamps
+    end
+
+    add_foreign_key :party_individual_profiles, :party_records
+    add_index :party_individual_profiles, :party_record_id, unique: true
+  end
+end

--- a/db/migrate/20260422130004_create_deposit_accounts.rb
+++ b/db/migrate/20260422130004_create_deposit_accounts.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateDepositAccounts < ActiveRecord::Migration[8.1]
+  def change
+    create_table :deposit_accounts do |t|
+      t.string :account_number, null: false
+      t.string :currency, null: false, default: "USD"
+      t.string :status, null: false
+      t.string :product_code, null: false
+      t.timestamps
+    end
+
+    add_index :deposit_accounts, :account_number, unique: true
+  end
+end

--- a/db/migrate/20260422130005_create_deposit_account_parties.rb
+++ b/db/migrate/20260422130005_create_deposit_account_parties.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class CreateDepositAccountParties < ActiveRecord::Migration[8.1]
+  def change
+    create_table :deposit_account_parties do |t|
+      t.bigint :deposit_account_id, null: false
+      t.bigint :party_record_id, null: false
+      t.string :role, null: false
+      t.string :status, null: false
+      t.date :effective_on, null: false
+      t.date :ended_on
+      t.timestamps
+    end
+
+    add_foreign_key :deposit_account_parties, :deposit_accounts
+    add_foreign_key :deposit_account_parties, :party_records
+    add_index :deposit_account_parties, :deposit_account_id
+    add_index :deposit_account_parties, :party_record_id
+    add_index :deposit_account_parties,
+      %i[deposit_account_id party_record_id role],
+      unique: true,
+      name: "index_dap_unique_open_active_per_account_party_role",
+      where: "status = 'active' AND ended_on IS NULL"
+  end
+end

--- a/db/migrate/20260422130007_add_source_account_id_to_operational_events.rb
+++ b/db/migrate/20260422130007_add_source_account_id_to_operational_events.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSourceAccountIdToOperationalEvents < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :operational_events, :source_account, foreign_key: { to_table: :deposit_accounts }, null: true
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,7 @@
 require_relative "../lib/bank_core/seeds/gl_coa"
 
 BankCore::Seeds::GlCoa.seed!
+
+if Core::BusinessDate::Models::BusinessDateSetting.none?
+  Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.current)
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -93,6 +93,107 @@ CREATE TABLE public.ar_internal_metadata (
 
 
 --
+-- Name: core_business_date_settings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.core_business_date_settings (
+    id bigint NOT NULL,
+    current_business_on date NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: core_business_date_settings_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.core_business_date_settings_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: core_business_date_settings_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.core_business_date_settings_id_seq OWNED BY public.core_business_date_settings.id;
+
+
+--
+-- Name: deposit_account_parties; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.deposit_account_parties (
+    id bigint NOT NULL,
+    deposit_account_id bigint NOT NULL,
+    party_record_id bigint NOT NULL,
+    role character varying NOT NULL,
+    status character varying NOT NULL,
+    effective_on date NOT NULL,
+    ended_on date,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: deposit_account_parties_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.deposit_account_parties_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: deposit_account_parties_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.deposit_account_parties_id_seq OWNED BY public.deposit_account_parties.id;
+
+
+--
+-- Name: deposit_accounts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.deposit_accounts (
+    id bigint NOT NULL,
+    account_number character varying NOT NULL,
+    currency character varying DEFAULT 'USD'::character varying NOT NULL,
+    status character varying NOT NULL,
+    product_code character varying NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: deposit_accounts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.deposit_accounts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: deposit_accounts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.deposit_accounts_id_seq OWNED BY public.deposit_accounts.id;
+
+
+--
 -- Name: gl_accounts; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -182,7 +283,7 @@ CREATE TABLE public.journal_lines (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     CONSTRAINT journal_lines_amount_non_negative CHECK ((amount_minor_units >= 0)),
-    CONSTRAINT journal_lines_side_enum CHECK (((side)::text = ANY ((ARRAY['debit'::character varying, 'credit'::character varying])::text[])))
+    CONSTRAINT journal_lines_side_enum CHECK (((side)::text = ANY (ARRAY[('debit'::character varying)::text, ('credit'::character varying)::text])))
 );
 
 
@@ -219,7 +320,8 @@ CREATE TABLE public.operational_events (
     currency character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    channel character varying NOT NULL
+    channel character varying NOT NULL,
+    source_account_id bigint
 );
 
 
@@ -240,6 +342,78 @@ CREATE SEQUENCE public.operational_events_id_seq
 --
 
 ALTER SEQUENCE public.operational_events_id_seq OWNED BY public.operational_events.id;
+
+
+--
+-- Name: party_individual_profiles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.party_individual_profiles (
+    id bigint NOT NULL,
+    party_record_id bigint NOT NULL,
+    first_name character varying NOT NULL,
+    middle_name character varying,
+    last_name character varying NOT NULL,
+    name_suffix character varying,
+    preferred_first_name character varying,
+    preferred_last_name character varying,
+    date_of_birth date,
+    occupation character varying,
+    employer character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: party_individual_profiles_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.party_individual_profiles_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: party_individual_profiles_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.party_individual_profiles_id_seq OWNED BY public.party_individual_profiles.id;
+
+
+--
+-- Name: party_records; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.party_records (
+    id bigint NOT NULL,
+    name character varying NOT NULL,
+    party_type character varying NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: party_records_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.party_records_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: party_records_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.party_records_id_seq OWNED BY public.party_records.id;
 
 
 --
@@ -284,6 +458,27 @@ CREATE TABLE public.schema_migrations (
 
 
 --
+-- Name: core_business_date_settings id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.core_business_date_settings ALTER COLUMN id SET DEFAULT nextval('public.core_business_date_settings_id_seq'::regclass);
+
+
+--
+-- Name: deposit_account_parties id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.deposit_account_parties ALTER COLUMN id SET DEFAULT nextval('public.deposit_account_parties_id_seq'::regclass);
+
+
+--
+-- Name: deposit_accounts id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.deposit_accounts ALTER COLUMN id SET DEFAULT nextval('public.deposit_accounts_id_seq'::regclass);
+
+
+--
 -- Name: gl_accounts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -312,6 +507,20 @@ ALTER TABLE ONLY public.operational_events ALTER COLUMN id SET DEFAULT nextval('
 
 
 --
+-- Name: party_individual_profiles id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.party_individual_profiles ALTER COLUMN id SET DEFAULT nextval('public.party_individual_profiles_id_seq'::regclass);
+
+
+--
+-- Name: party_records id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.party_records ALTER COLUMN id SET DEFAULT nextval('public.party_records_id_seq'::regclass);
+
+
+--
 -- Name: posting_batches id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -324,6 +533,30 @@ ALTER TABLE ONLY public.posting_batches ALTER COLUMN id SET DEFAULT nextval('pub
 
 ALTER TABLE ONLY public.ar_internal_metadata
     ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
+
+
+--
+-- Name: core_business_date_settings core_business_date_settings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.core_business_date_settings
+    ADD CONSTRAINT core_business_date_settings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: deposit_account_parties deposit_account_parties_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.deposit_account_parties
+    ADD CONSTRAINT deposit_account_parties_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: deposit_accounts deposit_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.deposit_accounts
+    ADD CONSTRAINT deposit_accounts_pkey PRIMARY KEY (id);
 
 
 --
@@ -359,6 +592,22 @@ ALTER TABLE ONLY public.operational_events
 
 
 --
+-- Name: party_individual_profiles party_individual_profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.party_individual_profiles
+    ADD CONSTRAINT party_individual_profiles_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: party_records party_records_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.party_records
+    ADD CONSTRAINT party_records_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: posting_batches posting_batches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -372,6 +621,34 @@ ALTER TABLE ONLY public.posting_batches
 
 ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: index_dap_unique_open_active_per_account_party_role; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_dap_unique_open_active_per_account_party_role ON public.deposit_account_parties USING btree (deposit_account_id, party_record_id, role) WHERE (((status)::text = 'active'::text) AND (ended_on IS NULL));
+
+
+--
+-- Name: index_deposit_account_parties_on_deposit_account_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_deposit_account_parties_on_deposit_account_id ON public.deposit_account_parties USING btree (deposit_account_id);
+
+
+--
+-- Name: index_deposit_account_parties_on_party_record_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_deposit_account_parties_on_party_record_id ON public.deposit_account_parties USING btree (party_record_id);
+
+
+--
+-- Name: index_deposit_accounts_on_account_number; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_deposit_accounts_on_account_number ON public.deposit_accounts USING btree (account_number);
 
 
 --
@@ -438,6 +715,20 @@ CREATE UNIQUE INDEX index_operational_events_on_channel_and_idempotency_key ON p
 
 
 --
+-- Name: index_operational_events_on_source_account_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_operational_events_on_source_account_id ON public.operational_events USING btree (source_account_id);
+
+
+--
+-- Name: index_party_individual_profiles_on_party_record_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_party_individual_profiles_on_party_record_id ON public.party_individual_profiles USING btree (party_record_id);
+
+
+--
 -- Name: index_posting_batches_on_operational_event_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -463,6 +754,38 @@ CREATE CONSTRAINT TRIGGER journal_lines_balance_check AFTER INSERT OR DELETE OR 
 --
 
 CREATE TRIGGER journal_lines_immutability_check BEFORE DELETE OR UPDATE ON public.journal_lines FOR EACH ROW EXECUTE FUNCTION public.ledger_journal_lines_reject_mutations();
+
+
+--
+-- Name: deposit_account_parties fk_deposit_account_parties_deposit_account; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.deposit_account_parties
+    ADD CONSTRAINT fk_deposit_account_parties_deposit_account FOREIGN KEY (deposit_account_id) REFERENCES public.deposit_accounts(id);
+
+
+--
+-- Name: deposit_account_parties fk_deposit_account_parties_party_record; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.deposit_account_parties
+    ADD CONSTRAINT fk_deposit_account_parties_party_record FOREIGN KEY (party_record_id) REFERENCES public.party_records(id);
+
+
+--
+-- Name: operational_events fk_operational_events_source_account; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.operational_events
+    ADD CONSTRAINT fk_operational_events_source_account FOREIGN KEY (source_account_id) REFERENCES public.deposit_accounts(id);
+
+
+--
+-- Name: party_individual_profiles fk_party_individual_profiles_party_record; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.party_individual_profiles
+    ADD CONSTRAINT fk_party_individual_profiles_party_record FOREIGN KEY (party_record_id) REFERENCES public.party_records(id);
 
 
 --
@@ -528,6 +851,12 @@ ALTER TABLE ONLY public.journal_lines
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260422130007'),
+('20260422130005'),
+('20260422130004'),
+('20260422130003'),
+('20260422130002'),
+('20260422130001'),
 ('20260422120011'),
 ('20260422120010'),
 ('20260422120005'),

--- a/docs/adr/0007-party-account-ownership.md
+++ b/docs/adr/0007-party-account-ownership.md
@@ -143,7 +143,8 @@ Same columns, with `loan_account_id` (FK → `loan_accounts`) replacing `deposit
 * [ADR-0005](0005-product-configuration-framework.md) — product behavior vs party-on-account contract  
 * [ADR-0006](0006-canonical-party-cif-model.md) — conceptual party-to-account separation  
 * [ADR-0009](0009-initial-party-persistence-schema.md) — `party_records` / profiles (FK target for `party_record_id`)  
-* [ADR-0010](0010-ledger-persistence-and-seeded-coa.md) — ledger tables do not encode CIF participation
+* [ADR-0010](0010-ledger-persistence-and-seeded-coa.md) — ledger tables do not encode CIF participation  
+* [ADR-0011](0011-accounts-deposit-vertical-slice-mvp.md) — **deposit-only** slice 1 addendum (`deposit_accounts`, first `OpenAccount`, defer `loan_*`)
 
 ---
 

--- a/docs/adr/0010-ledger-persistence-and-seeded-coa.md
+++ b/docs/adr/0010-ledger-persistence-and-seeded-coa.md
@@ -153,7 +153,8 @@ GL accounts are seeded from **[docs/concepts/100-chart-of-accounts.tsv](../conce
 
 * [ADR-0002](0002-operational-event-model.md)  
 * [ADR-0003](0003-posting-journal-architecture.md)  
-* [ADR-0008](0008-money-currency-rounding-policy.md)
+* [ADR-0008](0008-money-currency-rounding-policy.md)  
+* [ADR-0011](0011-accounts-deposit-vertical-slice-mvp.md) — `deposit_accounts` and future **`operational_events.source_account_id`** for slice 1
 
 ---
 

--- a/docs/adr/0011-accounts-deposit-vertical-slice-mvp.md
+++ b/docs/adr/0011-accounts-deposit-vertical-slice-mvp.md
@@ -1,0 +1,113 @@
+# ADR-0011: Accounts deposit MVP addendum (vertical slice 1)
+
+**Status:** Accepted  
+**Date:** 2026-04-22  
+**Decision Type:** Domain data model and command scope (`Accounts` for first vertical slice)  
+**Aligns with:** [ADR-0007](0007-party-account-ownership.md) (participation tables and enums), [ADR-0009](0009-initial-party-persistence-schema.md) (`party_records` FK target), [ADR-0008](0008-money-currency-rounding-policy.md) (single-currency MVP), [docs/architecture/bankcore-module-catalog.md](../architecture/bankcore-module-catalog.md) §6.7, §10
+
+---
+
+## 1. Context
+
+[ADR-0007](0007-party-account-ownership.md) defines **symmetric** participation for **deposit** and **loan** contracts but does not fix **minimal `deposit_accounts` columns**, **product stubbing**, or **which half of the symmetry ships first**. The first vertical slice needs **locked** choices so migrations and `Accounts::Commands::OpenAccount` do not drift.
+
+This ADR is an **addendum**: it narrows implementation for **slice 1** only. It does **not** relax ADR-0007’s participation semantics where those tables exist.
+
+---
+
+## 2. Decision (locked for slice 1)
+
+### 2.1 Loan side (symmetry deferral)
+
+* **Do not** create **`loan_accounts`** or **`loan_account_parties`** migrations until a loan vertical slice is scheduled.
+* ADR-0007 remains the **authoritative** shape when loan work starts.
+
+### 2.2 `deposit_accounts` (minimal contract row)
+
+The **Accounts** module owns a new **`deposit_accounts`** table with at least:
+
+| Column            | Type     | Notes |
+| ----------------- | -------- | ----- |
+| `id`              | bigint   | PK |
+| `account_number`  | string   | NOT NULL, **UNIQUE** — institution-unique display/reference; generation strategy is implementation detail (tests may use random; production may use sequential or another allocator later). |
+| `currency`        | string   | NOT NULL, default **`USD`** (ADR-0008 single-currency MVP). |
+| `status`          | string   | NOT NULL — application enum for slice 1: **`open`**, **`closed`** (extend only via ADR/catalog when needed). |
+| `product_code`    | string   | NOT NULL — **stub** until Products ([ADR-0005](0005-product-configuration-framework.md)); `OpenAccount` sets the **canonical slice-1 literal** below. No `deposit_products` FK in slice 1. |
+| `created_at` / `updated_at` | datetime | |
+
+**Canonical `product_code` (slice 1):** the string **`slice1_demand_deposit`** — use in `OpenAccount`, seeds, and slice-1 integration tests so posting and accounts stay aligned until Products replaces it.
+
+**Must not** in slice 1: `account_relationships`, restrictions, notes, available balance, holds (see **§4 Non-goals**).
+
+### 2.3 `deposit_account_parties` (first open)
+
+Per [ADR-0007 §2.8](0007-party-account-ownership.md), **`OpenAccount`** creates **exactly one** participation row for slice 1:
+
+* **`role`:** `owner`
+* **`status`:** `active` (do **not** use `pending` for CIP gating in slice 1 unless a later ADR requires it)
+* **`effective_on`:** **`Core::BusinessDate`** current processing date when that service exists; until then, the command accepts an explicit `effective_on` **or** uses the same date source agreed for `RecordEvent` (document in command/tests—**must** align with bank-date semantics, not silent `Date.current` in production paths without review)
+* **`ended_on`:** `NULL`
+
+**Joint / second party:** out of scope; **`OpenAccount`** accepts a **single** `party_record_id` only.
+
+### 2.4 `OpenAccount` invariants
+
+* **`party_record_id`** MUST reference an existing **`party_records.id`** (Party domain is system-of-record; Accounts validates via read/query port, not direct mutation of Party tables).
+* Enforce ADR-0007 **§2.7** (“at most one open active row per `(deposit_account_id, party_record_id, role)`”) in **application commands** for slice 1.
+* Add a **partial unique index** matching ADR-0007 §2.7 when status values and migration ordering are stable (same PR or immediate follow-up).
+
+### 2.5 Linking operational events to the deposit account
+
+* **`operational_events`** does not yet carry account FKs in the ledger slice ([ADR-0010](0010-ledger-persistence-and-seeded-coa.md) §5).
+* When **`RecordEvent`** / financial **`deposit.accepted`** is implemented, add a migration introducing **`source_account_id`** (nullable bigint, FK → **`deposit_accounts`**, name may be adjusted to match ADR-0002 §8 column roadmap) **in the same work as or immediately before** event payloads that require it—not necessarily bundled with the first **`deposit_accounts`** migration, but **documented** so posting can resolve customer liability from the **account** path.
+
+---
+
+## 3. Worked example (slice 1)
+
+**Pre:** `party_records` row `id = 42` exists (from `CreateParty`). Current business date = `2026-04-22`.
+
+**Command:** `Accounts::Commands::OpenAccount` with `party_record_id: 42`, optional overrides only as documented (e.g. tests).
+
+**Result:**
+
+1. One **`deposit_accounts`** row: `account_number` unique, `currency: "USD"`, `status: "open"`, `product_code: "slice1_demand_deposit"`.
+2. One **`deposit_account_parties`** row: `deposit_account_id` → new account, `party_record_id: 42`, `role: "owner"`, `status: "active"`, `effective_on: 2026-04-22`, `ended_on: NULL`.
+
+**Later:** `RecordEvent` for `deposit.accepted` sets `source_account_id` to this `deposit_accounts.id` when that column exists.
+
+---
+
+## 4. Non-goals (slice 1)
+
+* **`loan_accounts` / `loan_account_parties`**
+* **`Deposits`** servicing (interest, fees, OD)—catalog §6.8
+* **Available balance / holds**—[ADR-0004](0004-account-balance-model.md)
+* **Full Products** configuration—ADR-0005; **`product_code`** stub only
+* **Joint owners**, **`AddPartyToAccount`**, **`account_relationships`**
+
+---
+
+## 5. Consequences
+
+**Positive:** One clear path for migrations and `OpenAccount`; participation stays ADR-0007–compliant; product and loan complexity deferred without ambiguity.
+
+**Negative:** **`product_code`** is not FK-enforced; typo risk until Products domain exists. **Loan** symmetry is deferred—first loan slice must add tables and revisit tests.
+
+**Neutral:** **`effective_on`** coupling to **`Core::BusinessDate`** may require a small command signature change when BusinessDate lands.
+
+---
+
+## 6. Related ADRs
+
+* [ADR-0007](0007-party-account-ownership.md) — participation model (this ADR implements the **deposit** half first)
+* [ADR-0009](0009-initial-party-persistence-schema.md) — `party_records` FK target
+* [ADR-0002](0002-operational-event-model.md) — operational events; **`source_account_id`** when events reference accounts
+* [ADR-0010](0010-ledger-persistence-and-seeded-coa.md) — current `operational_events` MVP columns; extend per §2.5 above
+* [ADR-0001](0001-modular-monolith-architecture-with-domain-boundaries.md) — `Accounts` vs `Party` vs `Core` boundaries
+
+---
+
+## 7. Summary
+
+Vertical slice 1 **ships `deposit_accounts` + `deposit_account_parties` only**, with **`OpenAccount`** creating one **`owner` / `active`** participation row, **`product_code`** string stub, **`USD`** default currency, ADR-0007 **§2.7** enforced in commands first, **`loan_*`** tables deferred, and **`operational_events.source_account_id`** (or equivalent) added when financial events reference an account.

--- a/test/domains/accounts/open_account_test.rb
+++ b/test/domains/accounts/open_account_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AccountsOpenAccountTest < ActiveSupport::TestCase
+  setup do
+    Core::BusinessDate::Models::BusinessDateSetting.delete_all
+    Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.new(2026, 4, 21))
+    @party = Party::Commands::CreateParty.call(party_type: "individual", first_name: "A", last_name: "B")
+  end
+
+  test "opens account with owner participation and slice product code" do
+    account = Accounts::Commands::OpenAccount.call(party_record_id: @party.id)
+    assert account.persisted?
+    assert_equal Accounts::SLICE1_PRODUCT_CODE, account.product_code
+    assert_equal Accounts::Models::DepositAccount::STATUS_OPEN, account.status
+    assert_equal "USD", account.currency
+    assert_equal 1, account.deposit_account_parties.count
+    row = account.deposit_account_parties.first
+    assert_equal Accounts::Models::DepositAccountParty::ROLE_OWNER, row.role
+    assert_equal Accounts::Models::DepositAccountParty::STATUS_ACTIVE, row.status
+    assert_equal Date.new(2026, 4, 21), row.effective_on
+    assert_nil row.ended_on
+  end
+
+  test "uses explicit effective_on when provided" do
+    on = Date.new(2026, 5, 1)
+    account = Accounts::Commands::OpenAccount.call(party_record_id: @party.id, effective_on: on)
+    assert_equal on, account.deposit_account_parties.first.effective_on
+  end
+
+  test "raises when party is missing" do
+    assert_raises(Accounts::Commands::OpenAccount::PartyNotFound) do
+      Accounts::Commands::OpenAccount.call(party_record_id: 9_999_999)
+    end
+  end
+
+  test "CreateParty then OpenAccount" do
+    party = Party::Commands::CreateParty.call(party_type: "individual", first_name: "X", last_name: "Y")
+    account = Accounts::Commands::OpenAccount.call(party_record_id: party.id)
+    assert_equal party.id, account.deposit_account_parties.first.party_record_id
+  end
+end

--- a/test/domains/core/business_date/current_business_date_test.rb
+++ b/test/domains/core/business_date/current_business_date_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CoreBusinessDateCurrentBusinessDateTest < ActiveSupport::TestCase
+  setup do
+    Core::BusinessDate::Models::BusinessDateSetting.delete_all
+  end
+
+  test "call raises when no row" do
+    assert_raises(Core::BusinessDate::Errors::NotSet) do
+      Core::BusinessDate::Services::CurrentBusinessDate.call
+    end
+  end
+
+  test "call returns stored date after set" do
+    Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.new(2026, 4, 15))
+    assert_equal Date.new(2026, 4, 15), Core::BusinessDate::Services::CurrentBusinessDate.call
+  end
+
+  test "advance moves forward one day" do
+    Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.new(2026, 1, 2))
+    Core::BusinessDate::Commands::AdvanceBusinessDate.call
+    assert_equal Date.new(2026, 1, 3), Core::BusinessDate::Services::CurrentBusinessDate.call
+  end
+
+  test "set updates existing singleton" do
+    Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.new(2026, 6, 1))
+    Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.new(2026, 6, 10))
+    assert_equal 1, Core::BusinessDate::Models::BusinessDateSetting.count
+    assert_equal Date.new(2026, 6, 10), Core::BusinessDate::Services::CurrentBusinessDate.call
+  end
+end

--- a/test/domains/core/operational_events/record_event_test.rb
+++ b/test/domains/core/operational_events/record_event_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CoreOperationalEventsRecordEventTest < ActiveSupport::TestCase
+  setup do
+    BankCore::Seeds::GlCoa.seed!
+    Core::BusinessDate::Models::BusinessDateSetting.delete_all
+    Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.new(2026, 4, 22))
+    @party = Party::Commands::CreateParty.call(party_type: "individual", first_name: "Pat", last_name: "Lee")
+    @account = Accounts::Commands::OpenAccount.call(party_record_id: @party.id)
+  end
+
+  test "creates pending deposit.accepted with source_account_id" do
+    r = record_deposit!(idempotency_key: "idem-1", amount: 50_00)
+    assert_equal :created, r[:outcome]
+    ev = r[:event]
+    assert_equal "pending", ev.status
+    assert_equal "deposit.accepted", ev.event_type
+    assert_equal @account.id, ev.source_account_id
+    assert_equal 50_00, ev.amount_minor_units
+    assert_equal "teller", ev.channel
+  end
+
+  test "replay returns same row when fingerprint matches" do
+    a = record_deposit!(idempotency_key: "idem-replay", amount: 10_00)
+    b = record_deposit!(idempotency_key: "idem-replay", amount: 10_00)
+    assert_equal :created, a[:outcome]
+    assert_equal :replay, b[:outcome]
+    assert_equal a[:event].id, b[:event].id
+  end
+
+  test "mismatch on same idempotency key raises with fingerprint" do
+    record_deposit!(idempotency_key: "idem-mix", amount: 10_00)
+    err = assert_raises(Core::OperationalEvents::Commands::RecordEvent::MismatchedIdempotency) do
+      record_deposit!(idempotency_key: "idem-mix", amount: 11_00)
+    end
+    assert_predicate err.fingerprint, :present?
+  end
+
+  test "posted replay raises" do
+    r = record_deposit!(idempotency_key: "idem-posted", amount: 5_00)
+    Core::Posting::Commands::PostEvent.call(operational_event_id: r[:event].id)
+    assert_raises(Core::OperationalEvents::Commands::RecordEvent::PostedReplay) do
+      record_deposit!(idempotency_key: "idem-posted", amount: 5_00)
+    end
+  end
+
+  test "rejects invalid channel" do
+    assert_raises(Core::OperationalEvents::Commands::RecordEvent::InvalidRequest) do
+      Core::OperationalEvents::Commands::RecordEvent.call(
+        event_type: "deposit.accepted",
+        channel: "legacy",
+        idempotency_key: "x",
+        amount_minor_units: 1,
+        currency: "USD",
+        source_account_id: @account.id
+      )
+    end
+  end
+
+  test "requires amount and currency and source account for deposit" do
+    assert_raises(Core::OperationalEvents::Commands::RecordEvent::InvalidRequest) do
+      Core::OperationalEvents::Commands::RecordEvent.call(
+        event_type: "deposit.accepted",
+        channel: "teller",
+        idempotency_key: "a",
+        amount_minor_units: nil,
+        currency: "USD",
+        source_account_id: @account.id
+      )
+    end
+  end
+
+  private
+
+  def record_deposit!(idempotency_key:, amount:)
+    Core::OperationalEvents::Commands::RecordEvent.call(
+      event_type: "deposit.accepted",
+      channel: "teller",
+      idempotency_key: idempotency_key,
+      amount_minor_units: amount,
+      currency: "USD",
+      source_account_id: @account.id
+    )
+  end
+end

--- a/test/domains/core/posting/post_event_test.rb
+++ b/test/domains/core/posting/post_event_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CorePostingPostEventTest < ActiveSupport::TestCase
+  setup do
+    BankCore::Seeds::GlCoa.seed!
+    Core::BusinessDate::Models::BusinessDateSetting.delete_all
+    Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.new(2026, 4, 22))
+    party = Party::Commands::CreateParty.call(party_type: "individual", first_name: "Q", last_name: "R")
+    @account = Accounts::Commands::OpenAccount.call(party_record_id: party.id)
+  end
+
+  test "posts balanced 1110/2110 and marks event posted" do
+    ev = create_pending_event!(amount: 12_34)
+    r = Core::Posting::Commands::PostEvent.call(operational_event_id: ev.id)
+    assert_equal :posted, r[:outcome]
+    assert_equal "posted", ev.reload.status
+    batch = ev.posting_batches.sole
+    assert_equal "posted", batch.status
+    entry = batch.journal_entries.sole
+    lines = entry.journal_lines.order(:sequence_no)
+    assert_equal 2, lines.size
+    assert_equal 12_34, lines.sum { |l| l.side == "debit" ? l.amount_minor_units : 0 }
+    assert_equal 12_34, lines.sum { |l| l.side == "credit" ? l.amount_minor_units : 0 }
+    assert_equal Core::Ledger::Models::GlAccount.find_by!(account_number: "1110").id, lines.find_by(side: "debit").gl_account_id
+    assert_equal Core::Ledger::Models::GlAccount.find_by!(account_number: "2110").id, lines.find_by(side: "credit").gl_account_id
+  end
+
+  test "second post is idempotent" do
+    ev = create_pending_event!(amount: 100)
+    Core::Posting::Commands::PostEvent.call(operational_event_id: ev.id)
+    r = Core::Posting::Commands::PostEvent.call(operational_event_id: ev.id)
+    assert_equal :already_posted, r[:outcome]
+    assert_equal 1, ev.reload.posting_batches.count
+  end
+
+  test "rolls back and leaves event pending when GL is missing" do
+    ev = create_pending_event!(amount: 200)
+    cash = Core::Ledger::Models::GlAccount.find_by!(account_number: "1110")
+    prior = cash.account_number
+    cash.update_column(:account_number, "1110-tmp-missing")
+    assert_raises(ActiveRecord::RecordNotFound) do
+      Core::Posting::Commands::PostEvent.call(operational_event_id: ev.id)
+    end
+    cash.update_column(:account_number, prior)
+    assert_equal "pending", ev.reload.status
+    assert_equal 0, ev.posting_batches.count
+  end
+
+  test "not found raises" do
+    assert_raises(Core::Posting::Commands::PostEvent::NotFound) do
+      Core::Posting::Commands::PostEvent.call(operational_event_id: 0)
+    end
+  end
+
+  private
+
+  def create_pending_event!(amount:)
+    Core::OperationalEvents::Commands::RecordEvent.call(
+      event_type: "deposit.accepted",
+      channel: "batch",
+      idempotency_key: "post-test-#{SecureRandom.hex(6)}",
+      amount_minor_units: amount,
+      currency: "USD",
+      source_account_id: @account.id
+    )[:event]
+  end
+end

--- a/test/domains/party/create_party_test.rb
+++ b/test/domains/party/create_party_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PartyCreatePartyTest < ActiveSupport::TestCase
+  test "creates individual party with derived name" do
+    record = Party::Commands::CreateParty.call(
+      party_type: "individual",
+      first_name: "Jane",
+      last_name: "Doe"
+    )
+    assert_equal "Jane Doe", record.name
+    assert_equal "individual", record.party_type
+    assert record.individual_profile
+    assert_equal "Jane", record.individual_profile.first_name
+  end
+
+  test "name includes middle and suffix per ADR-0009" do
+    record = Party::Commands::CreateParty.call(
+      party_type: "individual",
+      first_name: "Jane",
+      middle_name: "Marie",
+      last_name: "Doe",
+      name_suffix: "Jr."
+    )
+    assert_equal "Jane Marie Doe, Jr.", record.name
+  end
+
+  test "rejects non-individual party types" do
+    assert_raises(Party::Commands::CreateParty::UnsupportedPartyType) do
+      Party::Commands::CreateParty.call(party_type: "organization", first_name: "X", last_name: "Y")
+    end
+  end
+
+  test "FindParty returns record" do
+    created = Party::Commands::CreateParty.call(party_type: "individual", first_name: "A", last_name: "B")
+    found = Party::Queries::FindParty.by_id(created.id)
+    assert_equal created.id, found.id
+  end
+end

--- a/test/integration/slice1_vertical_slice_proof_test.rb
+++ b/test/integration/slice1_vertical_slice_proof_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Slice1VerticalSliceProofTest < ActionDispatch::IntegrationTest
+  test "full teller flow: party, account, pending event, post, ledger invariants" do
+    BankCore::Seeds::GlCoa.seed!
+    Core::BusinessDate::Models::BusinessDateSetting.delete_all
+    Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.new(2026, 4, 21))
+
+    post "/teller/parties",
+      params: {
+        party_type: "individual",
+        first_name: "Proof",
+        middle_name: "M",
+        last_name: "Customer",
+        name_suffix: "Sr."
+      }.to_json,
+      headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :created
+    party_json = response.parsed_body
+    party_id = party_json["id"]
+    assert_equal "Proof M Customer, Sr.", party_json["name"]
+
+    post "/teller/deposit_accounts",
+      params: { deposit_account: { party_record_id: party_id } }.to_json,
+      headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :created
+    account_id = response.parsed_body["id"]
+    account_number = response.parsed_body["account_number"]
+    assert_equal Accounts::SLICE1_PRODUCT_CODE, response.parsed_body["product_code"]
+
+    account = Accounts::Models::DepositAccount.find(account_id)
+    assert_equal "open", account.status
+    participation = account.deposit_account_parties.sole
+    assert_equal party_id, participation.party_record_id
+    assert_equal "owner", participation.role
+    assert_equal "active", participation.status
+    assert_equal Date.new(2026, 4, 21), participation.effective_on
+
+    idem = "slice1-proof-#{SecureRandom.hex(8)}"
+    post "/teller/operational_events",
+      params: {
+        operational_event: {
+          event_type: "deposit.accepted",
+          channel: "teller",
+          idempotency_key: idem,
+          amount_minor_units: 10_000,
+          currency: "USD",
+          source_account_id: account_id
+        }
+      }.to_json,
+      headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :created
+    event_id = response.parsed_body["id"]
+
+    event = Core::OperationalEvents::Models::OperationalEvent.find(event_id)
+    assert_equal "pending", event.status
+    assert_equal "teller", event.channel
+    assert_equal idem, event.idempotency_key
+    assert_equal account_id, event.source_account_id
+    assert_equal account.id, event.source_account.id
+
+    post "/teller/operational_events/#{event_id}/post", headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :created
+
+    event.reload
+    assert_equal "posted", event.status
+    batch = event.posting_batches.sole
+    assert_equal "posted", batch.status
+    entry = batch.journal_entries.sole
+    lines = entry.journal_lines.order(:sequence_no)
+    debits = lines.where(side: "debit").sum(:amount_minor_units)
+    credits = lines.where(side: "credit").sum(:amount_minor_units)
+    assert_equal debits, credits
+    assert_equal 10_000, debits
+    gl_nums = lines.includes(:gl_account).map { |l| l.gl_account.account_number }.sort
+    assert_equal %w[1110 2110], gl_nums
+    assert_equal account_number, account.account_number
+  end
+end

--- a/test/integration/teller/teller_requests_test.rb
+++ b/test/integration/teller/teller_requests_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TellerRequestsTest < ActionDispatch::IntegrationTest
+  setup do
+    BankCore::Seeds::GlCoa.seed!
+    Core::BusinessDate::Models::BusinessDateSetting.delete_all
+    Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.new(2026, 4, 22))
+  end
+
+  test "party and deposit account happy path" do
+    post "/teller/parties",
+      params: { party_type: "individual", first_name: "Sam", last_name: "Rivera" }.to_json,
+      headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :created
+    party_id = response.parsed_body["id"]
+
+    post "/teller/deposit_accounts",
+      params: { deposit_account: { party_record_id: party_id } }.to_json,
+      headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :created
+    assert_predicate response.parsed_body["account_number"], :present?
+  end
+
+  test "operational event idempotency and post" do
+    party_id = create_party!
+    account_id = open_account!(party_id)
+
+    body = {
+      operational_event: {
+        event_type: "deposit.accepted",
+        channel: "api",
+        idempotency_key: "api-deposit-1",
+        amount_minor_units: 500,
+        currency: "USD",
+        source_account_id: account_id
+      }
+    }
+    post "/teller/operational_events", params: body.to_json, headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :created
+    event_id = response.parsed_body["id"]
+
+    post "/teller/operational_events", params: body.to_json, headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :success
+    assert_equal "replay", response.parsed_body["outcome"]
+
+    post "/teller/operational_events/#{event_id}/post", headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :created
+    assert_equal "posted", response.parsed_body["outcome"]
+
+    post "/teller/operational_events/#{event_id}/post", headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :success
+    assert_equal "already_posted", response.parsed_body["outcome"]
+  end
+
+  test "deposit account returns 404 for unknown party" do
+    post "/teller/deposit_accounts",
+      params: { deposit_account: { party_record_id: 0 } }.to_json,
+      headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :not_found
+  end
+
+  private
+
+  def create_party!
+    post "/teller/parties",
+      params: { party_type: "individual", first_name: "A", last_name: "B" }.to_json,
+      headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :created
+    response.parsed_body["id"]
+  end
+
+  def open_account!(party_id)
+    post "/teller/deposit_accounts",
+      params: { deposit_account: { party_record_id: party_id } }.to_json,
+      headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :created
+    response.parsed_body["id"]
+  end
+end


### PR DESCRIPTION
## Summary

Implements GitHub milestone **Slice 1** (#2–#8): institution business date, Party persistence and `CreateParty`, `OpenAccount` with deposit tables and ADR-0011 product stub, `RecordEvent` with `source_account_id` and idempotency, `PostEvent` with hard-coded GL **1110** / **2110**, Style-A Teller JSON routes, and an HTTP end-to-end proof test.

## Changes

- **Core::BusinessDate** — singleton settings table, `CurrentBusinessDate`, `SetBusinessDate` / `AdvanceBusinessDate`, seeds when unset.
- **Party** — `party_records`, `party_individual_profiles`, `CreateParty`, `FindParty`, individual-only slice.
- **Accounts** — `deposit_accounts`, `deposit_account_parties`, `OpenAccount`, `slice1_demand_deposit`, partial unique index for open active participation (in `create_deposit_account_parties` migration).
- **Operational events** — `source_account_id` FK, `RecordEvent` for `deposit.accepted` with channel-scoped idempotency and fingerprint conflicts.
- **Posting** — `PostEvent` single transaction, balanced legs, idempotent when already posted.
- **Teller** — `POST /teller/parties`, `deposit_accounts`, `operational_events`, `operational_events/:id/post`; `ActionController::API` with CSRF note in controller.

## Testing

- `bin/rails zeitwerk:check` and `bin/rails test` (domain + integration, including slice proof).

## References

- ADR-0011, ADR-0007, ADR-0009, ADR-0002, ADR-0010
- Module catalog / bounded domains under `app/domains`

Made with [Cursor](https://cursor.com)