### PR TITLE
Phase 1: operational events, posting registry, holds, teller sessions

### DIFF
--- a/app/controllers/teller/holds_controller.rb
+++ b/app/controllers/teller/holds_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Teller
+  class HoldsController < ApplicationController
+    def create
+      attrs = params.require(:hold).permit(:deposit_account_id, :amount_minor_units, :currency, :channel, :idempotency_key,
+                                           :business_date).to_h.symbolize_keys
+      attrs[:deposit_account_id] = attrs[:deposit_account_id].to_i
+      attrs[:amount_minor_units] = attrs[:amount_minor_units].to_i
+      if attrs[:business_date].present?
+        attrs[:business_date] = Date.iso8601(attrs[:business_date].to_s)
+      else
+        attrs.delete(:business_date)
+      end
+
+      result = Accounts::Commands::PlaceHold.call(**attrs)
+      status = result[:outcome] == :created ? :created : :ok
+      render json: { hold_id: result[:hold].id, operational_event_id: result[:event].id, outcome: result[:outcome] }, status: status
+    rescue Accounts::Commands::PlaceHold::InvalidRequest => e
+      render json: { error: "invalid_request", message: e.message }, status: :unprocessable_entity
+    end
+
+    def release
+      attrs = params.require(:hold_release).permit(:hold_id, :channel, :idempotency_key, :business_date).to_h.symbolize_keys
+      attrs[:hold_id] = attrs[:hold_id].to_i
+      if attrs[:business_date].present?
+        attrs[:business_date] = Date.iso8601(attrs[:business_date].to_s)
+      else
+        attrs.delete(:business_date)
+      end
+
+      result = Accounts::Commands::ReleaseHold.call(**attrs)
+      status = result[:outcome] == :created ? :created : :ok
+      render json: { operational_event_id: result[:event].id, outcome: result[:outcome] }, status: status
+    rescue Accounts::Commands::ReleaseHold::InvalidRequest => e
+      render json: { error: "invalid_request", message: e.message }, status: :unprocessable_entity
+    rescue Accounts::Commands::ReleaseHold::HoldNotFound => e
+      render json: { error: "not_found", message: e.message }, status: :not_found
+    end
+  end
+end

--- a/app/controllers/teller/operational_events_controller.rb
+++ b/app/controllers/teller/operational_events_controller.rb
@@ -4,10 +4,21 @@ module Teller
   class OperationalEventsController < ApplicationController
     def create
       attrs = params.require(:operational_event).permit(
-        :event_type, :channel, :idempotency_key, :amount_minor_units, :currency, :source_account_id, :business_date
+        :event_type, :channel, :idempotency_key, :amount_minor_units, :currency, :source_account_id,
+        :destination_account_id, :teller_session_id, :business_date
       ).to_h.symbolize_keys
       attrs[:amount_minor_units] = attrs[:amount_minor_units].to_i
       attrs[:source_account_id] = attrs[:source_account_id].to_i
+      if attrs[:destination_account_id].present?
+        attrs[:destination_account_id] = attrs[:destination_account_id].to_i
+      else
+        attrs.delete(:destination_account_id)
+      end
+      if attrs[:teller_session_id].present?
+        attrs[:teller_session_id] = attrs[:teller_session_id].to_i
+      else
+        attrs.delete(:teller_session_id)
+      end
       if attrs[:business_date].present?
         attrs[:business_date] = Date.iso8601(attrs[:business_date].to_s)
       else

--- a/app/controllers/teller/overrides_controller.rb
+++ b/app/controllers/teller/overrides_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Teller
+  class OverridesController < ApplicationController
+    def create
+      attrs = params.require(:override).permit(:event_type, :channel, :idempotency_key, :reference_id, :actor_id, :business_date).to_h.symbolize_keys
+      attrs[:actor_id] = attrs[:actor_id].to_i if attrs[:actor_id].present?
+      if attrs[:business_date].present?
+        attrs[:business_date] = Date.iso8601(attrs[:business_date].to_s)
+      else
+        attrs.delete(:business_date)
+      end
+
+      result = Core::OperationalEvents::Commands::RecordControlEvent.call(**attrs)
+      status = result[:outcome] == :created ? :created : :ok
+      render json: { id: result[:event].id, outcome: result[:outcome] }, status: status
+    rescue Core::OperationalEvents::Commands::RecordControlEvent::InvalidRequest => e
+      render json: { error: "invalid_request", message: e.message }, status: :unprocessable_entity
+    rescue Core::OperationalEvents::Commands::RecordControlEvent::MismatchedIdempotency => e
+      render json: { error: "idempotency_conflict", fingerprint: e.fingerprint }, status: :conflict
+    end
+  end
+end

--- a/app/controllers/teller/reversals_controller.rb
+++ b/app/controllers/teller/reversals_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Teller
+  class ReversalsController < ApplicationController
+    def create
+      attrs = params.require(:reversal).permit(:original_operational_event_id, :channel, :idempotency_key, :business_date).to_h.symbolize_keys
+      attrs[:original_operational_event_id] = attrs[:original_operational_event_id].to_i
+      if attrs[:business_date].present?
+        attrs[:business_date] = Date.iso8601(attrs[:business_date].to_s)
+      else
+        attrs.delete(:business_date)
+      end
+
+      result = Core::OperationalEvents::Commands::RecordReversal.call(**attrs)
+      status = result[:outcome] == :created ? :created : :ok
+      render json: { id: result[:event].id, outcome: result[:outcome] }, status: status
+    rescue Core::OperationalEvents::Commands::RecordReversal::InvalidRequest => e
+      render json: { error: "invalid_request", message: e.message }, status: :unprocessable_entity
+    rescue Core::OperationalEvents::Commands::RecordReversal::NotFound => e
+      render json: { error: "not_found", message: e.message }, status: :not_found
+    rescue Core::OperationalEvents::Commands::RecordReversal::MismatchedIdempotency => e
+      render json: { error: "idempotency_conflict", fingerprint: e.fingerprint }, status: :conflict
+    rescue Core::OperationalEvents::Commands::RecordReversal::PostedReplay => e
+      render json: { error: "posted_replay", message: e.message.presence || "already posted" }, status: :conflict
+    end
+  end
+end

--- a/app/controllers/teller/teller_sessions_controller.rb
+++ b/app/controllers/teller/teller_sessions_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Teller
+  class TellerSessionsController < ApplicationController
+    def create
+      drawer = params.permit(:drawer_code)[:drawer_code]
+      session = Teller::Commands::OpenSession.call(drawer_code: drawer)
+      render json: { id: session.id, status: session.status, opened_at: session.opened_at }, status: :created
+    rescue Teller::Commands::OpenSession::SessionAlreadyOpen => e
+      render json: { error: "session_already_open", message: e.message }, status: :unprocessable_entity
+    end
+
+    def close
+      attrs = params.require(:teller_session_close).permit(
+        :teller_session_id, :expected_cash_minor_units, :actual_cash_minor_units
+      ).to_h.symbolize_keys
+      attrs[:teller_session_id] = attrs[:teller_session_id].to_i
+      session = Teller::Commands::CloseSession.call(
+        teller_session_id: attrs[:teller_session_id],
+        expected_cash_minor_units: attrs[:expected_cash_minor_units].to_i,
+        actual_cash_minor_units: attrs[:actual_cash_minor_units].to_i
+      )
+      render json: { id: session.id, status: session.status, variance_minor_units: session.variance_minor_units }, status: :ok
+    rescue Teller::Commands::CloseSession::NotFound => e
+      render json: { error: "not_found", message: e.message }, status: :not_found
+    rescue Teller::Commands::CloseSession::InvalidState => e
+      render json: { error: "invalid_state", message: e.message }, status: :unprocessable_entity
+    end
+  end
+end

--- a/app/domains/accounts/commands/place_hold.rb
+++ b/app/domains/accounts/commands/place_hold.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Commands
+    class PlaceHold
+      class Error < StandardError; end
+      class InvalidRequest < Error; end
+
+      # Creates an active hold and a posted `hold.placed` operational event (no GL posting).
+      def self.call(deposit_account_id:, amount_minor_units:, currency:, channel:, idempotency_key:, business_date: nil)
+        ch = channel.to_s
+        unless Core::OperationalEvents::Commands::RecordEvent::CHANNELS.include?(ch)
+          raise InvalidRequest, "channel must be one of: #{Core::OperationalEvents::Commands::RecordEvent::CHANNELS.join(", ")}"
+        end
+
+        on_date = business_date || Core::BusinessDate::Services::CurrentBusinessDate.call
+        validate_account!(deposit_account_id)
+        validate_amount!(amount_minor_units, currency)
+
+        begin
+          Core::OperationalEvents::Models::OperationalEvent.transaction(requires_new: true) do
+            existing = Core::OperationalEvents::Models::OperationalEvent.lock.find_by(channel: channel, idempotency_key: idempotency_key)
+            if existing
+              validate_hold_placed_replay!(existing, deposit_account_id, amount_minor_units, currency)
+              return { outcome: :replay, event: existing, hold: find_hold_for_event(existing) }
+            end
+
+            event = Core::OperationalEvents::Models::OperationalEvent.create!(
+              event_type: "hold.placed",
+              status: Core::OperationalEvents::Models::OperationalEvent::STATUS_POSTED,
+              business_date: on_date,
+              channel: channel,
+              idempotency_key: idempotency_key,
+              amount_minor_units: amount_minor_units,
+              currency: currency,
+              source_account_id: deposit_account_id
+            )
+
+            hold = Accounts::Models::Hold.create!(
+              deposit_account_id: deposit_account_id,
+              amount_minor_units: amount_minor_units,
+              currency: currency,
+              status: Accounts::Models::Hold::STATUS_ACTIVE,
+              placed_by_operational_event: event
+            )
+
+            { outcome: :created, event: event, hold: hold }
+          end
+        rescue ActiveRecord::RecordNotUnique
+          existing = Core::OperationalEvents::Models::OperationalEvent.find_by!(channel: channel, idempotency_key: idempotency_key)
+          validate_hold_placed_replay!(existing, deposit_account_id, amount_minor_units, currency)
+          { outcome: :replay, event: existing, hold: find_hold_for_event(existing) }
+        end
+      end
+
+      def self.validate_hold_placed_replay!(existing, deposit_account_id, amount_minor_units, currency)
+        raise InvalidRequest, "idempotency replay type mismatch" unless existing.event_type == "hold.placed"
+        raise InvalidRequest, "idempotency replay mismatch" unless existing.source_account_id == deposit_account_id &&
+          existing.amount_minor_units == amount_minor_units && existing.currency == currency
+      end
+      private_class_method :validate_hold_placed_replay!
+
+      def self.find_hold_for_event(event)
+        Accounts::Models::Hold.find_by(placed_by_operational_event_id: event.id)
+      end
+      private_class_method :find_hold_for_event
+
+      def self.validate_account!(deposit_account_id)
+        acc = Accounts::Models::DepositAccount.find_by(id: deposit_account_id)
+        raise InvalidRequest, "deposit_account_id not found" if acc.nil?
+        raise InvalidRequest, "account must be open" unless acc.status == Accounts::Models::DepositAccount::STATUS_OPEN
+      end
+      private_class_method :validate_account!
+
+      def self.validate_amount!(amount_minor_units, currency)
+        if amount_minor_units.nil? || amount_minor_units.to_i <= 0
+          raise InvalidRequest, "amount_minor_units must be a positive integer"
+        end
+        raise InvalidRequest, "currency is required" if currency.blank?
+        raise InvalidRequest, "currency must be USD" unless currency.to_s == "USD"
+      end
+      private_class_method :validate_amount!
+    end
+  end
+end

--- a/app/domains/accounts/commands/release_hold.rb
+++ b/app/domains/accounts/commands/release_hold.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Commands
+    class ReleaseHold
+      class Error < StandardError; end
+      class InvalidRequest < Error; end
+      class HoldNotFound < Error; end
+
+      # Releases an active hold; creates a posted `hold.released` operational event (no GL).
+      def self.call(hold_id:, channel:, idempotency_key:, business_date: nil)
+        ch = channel.to_s
+        unless Core::OperationalEvents::Commands::RecordEvent::CHANNELS.include?(ch)
+          raise InvalidRequest, "channel must be one of: #{Core::OperationalEvents::Commands::RecordEvent::CHANNELS.join(", ")}"
+        end
+
+        on_date = business_date || Core::BusinessDate::Services::CurrentBusinessDate.call
+
+        Core::OperationalEvents::Models::OperationalEvent.transaction do
+          existing = Core::OperationalEvents::Models::OperationalEvent.lock.find_by(channel: channel, idempotency_key: idempotency_key)
+          if existing
+            raise InvalidRequest, "idempotency replay type mismatch" unless existing.event_type == "hold.released"
+            hold = Accounts::Models::Hold.find(hold_id)
+            raise InvalidRequest, "idempotency replay mismatch" unless existing.source_account_id == hold.deposit_account_id
+
+            return { outcome: :replay, event: existing, hold: hold.reload }
+          end
+
+          hold = Accounts::Models::Hold.lock.find_by(id: hold_id)
+          raise HoldNotFound, "hold_id=#{hold_id}" if hold.nil?
+          raise InvalidRequest, "hold is not active" unless hold.status == Accounts::Models::Hold::STATUS_ACTIVE
+
+          event = Core::OperationalEvents::Models::OperationalEvent.create!(
+            event_type: "hold.released",
+            status: Core::OperationalEvents::Models::OperationalEvent::STATUS_POSTED,
+            business_date: on_date,
+            channel: channel,
+            idempotency_key: idempotency_key,
+            amount_minor_units: hold.amount_minor_units,
+            currency: hold.currency,
+            source_account_id: hold.deposit_account_id,
+            reference_id: hold.id.to_s
+          )
+
+          hold.update!(
+            status: Accounts::Models::Hold::STATUS_RELEASED,
+            released_by_operational_event: event
+          )
+
+          { outcome: :created, event: event, hold: hold.reload }
+        end
+      rescue ActiveRecord::RecordNotUnique
+        existing = Core::OperationalEvents::Models::OperationalEvent.find_by!(channel: channel, idempotency_key: idempotency_key)
+        hold = Accounts::Models::Hold.find(hold_id)
+        { outcome: :replay, event: existing, hold: hold.reload }
+      end
+    end
+  end
+end

--- a/app/domains/accounts/models/deposit_account.rb
+++ b/app/domains/accounts/models/deposit_account.rb
@@ -13,7 +13,7 @@ module Accounts
 
       validates :account_number, presence: true, uniqueness: true
       validates :currency, presence: true
-      validates :status, presence: true, inclusion: { in: [STATUS_OPEN, STATUS_CLOSED] }
+      validates :status, presence: true, inclusion: { in: [ STATUS_OPEN, STATUS_CLOSED ] }
       validates :product_code, presence: true
     end
   end

--- a/app/domains/accounts/models/hold.rb
+++ b/app/domains/accounts/models/hold.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Models
+    class Hold < ApplicationRecord
+      self.table_name = "holds"
+
+      STATUS_ACTIVE = "active"
+      STATUS_RELEASED = "released"
+      STATUS_EXPIRED = "expired"
+
+      belongs_to :deposit_account, class_name: "Accounts::Models::DepositAccount"
+      belongs_to :placed_by_operational_event, class_name: "Core::OperationalEvents::Models::OperationalEvent", optional: true
+      belongs_to :released_by_operational_event, class_name: "Core::OperationalEvents::Models::OperationalEvent", optional: true
+
+      scope :active_for_account, ->(deposit_account_id) { where(deposit_account_id: deposit_account_id, status: STATUS_ACTIVE) }
+    end
+  end
+end

--- a/app/domains/accounts/services/available_balance_minor_units.rb
+++ b/app/domains/accounts/services/available_balance_minor_units.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Services
+    # Ledger on 2110 for this deposit account (credits − debits) minus active holds (ADR-0004).
+    class AvailableBalanceMinorUnits
+      GL_DDA = "2110"
+
+      def self.call(deposit_account_id:)
+        ledger = ledger_balance_minor_units(deposit_account_id: deposit_account_id)
+        held = Accounts::Models::Hold.where(deposit_account_id: deposit_account_id, status: Accounts::Models::Hold::STATUS_ACTIVE)
+          .sum(:amount_minor_units)
+        ledger - held
+      end
+
+      def self.ledger_balance_minor_units(deposit_account_id:)
+        dda = Core::Ledger::Models::GlAccount.find_by(account_number: GL_DDA)
+        return 0 if dda.nil?
+
+        lines = Core::Ledger::Models::JournalLine.where(gl_account_id: dda.id, deposit_account_id: deposit_account_id)
+        credits = lines.where(side: "credit").sum(:amount_minor_units)
+        debits = lines.where(side: "debit").sum(:amount_minor_units)
+        credits - debits
+      end
+    end
+  end
+end

--- a/app/domains/core/ledger/models/journal_line.rb
+++ b/app/domains/core/ledger/models/journal_line.rb
@@ -8,6 +8,7 @@ module Core
 
         belongs_to :journal_entry, class_name: "Core::Ledger::Models::JournalEntry", inverse_of: :journal_lines
         belongs_to :gl_account, class_name: "Core::Ledger::Models::GlAccount"
+        belongs_to :deposit_account, class_name: "Accounts::Models::DepositAccount", optional: true
       end
     end
   end

--- a/app/domains/core/operational_events/commands/record_control_event.rb
+++ b/app/domains/core/operational_events/commands/record_control_event.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "digest"
+
+module Core
+  module OperationalEvents
+    module Commands
+      # Non-financial operational audit rows (override workflow). No posting batch.
+      class RecordControlEvent
+        class Error < StandardError; end
+        class InvalidRequest < Error; end
+        class MismatchedIdempotency < Error
+          attr_reader :fingerprint
+
+          def initialize(fingerprint)
+            @fingerprint = fingerprint
+            super("idempotency_key replay does not match original request fingerprint=#{fingerprint}")
+          end
+        end
+
+        CONTROL_EVENT_TYPES = %w[override.requested override.approved].freeze
+
+        def self.call(event_type:, channel:, idempotency_key:, reference_id:, actor_id: nil, business_date: nil)
+          RecordEvent.validate_channel!(channel)
+          type = event_type.to_s
+          unless CONTROL_EVENT_TYPES.include?(type)
+            raise InvalidRequest, "event_type not supported: #{event_type.inspect}"
+          end
+          raise InvalidRequest, "reference_id is required" if reference_id.blank?
+
+          on_date = business_date || Core::BusinessDate::Services::CurrentBusinessDate.call
+          incoming_fp = fingerprint(event_type: type, channel: channel, idempotency_key: idempotency_key,
+                                      reference_id: reference_id.to_s, actor_id: actor_id)
+
+          begin
+            Models::OperationalEvent.transaction(requires_new: true) do
+              existing = Models::OperationalEvent.lock.find_by(channel: channel, idempotency_key: idempotency_key)
+              if existing
+                return handle_existing(existing, incoming_fp)
+              end
+
+              event = Models::OperationalEvent.create!(
+                event_type: type,
+                status: Models::OperationalEvent::STATUS_POSTED,
+                business_date: on_date,
+                channel: channel,
+                idempotency_key: idempotency_key,
+                reference_id: reference_id.to_s,
+                actor_id: actor_id,
+                amount_minor_units: nil,
+                currency: nil,
+                source_account_id: nil
+              )
+              { outcome: :created, event: event }
+            end
+          rescue ActiveRecord::RecordNotUnique
+            existing = Models::OperationalEvent.find_by!(channel: channel, idempotency_key: idempotency_key)
+            handle_existing(existing, incoming_fp)
+          end
+        end
+
+        def self.fingerprint(event_type:, channel:, idempotency_key:, reference_id:, actor_id:)
+          payload = {
+            event_type: event_type,
+            channel: channel.to_s,
+            idempotency_key: idempotency_key.to_s,
+            reference_id: reference_id,
+            actor_id: actor_id&.to_i
+          }
+          Digest::SHA256.hexdigest(payload.to_json)
+        end
+
+        def self.handle_existing(existing, incoming_fp)
+          existing_fp = fingerprint(
+            event_type: existing.event_type,
+            channel: existing.channel,
+            idempotency_key: existing.idempotency_key,
+            reference_id: existing.reference_id.to_s,
+            actor_id: existing.actor_id
+          )
+          raise MismatchedIdempotency.new(incoming_fp) if existing_fp != incoming_fp
+
+          { outcome: :replay, event: existing }
+        end
+        private_class_method :handle_existing
+      end
+    end
+  end
+end

--- a/app/domains/core/operational_events/commands/record_event.rb
+++ b/app/domains/core/operational_events/commands/record_event.rb
@@ -23,7 +23,7 @@ module Core
           end
         end
 
-        SLICE_EVENT_TYPES = %w[deposit.accepted].freeze
+        FINANCIAL_EVENT_TYPES = %w[deposit.accepted withdrawal.posted transfer.completed].freeze
         CHANNELS = %w[teller api batch system].freeze
 
         # @return [Hash] `{ outcome: :created|:replay, event: OperationalEvent }`
@@ -34,21 +34,28 @@ module Core
           amount_minor_units:,
           currency:,
           source_account_id:,
-          business_date: nil
+          destination_account_id: nil,
+          business_date: nil,
+          teller_session_id: nil
         )
           validate_channel!(channel)
           validate_event_type!(event_type)
-          validate_deposit_accepted!(amount_minor_units, currency, source_account_id)
+          validate_financial_amounts!(event_type, amount_minor_units, currency, source_account_id, destination_account_id)
           validate_source_account!(source_account_id)
+          validate_destination_account!(event_type, destination_account_id)
+          validate_transfer_distinct!(event_type, source_account_id, destination_account_id)
+          validate_withdrawal_available!(event_type, source_account_id, amount_minor_units)
+          validate_transfer_available!(event_type, source_account_id, amount_minor_units)
 
           on_date = business_date || Core::BusinessDate::Services::CurrentBusinessDate.call
-          incoming_fp = fingerprint(
+          incoming_fp = fingerprint_for(
             event_type: event_type,
             channel: channel,
             idempotency_key: idempotency_key,
             amount_minor_units: amount_minor_units,
             currency: currency,
-            source_account_id: source_account_id
+            source_account_id: source_account_id,
+            destination_account_id: destination_account_id
           )
 
           begin
@@ -66,7 +73,9 @@ module Core
                 idempotency_key: idempotency_key,
                 amount_minor_units: amount_minor_units,
                 currency: currency,
-                source_account_id: source_account_id
+                source_account_id: source_account_id,
+                destination_account_id: destination_account_id,
+                teller_session_id: teller_session_id
               )
               { outcome: :created, event: event }
             end
@@ -76,15 +85,19 @@ module Core
           end
         end
 
-        def self.fingerprint(event_type:, channel:, idempotency_key:, amount_minor_units:, currency:, source_account_id:)
+        def self.fingerprint_for(event_type:, channel:, idempotency_key:, amount_minor_units:, currency:, source_account_id:,
+                                destination_account_id: nil)
           payload = {
-            event_type: event_type,
-            channel: channel,
-            idempotency_key: idempotency_key,
+            event_type: event_type.to_s,
+            channel: channel.to_s,
+            idempotency_key: idempotency_key.to_s,
             amount_minor_units: amount_minor_units.to_i,
             currency: currency.to_s,
             source_account_id: source_account_id.to_i
           }
+          if event_type.to_s == "transfer.completed"
+            payload[:destination_account_id] = destination_account_id.to_i
+          end
           Digest::SHA256.hexdigest(payload.to_json)
         end
 
@@ -95,18 +108,21 @@ module Core
         end
 
         def self.validate_event_type!(event_type)
-          return if SLICE_EVENT_TYPES.include?(event_type.to_s)
+          return if FINANCIAL_EVENT_TYPES.include?(event_type.to_s)
 
-          raise InvalidRequest, "event_type not supported in slice 1: #{event_type.inspect}"
+          raise InvalidRequest, "event_type not supported: #{event_type.inspect}"
         end
 
-        def self.validate_deposit_accepted!(amount_minor_units, currency, source_account_id)
+        def self.validate_financial_amounts!(event_type, amount_minor_units, currency, source_account_id, destination_account_id)
           if amount_minor_units.nil? || amount_minor_units.to_i <= 0
             raise InvalidRequest, "amount_minor_units must be a positive integer"
           end
           raise InvalidRequest, "currency is required" if currency.blank?
-          raise InvalidRequest, "currency must be USD for slice 1" unless currency.to_s == "USD"
-          raise InvalidRequest, "source_account_id is required for deposit.accepted" if source_account_id.blank?
+          raise InvalidRequest, "currency must be USD" unless currency.to_s == "USD"
+          raise InvalidRequest, "source_account_id is required" if source_account_id.blank?
+          if event_type.to_s == "transfer.completed" && destination_account_id.blank?
+            raise InvalidRequest, "destination_account_id is required for transfer.completed"
+          end
         end
 
         def self.validate_source_account!(source_account_id)
@@ -115,14 +131,44 @@ module Core
           raise InvalidRequest, "source account must be open" unless acc.status == Accounts::Models::DepositAccount::STATUS_OPEN
         end
 
+        def self.validate_destination_account!(event_type, destination_account_id)
+          return unless event_type.to_s == "transfer.completed"
+
+          acc = Accounts::Models::DepositAccount.find_by(id: destination_account_id)
+          raise InvalidRequest, "destination_account_id not found" if acc.nil?
+          raise InvalidRequest, "destination account must be open" unless acc.status == Accounts::Models::DepositAccount::STATUS_OPEN
+        end
+
+        def self.validate_transfer_distinct!(event_type, source_account_id, destination_account_id)
+          return unless event_type.to_s == "transfer.completed"
+          return if source_account_id.to_i != destination_account_id.to_i
+
+          raise InvalidRequest, "transfer requires distinct source and destination accounts"
+        end
+
+        def self.validate_withdrawal_available!(event_type, source_account_id, amount_minor_units)
+          return unless event_type.to_s == "withdrawal.posted"
+
+          available = Accounts::Services::AvailableBalanceMinorUnits.call(deposit_account_id: source_account_id)
+          raise InvalidRequest, "insufficient available balance" if available < amount_minor_units.to_i
+        end
+
+        def self.validate_transfer_available!(event_type, source_account_id, amount_minor_units)
+          return unless event_type.to_s == "transfer.completed"
+
+          available = Accounts::Services::AvailableBalanceMinorUnits.call(deposit_account_id: source_account_id)
+          raise InvalidRequest, "insufficient available balance" if available < amount_minor_units.to_i
+        end
+
         def self.handle_existing(existing, incoming_fp)
-          existing_fp = fingerprint(
+          existing_fp = fingerprint_for(
             event_type: existing.event_type,
             channel: existing.channel,
             idempotency_key: existing.idempotency_key,
             amount_minor_units: existing.amount_minor_units,
             currency: existing.currency,
-            source_account_id: existing.source_account_id
+            source_account_id: existing.source_account_id,
+            destination_account_id: existing.destination_account_id
           )
           raise MismatchedIdempotency.new(incoming_fp) if existing_fp != incoming_fp
           raise PostedReplay if existing.status == Models::OperationalEvent::STATUS_POSTED

--- a/app/domains/core/operational_events/commands/record_reversal.rb
+++ b/app/domains/core/operational_events/commands/record_reversal.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "digest"
+
+module Core
+  module OperationalEvents
+    module Commands
+      class RecordReversal
+        class Error < StandardError; end
+        class InvalidRequest < Error; end
+        class NotFound < Error; end
+        class MismatchedIdempotency < Error
+          attr_reader :fingerprint
+
+          def initialize(fingerprint)
+            @fingerprint = fingerprint
+            super("idempotency_key replay does not match original request fingerprint=#{fingerprint}")
+          end
+        end
+
+        class PostedReplay < Error
+        end
+
+        REVERSIBLE_TYPES = %w[deposit.accepted withdrawal.posted transfer.completed].freeze
+
+        def self.call(original_operational_event_id:, channel:, idempotency_key:, business_date: nil)
+          RecordEvent.validate_channel!(channel)
+
+          original = Models::OperationalEvent.find_by(id: original_operational_event_id)
+          raise NotFound, "original_operational_event_id=#{original_operational_event_id}" if original.nil?
+          unless original.status == Models::OperationalEvent::STATUS_POSTED
+            raise InvalidRequest, "original event must be posted"
+          end
+          unless REVERSIBLE_TYPES.include?(original.event_type)
+            raise InvalidRequest, "event_type cannot be reversed: #{original.event_type.inspect}"
+          end
+          if Models::OperationalEvent.exists?(reversal_of_event_id: original.id)
+            raise InvalidRequest, "original event already has a reversal"
+          end
+
+          on_date = business_date || Core::BusinessDate::Services::CurrentBusinessDate.call
+          incoming_fp = fingerprint(original_operational_event_id: original_operational_event_id, channel: channel,
+                                    idempotency_key: idempotency_key)
+
+          begin
+            Models::OperationalEvent.transaction(requires_new: true) do
+              existing = Models::OperationalEvent.lock.find_by(channel: channel, idempotency_key: idempotency_key)
+              if existing
+                return handle_existing(existing, incoming_fp, original_operational_event_id)
+              end
+
+              event = Models::OperationalEvent.create!(
+                event_type: "posting.reversal",
+                status: Models::OperationalEvent::STATUS_PENDING,
+                business_date: on_date,
+                channel: channel,
+                idempotency_key: idempotency_key,
+                amount_minor_units: original.amount_minor_units,
+                currency: original.currency,
+                source_account_id: original.source_account_id,
+                destination_account_id: original.destination_account_id,
+                reversal_of_event_id: original.id
+              )
+              { outcome: :created, event: event }
+            end
+          rescue ActiveRecord::RecordNotUnique
+            existing = Models::OperationalEvent.find_by!(channel: channel, idempotency_key: idempotency_key)
+            handle_existing(existing, incoming_fp, original_operational_event_id)
+          end
+        end
+
+        def self.fingerprint(original_operational_event_id:, channel:, idempotency_key:)
+          payload = {
+            event_type: "posting.reversal",
+            channel: channel.to_s,
+            idempotency_key: idempotency_key.to_s,
+            original_operational_event_id: original_operational_event_id.to_i
+          }
+          Digest::SHA256.hexdigest(payload.to_json)
+        end
+
+        def self.handle_existing(existing, incoming_fp, original_operational_event_id)
+          raise InvalidRequest, "not a reversal event" unless existing.event_type == "posting.reversal"
+          raise InvalidRequest, "reversal original mismatch" if existing.reversal_of_event_id != original_operational_event_id
+
+          existing_fp = fingerprint(
+            original_operational_event_id: existing.reversal_of_event_id,
+            channel: existing.channel,
+            idempotency_key: existing.idempotency_key
+          )
+          raise MismatchedIdempotency.new(incoming_fp) if existing_fp != incoming_fp
+          raise PostedReplay if existing.status == Models::OperationalEvent::STATUS_POSTED
+
+          { outcome: :replay, event: existing }
+        end
+        private_class_method :handle_existing
+      end
+    end
+  end
+end

--- a/app/domains/core/operational_events/models/operational_event.rb
+++ b/app/domains/core/operational_events/models/operational_event.rb
@@ -10,9 +10,16 @@ module Core
         STATUS_POSTED = "posted"
 
         belongs_to :source_account, class_name: "Accounts::Models::DepositAccount", optional: true
+        belongs_to :destination_account, class_name: "Accounts::Models::DepositAccount", optional: true
+        belongs_to :reversal_of_event, class_name: "Core::OperationalEvents::Models::OperationalEvent", optional: true
+        belongs_to :reversed_by_event, class_name: "Core::OperationalEvents::Models::OperationalEvent", optional: true
+        belongs_to :teller_session, class_name: "Teller::Models::TellerSession", optional: true
 
         has_many :posting_batches, class_name: "Core::Posting::Models::PostingBatch", dependent: :restrict_with_exception
         has_many :journal_entries, class_name: "Core::Ledger::Models::JournalEntry", dependent: :restrict_with_exception
+        has_many :reversal_events, class_name: "Core::OperationalEvents::Models::OperationalEvent",
+                                   foreign_key: :reversal_of_event_id,
+                                   dependent: :restrict_with_exception
       end
     end
   end

--- a/app/domains/core/posting/commands/post_event.rb
+++ b/app/domains/core/posting/commands/post_event.rb
@@ -11,6 +11,9 @@ module Core
         # @return [Hash] `{ outcome: :posted|:already_posted, event: OperationalEvent }`
         def self.call(operational_event_id:)
           Core::OperationalEvents::Models::OperationalEvent.transaction do
+            # Balance trigger is deferrable; defer until both lines exist (same pattern as prior implicit deferral).
+            ActiveRecord::Base.connection.execute("SET CONSTRAINTS ALL DEFERRED")
+
             event = Core::OperationalEvents::Models::OperationalEvent.lock.find_by(id: operational_event_id)
             raise NotFound, "operational_event_id=#{operational_event_id}" if event.nil?
 
@@ -22,15 +25,16 @@ module Core
               raise InvalidState, "operational event must be pending, was #{event.status.inspect}"
             end
 
-            raise InvalidState, "unsupported event_type for slice 1 posting" unless event.event_type == "deposit.accepted"
+            legs = PostingRules::Registry.legs_for(event)
+            validate_balanced_legs!(legs)
 
-            amount = event.amount_minor_units
-            raise InvalidState, "amount_minor_units required" if amount.nil? || amount <= 0
+            reverses_journal_entry_id = nil
+            if event.event_type == "posting.reversal"
+              orig = event.reversal_of_event
+              raise InvalidState, "reversal_of_event required" if orig.nil?
 
-            cash = Core::Ledger::Models::GlAccount.find_by!(account_number: "1110")
-            dda = Core::Ledger::Models::GlAccount.find_by!(account_number: "2110")
-
-            legs_balanced!(amount)
+              reverses_journal_entry_id = orig.journal_entries.order(:id).sole.id
+            end
 
             batch = Core::Posting::Models::PostingBatch.create!(
               operational_event: event,
@@ -43,39 +47,55 @@ module Core
               business_date: event.business_date,
               currency: event.currency,
               narrative: event.event_type,
-              effective_at: Time.current
+              effective_at: Time.current,
+              reverses_journal_entry_id: reverses_journal_entry_id
             )
 
-            Core::Ledger::Models::JournalLine.create!(
-              journal_entry: entry,
-              sequence_no: 1,
-              side: "debit",
-              gl_account: cash,
-              amount_minor_units: amount
-            )
-            Core::Ledger::Models::JournalLine.create!(
-              journal_entry: entry,
-              sequence_no: 2,
-              side: "credit",
-              gl_account: dda,
-              amount_minor_units: amount
-            )
+            legs.each do |leg|
+              gl = Core::Ledger::Models::GlAccount.find_by!(account_number: leg.gl_account_number)
+              Core::Ledger::Models::JournalLine.create!(
+                journal_entry: entry,
+                sequence_no: leg.sequence_no,
+                side: leg.side,
+                gl_account: gl,
+                amount_minor_units: leg.amount_minor_units,
+                deposit_account_id: leg.deposit_account_id
+              )
+            end
 
             ActiveRecord::Base.connection.execute("SET CONSTRAINTS ALL IMMEDIATE")
 
             batch.update!(status: "posted")
             event.update!(status: Core::OperationalEvents::Models::OperationalEvent::STATUS_POSTED)
 
+            link_reversal_journal!(event, entry) if event.event_type == "posting.reversal"
+
             { outcome: :posted, event: event }
           end
         end
 
-        def self.legs_balanced!(amount_minor_units)
-          debit = amount_minor_units
-          credit = amount_minor_units
-          raise InvalidState, "unbalanced legs" unless debit == credit
+        def self.validate_balanced_legs!(legs)
+          deb = legs.sum { |l| l.side == "debit" ? l.amount_minor_units : 0 }
+          cre = legs.sum { |l| l.side == "credit" ? l.amount_minor_units : 0 }
+          raise InvalidState, "unbalanced legs" unless deb == cre
         end
-        private_class_method :legs_balanced!
+        private_class_method :validate_balanced_legs!
+
+        def self.link_reversal_journal!(reversal_event, reversal_entry)
+          original = reversal_event.reversal_of_event
+          return if original.nil?
+
+          original_entry = original.journal_entries.order(:id).sole
+          original_entry.update_columns(
+            reversing_journal_entry_id: reversal_entry.id,
+            updated_at: Time.current
+          )
+          original.update_columns(
+            reversed_by_event_id: reversal_event.id,
+            updated_at: Time.current
+          )
+        end
+        private_class_method :link_reversal_journal!
       end
     end
   end

--- a/app/domains/core/posting/posting_rules/deposit_accepted.rb
+++ b/app/domains/core/posting/posting_rules/deposit_accepted.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Core
+  module Posting
+    module PostingRules
+      # GL 1110 / 2110 per ADR-0010 slice; liability leg tagged with deposit subledger.
+      module DepositAccepted
+        module_function
+
+        def legs_for(event)
+          amount = event.amount_minor_units
+          if amount.nil? || amount <= 0
+            raise Core::Posting::Commands::PostEvent::InvalidState, "amount_minor_units required"
+          end
+          if event.source_account_id.blank?
+            raise Core::Posting::Commands::PostEvent::InvalidState, "source_account_id required for deposit.accepted"
+          end
+
+          [
+            PostingLeg.new(
+              sequence_no: 1,
+              gl_account_number: "1110",
+              side: "debit",
+              amount_minor_units: amount,
+              deposit_account_id: nil
+            ),
+            PostingLeg.new(
+              sequence_no: 2,
+              gl_account_number: "2110",
+              side: "credit",
+              amount_minor_units: amount,
+              deposit_account_id: event.source_account_id
+            )
+          ]
+        end
+      end
+    end
+  end
+end

--- a/app/domains/core/posting/posting_rules/posting_leg.rb
+++ b/app/domains/core/posting/posting_rules/posting_leg.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Core
+  module Posting
+    module PostingRules
+      # Immutable description of one journal line to persist for an operational event.
+      PostingLeg = Struct.new(:sequence_no, :gl_account_number, :side, :amount_minor_units, :deposit_account_id,
+                              keyword_init: true)
+    end
+  end
+end

--- a/app/domains/core/posting/posting_rules/posting_reversal.rb
+++ b/app/domains/core/posting/posting_rules/posting_reversal.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Core
+  module Posting
+    module PostingRules
+      # Full compensating mirror of the original journal (swap debit/credit per line).
+      module PostingReversal
+        module_function
+
+        def legs_for(event)
+          original = event.reversal_of_event
+          if original.nil?
+            raise Core::Posting::Commands::PostEvent::InvalidState, "reversal_of_event_id required for posting.reversal"
+          end
+
+          orig_entry = original.journal_entries.order(:id).sole
+          orig_lines = orig_entry.journal_lines.includes(:gl_account).order(:sequence_no).to_a
+          if orig_lines.empty?
+            raise Core::Posting::Commands::PostEvent::InvalidState, "original event has no journal lines"
+          end
+
+          orig_lines.each_with_index.map do |line, idx|
+            mirrored_side = line.side == "debit" ? "credit" : "debit"
+            PostingLeg.new(
+              sequence_no: idx + 1,
+              gl_account_number: line.gl_account.account_number,
+              side: mirrored_side,
+              amount_minor_units: line.amount_minor_units,
+              deposit_account_id: line.deposit_account_id
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/domains/core/posting/posting_rules/registry.rb
+++ b/app/domains/core/posting/posting_rules/registry.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Core
+  module Posting
+    module PostingRules
+      module Registry
+        HANDLERS = {
+          "deposit.accepted" => DepositAccepted,
+          "withdrawal.posted" => WithdrawalPosted,
+          "transfer.completed" => TransferCompleted,
+          "posting.reversal" => PostingReversal
+        }.freeze
+
+        def self.legs_for(event)
+          handler = HANDLERS[event.event_type.to_s]
+          if handler.nil?
+            raise Core::Posting::Commands::PostEvent::InvalidState,
+                  "unsupported event_type for posting: #{event.event_type.inspect}"
+          end
+          handler.legs_for(event)
+        end
+      end
+    end
+  end
+end

--- a/app/domains/core/posting/posting_rules/transfer_completed.rb
+++ b/app/domains/core/posting/posting_rules/transfer_completed.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Core
+  module Posting
+    module PostingRules
+      # Internal transfer: Dr 2110 from source, Cr 2110 to destination (subledger on both legs).
+      module TransferCompleted
+        module_function
+
+        def legs_for(event)
+          amount = event.amount_minor_units
+          if amount.nil? || amount <= 0
+            raise Core::Posting::Commands::PostEvent::InvalidState, "amount_minor_units required"
+          end
+          if event.source_account_id.blank? || event.destination_account_id.blank?
+            raise Core::Posting::Commands::PostEvent::InvalidState,
+                  "source_account_id and destination_account_id required for transfer.completed"
+          end
+          if event.source_account_id == event.destination_account_id
+            raise Core::Posting::Commands::PostEvent::InvalidState, "transfer requires two distinct accounts"
+          end
+
+          [
+            PostingLeg.new(
+              sequence_no: 1,
+              gl_account_number: "2110",
+              side: "debit",
+              amount_minor_units: amount,
+              deposit_account_id: event.source_account_id
+            ),
+            PostingLeg.new(
+              sequence_no: 2,
+              gl_account_number: "2110",
+              side: "credit",
+              amount_minor_units: amount,
+              deposit_account_id: event.destination_account_id
+            )
+          ]
+        end
+      end
+    end
+  end
+end

--- a/app/domains/core/posting/posting_rules/withdrawal_posted.rb
+++ b/app/domains/core/posting/posting_rules/withdrawal_posted.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Core
+  module Posting
+    module PostingRules
+      # Cash out: reduce customer liability (2110), reduce cash asset (1110).
+      module WithdrawalPosted
+        module_function
+
+        def legs_for(event)
+          amount = event.amount_minor_units
+          if amount.nil? || amount <= 0
+            raise Core::Posting::Commands::PostEvent::InvalidState, "amount_minor_units required"
+          end
+          if event.source_account_id.blank?
+            raise Core::Posting::Commands::PostEvent::InvalidState, "source_account_id required for withdrawal.posted"
+          end
+
+          [
+            PostingLeg.new(
+              sequence_no: 1,
+              gl_account_number: "2110",
+              side: "debit",
+              amount_minor_units: amount,
+              deposit_account_id: event.source_account_id
+            ),
+            PostingLeg.new(
+              sequence_no: 2,
+              gl_account_number: "1110",
+              side: "credit",
+              amount_minor_units: amount,
+              deposit_account_id: nil
+            )
+          ]
+        end
+      end
+    end
+  end
+end

--- a/app/domains/party/services/individual_display_name.rb
+++ b/app/domains/party/services/individual_display_name.rb
@@ -5,7 +5,7 @@ module Party
     # ADR-0009 §2.3 — display `party_records.name` for individuals (not preferred_* fields).
     class IndividualDisplayName
       def self.build(first_name:, last_name:, middle_name: nil, name_suffix: nil)
-        parts = [first_name, middle_name.presence, last_name].compact
+        parts = [ first_name, middle_name.presence, last_name ].compact
         base = parts.join(" ")
         name_suffix.present? ? "#{base}, #{name_suffix}" : base
       end

--- a/app/domains/teller.rb
+++ b/app/domains/teller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module Teller
+end

--- a/app/domains/teller/commands/close_session.rb
+++ b/app/domains/teller/commands/close_session.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Teller
+  module Commands
+    class CloseSession
+      class Error < StandardError; end
+      class NotFound < Error; end
+      class InvalidState < Error; end
+
+      def self.call(teller_session_id:, expected_cash_minor_units:, actual_cash_minor_units:)
+        Teller::Models::TellerSession.transaction do
+          session = Teller::Models::TellerSession.lock.find_by(id: teller_session_id)
+          raise NotFound, "teller_session_id=#{teller_session_id}" if session.nil?
+          unless session.status == Teller::Models::TellerSession::STATUS_OPEN
+            raise InvalidState, "session must be open, was #{session.status.inspect}"
+          end
+
+          variance = actual_cash_minor_units.to_i - expected_cash_minor_units.to_i
+          session.update!(
+            status: Teller::Models::TellerSession::STATUS_CLOSED,
+            closed_at: Time.current,
+            expected_cash_minor_units: expected_cash_minor_units,
+            actual_cash_minor_units: actual_cash_minor_units,
+            variance_minor_units: variance
+          )
+          session
+        end
+      end
+    end
+  end
+end

--- a/app/domains/teller/commands/open_session.rb
+++ b/app/domains/teller/commands/open_session.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Teller
+  module Commands
+    class OpenSession
+      class Error < StandardError; end
+      class SessionAlreadyOpen < Error; end
+
+      # One open session per drawer_code (nil drawer = single open session for MVP).
+      def self.call(drawer_code: nil)
+        Teller::Models::TellerSession.transaction do
+          scope = Teller::Models::TellerSession.where(status: Teller::Models::TellerSession::STATUS_OPEN)
+          scope = scope.where(drawer_code: drawer_code) if drawer_code.present?
+          raise SessionAlreadyOpen, "open session exists for drawer" if scope.exists?
+
+          Teller::Models::TellerSession.create!(
+            status: Teller::Models::TellerSession::STATUS_OPEN,
+            opened_at: Time.current,
+            drawer_code: drawer_code
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/domains/teller/models/teller_session.rb
+++ b/app/domains/teller/models/teller_session.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Teller
+  module Models
+    class TellerSession < ApplicationRecord
+      self.table_name = "teller_sessions"
+
+      STATUS_OPEN = "open"
+      STATUS_CLOSED = "closed"
+      STATUS_PENDING_SUPERVISOR = "pending_supervisor"
+
+      has_many :operational_events, class_name: "Core::OperationalEvents::Models::OperationalEvent",
+                                    inverse_of: :teller_session,
+                                    dependent: :restrict_with_exception
+    end
+  end
+end

--- a/bin/dev-seed-sample-data
+++ b/bin/dev-seed-sample-data
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Load sample party / account / deposit events into the development database.
+# Requires RAILS_ENV=development (default when not set to test/production).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+exec bin/rails runner script/development_sample_data.rb

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,12 @@ Rails.application.routes.draw do
     post "deposit_accounts", to: "deposit_accounts#create"
     post "operational_events", to: "operational_events#create"
     post "operational_events/:id/post", to: "operational_event_posts#create"
+    post "reversals", to: "reversals#create"
+    post "holds", to: "holds#create"
+    post "holds/release", to: "holds#release"
+    post "teller_sessions", to: "teller_sessions#create"
+    post "teller_sessions/close", to: "teller_sessions#close"
+    post "overrides", to: "overrides#create"
   end
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20260423120000_add_deposit_account_id_to_journal_lines.rb
+++ b/db/migrate/20260423120000_add_deposit_account_id_to_journal_lines.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDepositAccountIdToJournalLines < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :journal_lines, :deposit_account, foreign_key: { to_table: :deposit_accounts }, null: true
+  end
+end

--- a/db/migrate/20260423120001_add_transfer_and_reversal_columns_to_operational_events.rb
+++ b/db/migrate/20260423120001_add_transfer_and_reversal_columns_to_operational_events.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddTransferAndReversalColumnsToOperationalEvents < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :operational_events, :destination_account, foreign_key: { to_table: :deposit_accounts }, null: true
+
+    add_column :operational_events, :reversal_of_event_id, :bigint
+    add_column :operational_events, :reversed_by_event_id, :bigint
+
+    add_foreign_key :operational_events, :operational_events, column: :reversal_of_event_id
+    add_foreign_key :operational_events, :operational_events, column: :reversed_by_event_id
+
+    add_index :operational_events, :reversal_of_event_id, unique: true, where: "reversal_of_event_id IS NOT NULL",
+      name: "index_operational_events_one_reversal_per_original"
+  end
+end

--- a/db/migrate/20260423120002_create_holds.rb
+++ b/db/migrate/20260423120002_create_holds.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateHolds < ActiveRecord::Migration[8.1]
+  def change
+    create_table :holds do |t|
+      t.references :deposit_account, null: false, foreign_key: true
+      t.bigint :amount_minor_units, null: false
+      t.string :currency, null: false, default: "USD"
+      t.string :status, null: false, default: "active"
+      t.references :placed_by_operational_event, null: true, foreign_key: { to_table: :operational_events }
+      t.references :released_by_operational_event, null: true, foreign_key: { to_table: :operational_events }
+      t.timestamps
+    end
+
+    add_check_constraint :holds, "amount_minor_units > 0", name: "holds_amount_positive"
+    add_check_constraint :holds, "status IN ('active','released','expired')", name: "holds_status_enum"
+  end
+end

--- a/db/migrate/20260423120003_create_teller_sessions.rb
+++ b/db/migrate/20260423120003_create_teller_sessions.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateTellerSessions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :teller_sessions do |t|
+      t.string :status, null: false, default: "open"
+      t.datetime :opened_at, null: false
+      t.datetime :closed_at
+      t.string :drawer_code
+      t.bigint :expected_cash_minor_units
+      t.bigint :actual_cash_minor_units
+      t.bigint :variance_minor_units
+      t.datetime :supervisor_approved_at
+      t.timestamps
+    end
+
+    add_check_constraint :teller_sessions, "status IN ('open','closed','pending_supervisor')",
+      name: "teller_sessions_status_enum"
+  end
+end

--- a/db/migrate/20260423120004_add_session_and_reference_to_operational_events.rb
+++ b/db/migrate/20260423120004_add_session_and_reference_to_operational_events.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddSessionAndReferenceToOperationalEvents < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :operational_events, :teller_session, null: true, foreign_key: true
+    add_column :operational_events, :reference_id, :string
+    add_column :operational_events, :actor_id, :bigint
+  end
+end

--- a/db/migrate/20260423120005_allow_journal_entry_reversal_link_update.rb
+++ b/db/migrate/20260423120005_allow_journal_entry_reversal_link_update.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Allow a single UPDATE on journal_entries: set reversing_journal_entry_id on the original entry
+# after the compensating entry is inserted (ADR-0010 §7). All other mutations remain forbidden.
+class AllowJournalEntryReversalLinkUpdate < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    execute <<~SQL
+      CREATE OR REPLACE FUNCTION ledger_journal_entries_reject_mutations() RETURNS trigger
+        LANGUAGE plpgsql AS $$
+      BEGIN
+        IF TG_OP = 'DELETE' THEN
+          RAISE EXCEPTION 'journal_entries are append-only (immutable)';
+        END IF;
+        IF TG_OP = 'UPDATE' THEN
+          IF OLD.reversing_journal_entry_id IS NULL
+             AND NEW.reversing_journal_entry_id IS NOT NULL
+             AND OLD.id = NEW.id
+             AND OLD.posting_batch_id IS NOT DISTINCT FROM NEW.posting_batch_id
+             AND OLD.operational_event_id IS NOT DISTINCT FROM NEW.operational_event_id
+             AND OLD.business_date IS NOT DISTINCT FROM NEW.business_date
+             AND OLD.currency IS NOT DISTINCT FROM NEW.currency
+             AND OLD.narrative IS NOT DISTINCT FROM NEW.narrative
+             AND OLD.effective_at IS NOT DISTINCT FROM NEW.effective_at
+             AND OLD.status IS NOT DISTINCT FROM NEW.status
+             AND OLD.reverses_journal_entry_id IS NOT DISTINCT FROM NEW.reverses_journal_entry_id
+             AND OLD.created_at IS NOT DISTINCT FROM NEW.created_at
+          THEN
+            RETURN NEW;
+          END IF;
+          RAISE EXCEPTION 'journal_entries are append-only (immutable)';
+        END IF;
+        RETURN NEW;
+      END;
+      $$;
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      CREATE OR REPLACE FUNCTION ledger_journal_entries_reject_mutations() RETURNS trigger
+        LANGUAGE plpgsql AS $$
+      BEGIN
+        IF TG_OP = 'UPDATE' OR TG_OP = 'DELETE' THEN
+          RAISE EXCEPTION 'journal_entries are append-only (immutable)';
+        END IF;
+        RETURN NEW;
+      END;
+      $$;
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -283,7 +283,7 @@ CREATE TABLE public.journal_lines (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     CONSTRAINT journal_lines_amount_non_negative CHECK ((amount_minor_units >= 0)),
-    CONSTRAINT journal_lines_side_enum CHECK (((side)::text = ANY (ARRAY[('debit'::character varying)::text, ('credit'::character varying)::text])))
+    CONSTRAINT journal_lines_side_enum CHECK (((side)::text = ANY ((ARRAY['debit'::character varying, 'credit'::character varying])::text[])))
 );
 
 
@@ -757,35 +757,19 @@ CREATE TRIGGER journal_lines_immutability_check BEFORE DELETE OR UPDATE ON publi
 
 
 --
--- Name: deposit_account_parties fk_deposit_account_parties_deposit_account; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: deposit_account_parties fk_rails_0245a491be; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.deposit_account_parties
-    ADD CONSTRAINT fk_deposit_account_parties_deposit_account FOREIGN KEY (deposit_account_id) REFERENCES public.deposit_accounts(id);
+    ADD CONSTRAINT fk_rails_0245a491be FOREIGN KEY (party_record_id) REFERENCES public.party_records(id);
 
 
 --
--- Name: deposit_account_parties fk_deposit_account_parties_party_record; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.deposit_account_parties
-    ADD CONSTRAINT fk_deposit_account_parties_party_record FOREIGN KEY (party_record_id) REFERENCES public.party_records(id);
-
-
---
--- Name: operational_events fk_operational_events_source_account; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: operational_events fk_rails_0f986cd613; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.operational_events
-    ADD CONSTRAINT fk_operational_events_source_account FOREIGN KEY (source_account_id) REFERENCES public.deposit_accounts(id);
-
-
---
--- Name: party_individual_profiles fk_party_individual_profiles_party_record; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.party_individual_profiles
-    ADD CONSTRAINT fk_party_individual_profiles_party_record FOREIGN KEY (party_record_id) REFERENCES public.party_records(id);
+    ADD CONSTRAINT fk_rails_0f986cd613 FOREIGN KEY (source_account_id) REFERENCES public.deposit_accounts(id);
 
 
 --
@@ -794,6 +778,14 @@ ALTER TABLE ONLY public.party_individual_profiles
 
 ALTER TABLE ONLY public.posting_batches
     ADD CONSTRAINT fk_rails_1a3b38f450 FOREIGN KEY (operational_event_id) REFERENCES public.operational_events(id);
+
+
+--
+-- Name: party_individual_profiles fk_rails_22a835d5da; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.party_individual_profiles
+    ADD CONSTRAINT fk_rails_22a835d5da FOREIGN KEY (party_record_id) REFERENCES public.party_records(id);
 
 
 --
@@ -818,6 +810,14 @@ ALTER TABLE ONLY public.journal_entries
 
 ALTER TABLE ONLY public.journal_lines
     ADD CONSTRAINT fk_rails_92eda40cad FOREIGN KEY (journal_entry_id) REFERENCES public.journal_entries(id);
+
+
+--
+-- Name: deposit_account_parties fk_rails_bf2b31365a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.deposit_account_parties
+    ADD CONSTRAINT fk_rails_bf2b31365a FOREIGN KEY (deposit_account_id) REFERENCES public.deposit_accounts(id);
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -17,7 +17,25 @@ CREATE FUNCTION public.ledger_journal_entries_reject_mutations() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
-  IF TG_OP = 'UPDATE' OR TG_OP = 'DELETE' THEN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'journal_entries are append-only (immutable)';
+  END IF;
+  IF TG_OP = 'UPDATE' THEN
+    IF OLD.reversing_journal_entry_id IS NULL
+       AND NEW.reversing_journal_entry_id IS NOT NULL
+       AND OLD.id = NEW.id
+       AND OLD.posting_batch_id IS NOT DISTINCT FROM NEW.posting_batch_id
+       AND OLD.operational_event_id IS NOT DISTINCT FROM NEW.operational_event_id
+       AND OLD.business_date IS NOT DISTINCT FROM NEW.business_date
+       AND OLD.currency IS NOT DISTINCT FROM NEW.currency
+       AND OLD.narrative IS NOT DISTINCT FROM NEW.narrative
+       AND OLD.effective_at IS NOT DISTINCT FROM NEW.effective_at
+       AND OLD.status IS NOT DISTINCT FROM NEW.status
+       AND OLD.reverses_journal_entry_id IS NOT DISTINCT FROM NEW.reverses_journal_entry_id
+       AND OLD.created_at IS NOT DISTINCT FROM NEW.created_at
+    THEN
+      RETURN NEW;
+    END IF;
     RAISE EXCEPTION 'journal_entries are append-only (immutable)';
   END IF;
   RETURN NEW;
@@ -230,6 +248,44 @@ ALTER SEQUENCE public.gl_accounts_id_seq OWNED BY public.gl_accounts.id;
 
 
 --
+-- Name: holds; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.holds (
+    id bigint NOT NULL,
+    deposit_account_id bigint NOT NULL,
+    amount_minor_units bigint NOT NULL,
+    currency character varying DEFAULT 'USD'::character varying NOT NULL,
+    status character varying DEFAULT 'active'::character varying NOT NULL,
+    placed_by_operational_event_id bigint,
+    released_by_operational_event_id bigint,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    CONSTRAINT holds_amount_positive CHECK ((amount_minor_units > 0)),
+    CONSTRAINT holds_status_enum CHECK (((status)::text = ANY ((ARRAY['active'::character varying, 'released'::character varying, 'expired'::character varying])::text[])))
+);
+
+
+--
+-- Name: holds_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.holds_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: holds_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.holds_id_seq OWNED BY public.holds.id;
+
+
+--
 -- Name: journal_entries; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -282,6 +338,7 @@ CREATE TABLE public.journal_lines (
     narrative character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
+    deposit_account_id bigint,
     CONSTRAINT journal_lines_amount_non_negative CHECK ((amount_minor_units >= 0)),
     CONSTRAINT journal_lines_side_enum CHECK (((side)::text = ANY ((ARRAY['debit'::character varying, 'credit'::character varying])::text[])))
 );
@@ -321,7 +378,13 @@ CREATE TABLE public.operational_events (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     channel character varying NOT NULL,
-    source_account_id bigint
+    source_account_id bigint,
+    destination_account_id bigint,
+    reversal_of_event_id bigint,
+    reversed_by_event_id bigint,
+    teller_session_id bigint,
+    reference_id character varying,
+    actor_id bigint
 );
 
 
@@ -458,6 +521,45 @@ CREATE TABLE public.schema_migrations (
 
 
 --
+-- Name: teller_sessions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.teller_sessions (
+    id bigint NOT NULL,
+    status character varying DEFAULT 'open'::character varying NOT NULL,
+    opened_at timestamp(6) without time zone NOT NULL,
+    closed_at timestamp(6) without time zone,
+    drawer_code character varying,
+    expected_cash_minor_units bigint,
+    actual_cash_minor_units bigint,
+    variance_minor_units bigint,
+    supervisor_approved_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    CONSTRAINT teller_sessions_status_enum CHECK (((status)::text = ANY ((ARRAY['open'::character varying, 'closed'::character varying, 'pending_supervisor'::character varying])::text[])))
+);
+
+
+--
+-- Name: teller_sessions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.teller_sessions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: teller_sessions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.teller_sessions_id_seq OWNED BY public.teller_sessions.id;
+
+
+--
 -- Name: core_business_date_settings id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -483,6 +585,13 @@ ALTER TABLE ONLY public.deposit_accounts ALTER COLUMN id SET DEFAULT nextval('pu
 --
 
 ALTER TABLE ONLY public.gl_accounts ALTER COLUMN id SET DEFAULT nextval('public.gl_accounts_id_seq'::regclass);
+
+
+--
+-- Name: holds id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.holds ALTER COLUMN id SET DEFAULT nextval('public.holds_id_seq'::regclass);
 
 
 --
@@ -528,6 +637,13 @@ ALTER TABLE ONLY public.posting_batches ALTER COLUMN id SET DEFAULT nextval('pub
 
 
 --
+-- Name: teller_sessions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.teller_sessions ALTER COLUMN id SET DEFAULT nextval('public.teller_sessions_id_seq'::regclass);
+
+
+--
 -- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -565,6 +681,14 @@ ALTER TABLE ONLY public.deposit_accounts
 
 ALTER TABLE ONLY public.gl_accounts
     ADD CONSTRAINT gl_accounts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: holds holds_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.holds
+    ADD CONSTRAINT holds_pkey PRIMARY KEY (id);
 
 
 --
@@ -624,6 +748,14 @@ ALTER TABLE ONLY public.schema_migrations
 
 
 --
+-- Name: teller_sessions teller_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.teller_sessions
+    ADD CONSTRAINT teller_sessions_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: index_dap_unique_open_active_per_account_party_role; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -659,6 +791,27 @@ CREATE UNIQUE INDEX index_gl_accounts_on_account_number ON public.gl_accounts US
 
 
 --
+-- Name: index_holds_on_deposit_account_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_holds_on_deposit_account_id ON public.holds USING btree (deposit_account_id);
+
+
+--
+-- Name: index_holds_on_placed_by_operational_event_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_holds_on_placed_by_operational_event_id ON public.holds USING btree (placed_by_operational_event_id);
+
+
+--
+-- Name: index_holds_on_released_by_operational_event_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_holds_on_released_by_operational_event_id ON public.holds USING btree (released_by_operational_event_id);
+
+
+--
 -- Name: index_journal_entries_on_operational_event_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -684,6 +837,13 @@ CREATE INDEX index_journal_entries_on_reverses_journal_entry_id ON public.journa
 --
 
 CREATE INDEX index_journal_entries_on_reversing_journal_entry_id ON public.journal_entries USING btree (reversing_journal_entry_id);
+
+
+--
+-- Name: index_journal_lines_on_deposit_account_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_journal_lines_on_deposit_account_id ON public.journal_lines USING btree (deposit_account_id);
 
 
 --
@@ -715,10 +875,31 @@ CREATE UNIQUE INDEX index_operational_events_on_channel_and_idempotency_key ON p
 
 
 --
+-- Name: index_operational_events_on_destination_account_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_operational_events_on_destination_account_id ON public.operational_events USING btree (destination_account_id);
+
+
+--
 -- Name: index_operational_events_on_source_account_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_operational_events_on_source_account_id ON public.operational_events USING btree (source_account_id);
+
+
+--
+-- Name: index_operational_events_on_teller_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_operational_events_on_teller_session_id ON public.operational_events USING btree (teller_session_id);
+
+
+--
+-- Name: index_operational_events_one_reversal_per_original; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_operational_events_one_reversal_per_original ON public.operational_events USING btree (reversal_of_event_id) WHERE (reversal_of_event_id IS NOT NULL);
 
 
 --
@@ -789,6 +970,22 @@ ALTER TABLE ONLY public.party_individual_profiles
 
 
 --
+-- Name: operational_events fk_rails_29073cc426; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.operational_events
+    ADD CONSTRAINT fk_rails_29073cc426 FOREIGN KEY (teller_session_id) REFERENCES public.teller_sessions(id);
+
+
+--
+-- Name: journal_lines fk_rails_2b0c279a73; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.journal_lines
+    ADD CONSTRAINT fk_rails_2b0c279a73 FOREIGN KEY (deposit_account_id) REFERENCES public.deposit_accounts(id);
+
+
+--
 -- Name: journal_entries fk_rails_3417d84ffc; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -797,11 +994,35 @@ ALTER TABLE ONLY public.journal_entries
 
 
 --
+-- Name: holds fk_rails_4283210e70; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.holds
+    ADD CONSTRAINT fk_rails_4283210e70 FOREIGN KEY (released_by_operational_event_id) REFERENCES public.operational_events(id);
+
+
+--
+-- Name: holds fk_rails_4c0c5bf773; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.holds
+    ADD CONSTRAINT fk_rails_4c0c5bf773 FOREIGN KEY (placed_by_operational_event_id) REFERENCES public.operational_events(id);
+
+
+--
 -- Name: journal_entries fk_rails_7f9a73cda9; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.journal_entries
     ADD CONSTRAINT fk_rails_7f9a73cda9 FOREIGN KEY (operational_event_id) REFERENCES public.operational_events(id);
+
+
+--
+-- Name: operational_events fk_rails_8cf89c2939; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.operational_events
+    ADD CONSTRAINT fk_rails_8cf89c2939 FOREIGN KEY (reversal_of_event_id) REFERENCES public.operational_events(id);
 
 
 --
@@ -829,6 +1050,14 @@ ALTER TABLE ONLY public.journal_entries
 
 
 --
+-- Name: operational_events fk_rails_e1fee9a69d; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.operational_events
+    ADD CONSTRAINT fk_rails_e1fee9a69d FOREIGN KEY (reversed_by_event_id) REFERENCES public.operational_events(id);
+
+
+--
 -- Name: journal_entries fk_rails_e2ae198c7f; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -845,12 +1074,34 @@ ALTER TABLE ONLY public.journal_lines
 
 
 --
+-- Name: holds fk_rails_ecf3d13b03; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.holds
+    ADD CONSTRAINT fk_rails_ecf3d13b03 FOREIGN KEY (deposit_account_id) REFERENCES public.deposit_accounts(id);
+
+
+--
+-- Name: operational_events fk_rails_f4a7a6dc52; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.operational_events
+    ADD CONSTRAINT fk_rails_f4a7a6dc52 FOREIGN KEY (destination_account_id) REFERENCES public.deposit_accounts(id);
+
+
+--
 -- PostgreSQL database dump complete
 --
 
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260423120005'),
+('20260423120004'),
+('20260423120003'),
+('20260423120002'),
+('20260423120001'),
+('20260423120000'),
 ('20260422130007'),
 ('20260422130005'),
 ('20260422130004'),

--- a/docs/adr/0002-operational-event-model.md
+++ b/docs/adr/0002-operational-event-model.md
@@ -39,7 +39,7 @@ This includes:
 
 ### 2.2 Event `event_type` registry (MVP)
 
-Canonical **`event_type`** strings (dotted codes such as `deposit.accepted` in §5) are the **application registry** for MVP. [docs/concepts/101-operational_event_enums_concept.md](../concepts/101-operational_event_enums_concept.md) supplies **parent/component vocabulary** for product and analytics; mapping from persisted `event_type` to concept-101 families is **documentation or a future mapping ADR**, not a second source of truth in the row. New `event_type` values require catalog or ADR review so posting and reporting stay aligned.
+Canonical **`event_type`** strings (dotted codes such as `deposit.accepted` in §5) are the **application registry** for MVP. Per-type semantics, posting, and idempotency fields are elaborated in **[docs/operational_events/](../operational_events/README.md)**. [docs/concepts/101-operational_event_enums_concept.md](../concepts/101-operational_event_enums_concept.md) supplies **parent/component vocabulary** for product and analytics; mapping from persisted `event_type` to concept-101 families is **documentation or a future mapping ADR**, not a second source of truth in the row. New `event_type` values require catalog or ADR review so posting and reporting stay aligned.
 
 ---
 
@@ -225,14 +225,14 @@ Authoritative **MVP column list** for the ledger slice is tabulated in [ADR-0010
 | Conceptual field (§4) | MVP table today | Note |
 | --------------------- | ----------------- | ---- |
 | `effective_at` | not persisted | **Slice A:** add when integrations require server timestamp of intent. |
-| `actor_id` | not persisted | **Slice B:** workspace / operator identity. |
+| `actor_id` | persisted (nullable bigint stub) | Operator id when supplied; full identity tables deferred. |
 | `channel` | persisted (idempotency §7.3) | Required for scoped idempotency; aligns with §4.1. |
-| `reference_id` / correlation | not persisted | **Slice A:** external trace (wire ref, file id, etc.). |
-| Reversal FKs | not persisted | **Slice A** when reversal commands ship. |
+| `reference_id` / correlation | persisted (`reference_id`) | Control / correlation (MVP teller overrides, hold release ref). |
+| Reversal FKs | persisted | **`reversal_of_event_id`**, **`reversed_by_event_id`** — see [ADR-0010](0010-ledger-persistence-and-seeded-coa.md) §5 and **`posting.reversal`** in [ADR-0012](0012-posting-rule-registry-and-journal-subledger.md). |
 | JSON metadata | not persisted | **Slice C:** versioned payload per `event_type` when needed. |
 | `amount_cents` (§4 wording) | `amount_minor_units` (ADR-0008) | Naming: use minor units in schema (ADR-0010). |
 | `source_account_id` (§4.2) | persisted — nullable FK → **`deposit_accounts`** | **Slice 1:** required for **`deposit.accepted`** financial path; idempotency mismatch logic includes it alongside type/amount/currency ([ADR-0011](0011-accounts-deposit-vertical-slice-mvp.md) §2.5). |
-| `destination_account_id` (§4.2) | not persisted | **Future slice:** internal transfers and similar events. |
+| `destination_account_id` (§4.2) | persisted — nullable FK → **`deposit_accounts`** | **`transfer.completed`** and mirrored on **`posting.reversal`**. |
 
 ### 8.2 Audit and timestamps
 

--- a/docs/adr/0010-ledger-persistence-and-seeded-coa.md
+++ b/docs/adr/0010-ledger-persistence-and-seeded-coa.md
@@ -71,6 +71,11 @@ Full lifecycle, idempotency scope, status vocabulary, column roadmap, and compos
 | `amount_minor_units` | bigint | nullable (financial events) |
 | `currency`         | string   | nullable |
 | `source_account_id` | bigint  | nullable, FK → **`deposit_accounts`** — populated for slice-1 **`deposit.accepted`** (and future account-sourced events); see [ADR-0011](0011-accounts-deposit-vertical-slice-mvp.md) §2.5. |
+| `destination_account_id` | bigint | nullable, FK → **`deposit_accounts`** — **`transfer.completed`**. |
+| `reversal_of_event_id` / `reversed_by_event_id` | bigint | nullable, self-FK — compensating **`posting.reversal`** linkage (ADR-0002 §6). |
+| `teller_session_id` | bigint | nullable, FK → **`teller_sessions`**. |
+| `reference_id` | string | nullable — control events, external correlation. |
+| `actor_id` | bigint | nullable — operator stub until identity tables land. |
 | `created_at` / `updated_at` | datetime | |
 
 ---
@@ -122,6 +127,7 @@ Persist **only balanced** entries in the same transaction as their lines (ADR-00
 | `amount_minor_units`   | bigint | NOT NULL, **CHECK (amount_minor_units >= 0)** (ADR-0008 §5.1) |
 | `narrative`            | string | nullable |
 | `created_at` / `updated_at` | datetime | |
+| `deposit_account_id` | bigint | nullable, FK → **`deposit_accounts`** — **subledger** for customer DDA liability on **2110** legs (ADR-0012); null for cash (1110) legs and legacy rows. |
 
 ---
 
@@ -137,7 +143,7 @@ Persist **only balanced** entries in the same transaction as their lines (ADR-00
 ## 10. Immutability
 
 - **`journal_lines`:** append-only — **no UPDATE or DELETE** enforced with a **BEFORE UPDATE OR DELETE** trigger that raises.
-- **`journal_entries`:** no UPDATE or DELETE after insert (same pattern) for MVP.
+- **`journal_entries`:** no UPDATE or DELETE after insert **except** one narrow case: setting **`reversing_journal_entry_id`** on the **original** entry when a compensating reversal entry is persisted (ADR-0003 reversal linkage). A replacement trigger function allows **only** that column to change from NULL to the new entry’s id when all other business columns are unchanged (migration `AllowJournalEntryReversalLinkUpdate`).
 - Enforcement is **DB-level** for defense in depth; domain code must still treat models as read-only after create.
 
 ---

--- a/docs/adr/0012-posting-rule-registry-and-journal-subledger.md
+++ b/docs/adr/0012-posting-rule-registry-and-journal-subledger.md
@@ -1,0 +1,49 @@
+# ADR-0012: Posting rule registry and journal subledger (`deposit_account_id`)
+
+**Status:** Accepted  
+**Date:** 2026-04-23  
+**Decision Type:** Core posting architecture  
+**Aligns with:** [ADR-0003](0003-posting-journal-architecture.md), [ADR-0010](0010-ledger-persistence-and-seeded-coa.md), [ADR-0002](0002-operational-event-model.md), [docs/operational_events/README.md](../operational_events/README.md)
+
+---
+
+## 1. Context
+
+Slice 1 inlined GL mapping inside `PostEvent` for a single `event_type`. Phase 1 adds withdrawals, transfers, and reversals; a growing `case` on `event_type` is hard to test and review.
+
+Per-account liability on GL **2110** cannot be inferred from aggregate GL rows alone; internal transfers require distinct subledger attribution on both legs.
+
+---
+
+## 2. Decision
+
+1. **`Core::Posting::PostingRules::Registry`** maps `event_type` string → a small rule module that returns an ordered list of **`PostingLeg`** structs (`gl_account_number`, `side`, `amount_minor_units`, optional `deposit_account_id`).
+2. **`Core::Posting::Commands::PostEvent`** owns batch + journal persistence only; it resolves legs via the registry, validates Σ debits = Σ credits, resolves `GlAccount` rows by `account_number` (seeded COA per ADR-0010 §3.2), and persists `journal_lines` including **`deposit_account_id`** where the leg is customer DDA liability (2110).
+3. **Ownership:** `Core::Posting` owns the registry and rule modules under `app/domains/core/posting/posting_rules/`. Other domains must not insert `journal_lines` directly.
+
+---
+
+## 3. MVP rules registered
+
+| `event_type` | Summary |
+| ------------ | ------- |
+| `deposit.accepted` | Dr 1110 / Cr 2110; Cr leg carries `deposit_account_id` = `source_account_id`. |
+| `withdrawal.posted` | Dr 2110 (`deposit_account_id` = source) / Cr 1110. |
+| `transfer.completed` | Dr 2110 (source) / Cr 2110 (destination). |
+| `posting.reversal` | Mirror lines of the original journal (see [ADR-0003](0003-posting-journal-architecture.md) reversals); subledger ids copied per line. |
+
+---
+
+## 4. Consequences
+
+- New financial `event_type` values require a registry entry, posting rule implementation, `RecordEvent` (or dedicated command) validation, idempotency fingerprint, tests, and `docs/operational_events/` spec alignment.
+- **Available balance** for authorization uses ledger projection on **2110** lines filtered by `deposit_account_id` minus active **`holds`** ([ADR-0004](0004-account-balance-model.md)); implemented in `Accounts::Services::AvailableBalanceMinorUnits`.
+
+---
+
+## 5. References
+
+- [docs/operational_events/deposit-accepted.md](../operational_events/deposit-accepted.md)
+- [docs/operational_events/withdrawal-posted.md](../operational_events/withdrawal-posted.md)
+- [docs/operational_events/transfer-completed.md](../operational_events/transfer-completed.md)
+- [docs/operational_events/compensating-reversal.md](../operational_events/compensating-reversal.md)

--- a/docs/adr/0013-holds-available-and-servicing-events.md
+++ b/docs/adr/0013-holds-available-and-servicing-events.md
@@ -1,0 +1,19 @@
+# ADR-0013: Holds, available balance, and servicing operational events
+
+**Status:** Accepted  
+**Date:** 2026-04-23  
+**Aligns with:** [ADR-0004](0004-account-balance-model.md), [ADR-0002](0002-operational-event-model.md)
+
+---
+
+## 1. Decision
+
+- **`holds`** table is owned by **`Accounts`**. Active holds reduce **available** balance; they do not post GL journals.
+- **`hold.placed`** / **`hold.released`** are persisted as `operational_events` rows with **`posted`** status at creation (no `PostEvent` path). Commands: **`Accounts::Commands::PlaceHold`** and **`Accounts::Commands::ReleaseHold`**.
+- **Available** for authorization: `Accounts::Services::AvailableBalanceMinorUnits` = ledger on GL **2110** filtered by `journal_lines.deposit_account_id` minus active hold amounts ([ADR-0012](0012-posting-rule-registry-and-journal-subledger.md) subledger).
+
+---
+
+## 2. Consequences
+
+- `withdrawal.posted` and `transfer.completed` **`RecordEvent`** reject when available &lt; amount.

--- a/docs/adr/0014-teller-sessions-and-control-events.md
+++ b/docs/adr/0014-teller-sessions-and-control-events.md
@@ -1,0 +1,19 @@
+# ADR-0014: Teller sessions and control operational events (MVP)
+
+**Status:** Accepted  
+**Date:** 2026-04-23  
+**Aligns with:** [roadmap.md](../roadmap.md) Phase 1, [module catalog](../architecture/bankcore-module-catalog.md)
+
+---
+
+## 1. Decision
+
+- **`teller_sessions`** is owned by **`Teller`**. Lifecycle: **`Teller::Commands::OpenSession`** / **`CloseSession`**. MVP uses **table-first** audit; optional `teller_session.opened` / `closed` operational event rows are **not** required for this slice.
+- **`operational_events.teller_session_id`** optionally links financial events to a session when clients pass it.
+- **`override.requested`** / **`override.approved`** are recorded via **`Core::OperationalEvents::Commands::RecordControlEvent`** (posted immediately, no GL). **`reference_id`** carries the subject (e.g. `teller_session:123`). Variance/supervisor workflow wiring is deferred beyond storing the audit row.
+
+---
+
+## 2. API
+
+Teller JSON routes are listed in [docs/operational_events/README.md](../operational_events/README.md).

--- a/docs/architecture/bankcore-module-catalog.md
+++ b/docs/architecture/bankcore-module-catalog.md
@@ -836,7 +836,8 @@ Each table family should have **one owning domain** even if all tables live in o
 | `operational_events`, `reversal_links`                       | `Core::OperationalEvents` |
 | `posting_batches`, `posting_legs`                            | `Core::Posting`           |
 | `journal_entries`, `journal_lines`, `gl_accounts`            | `Core::Ledger`            |
-| `holds`, `authorization_decisions`                           | `Limits`                  |
+| `holds`                                                      | `Accounts`                |
+| `authorization_decisions`                                    | `Limits`                  |
 | `teller_sessions`, `teller_transactions`                     | `Teller`                  |
 | `cash_locations`, `vault_transfers`, `cash_counts`           | `Cash`                    |
 | `approval_requests`, `approval_decisions`                    | `Workflow`                |

--- a/docs/operational_events/README.md
+++ b/docs/operational_events/README.md
@@ -30,18 +30,20 @@ Copy the structure from any existing file in this folder when adding a new `even
 
 ## Index
 
-| Spec | `event_type` | GL posting |
-| ---- | ------------ | ---------- |
-| [deposit-accepted.md](deposit-accepted.md) | `deposit.accepted` | Yes |
-| [withdrawal-posted.md](withdrawal-posted.md) | `withdrawal.posted` | Yes |
-| [transfer-completed.md](transfer-completed.md) | `transfer.completed` | Yes |
-| [compensating-reversal.md](compensating-reversal.md) | TBD (see spec) | Yes |
-| [hold-placed.md](hold-placed.md) | `hold.placed` | No (typical) |
-| [hold-released.md](hold-released.md) | `hold.released` | No (typical) |
-| [teller-session-opened.md](teller-session-opened.md) | `teller_session.opened` | No |
-| [teller-session-closed.md](teller-session-closed.md) | `teller_session.closed` | No |
-| [override-requested.md](override-requested.md) | `override.requested` | No |
-| [override-approved.md](override-approved.md) | `override.approved` | No |
+| Spec | `event_type` | GL posting | Record command |
+| ---- | ------------ | ---------- | ---------------- |
+| [deposit-accepted.md](deposit-accepted.md) | `deposit.accepted` | Yes | `RecordEvent` |
+| [withdrawal-posted.md](withdrawal-posted.md) | `withdrawal.posted` | Yes | `RecordEvent` |
+| [transfer-completed.md](transfer-completed.md) | `transfer.completed` | Yes | `RecordEvent` |
+| [compensating-reversal.md](compensating-reversal.md) | `posting.reversal` | Yes | `RecordReversal` |
+| [hold-placed.md](hold-placed.md) | `hold.placed` | No | `Accounts::Commands::PlaceHold` |
+| [hold-released.md](hold-released.md) | `hold.released` | No | `Accounts::Commands::ReleaseHold` |
+| [teller-session-opened.md](teller-session-opened.md) | (table-first MVP; OE optional) | No | `Teller::Commands::OpenSession` |
+| [teller-session-closed.md](teller-session-closed.md) | (table-first MVP; OE optional) | No | `Teller::Commands::CloseSession` |
+| [override-requested.md](override-requested.md) | `override.requested` | No | `RecordControlEvent` |
+| [override-approved.md](override-approved.md) | `override.approved` | No | `RecordControlEvent` |
+
+**Teller JSON routes (workspace):** `POST /teller/operational_events`, `POST /teller/operational_events/:id/post`, `POST /teller/reversals`, `POST /teller/holds`, `POST /teller/holds/release`, `POST /teller/teller_sessions`, `POST /teller/teller_sessions/close`, `POST /teller/overrides` (see [config/routes.rb](../../config/routes.rb)).
 
 ## Concept layering
 

--- a/docs/operational_events/README.md
+++ b/docs/operational_events/README.md
@@ -1,0 +1,52 @@
+# Operational event specs
+
+This directory holds **per–`event_type` specifications**: semantics, persistence, posting, idempotency, reversals, and cross-links to ADRs. They are the working source for implementers and tests; [ADR-0002](../adr/0002-operational-event-model.md) remains the cross-cutting model.
+
+## Filename convention
+
+- Files use **kebab-case**: `deposit-accepted.md` documents `event_type` **`deposit.accepted`** (dots in the type string, not in the filename).
+- One primary `event_type` per document. Patterns that span types (e.g. compensating reversal) live in a dedicated spec.
+
+## Spec format (use for every new doc)
+
+Each spec uses the same headings so scans and diffs stay predictable:
+
+| Section | Purpose |
+| ------- | ------- |
+| **Summary** | One short paragraph: what business fact this row records. |
+| **Registry** | Canonical `event_type` string, category (financial / servicing / operational), MVP phase note. |
+| **Semantics** | Preconditions, postconditions, what must never happen. |
+| **Persistence** | Required and optional columns / FKs on `operational_events` (and related tables if this type owns rows elsewhere). |
+| **Lifecycle** | `pending` → `posted` (and any other allowed values); meaning of `posted` for non–GL-backed types. |
+| **Posting** | Whether `PostEvent` runs; GL accounts and legs at a high level; subledger (`deposit_account_id` on lines) if applicable. |
+| **Idempotency** | `(channel, idempotency_key)` rules; which fields participate in the **fingerprint** for mismatch detection. |
+| **Reversals** | Whether this type can be reversed, by what compensating type, supervisor gate if any. |
+| **Relationships** | `teller_session_id`, `source_account_id`, `destination_account_id`, links to `holds`, etc. |
+| **Module ownership** | Which `app/domains/**` module owns validation and commands (per [module catalog](../architecture/bankcore-module-catalog.md)). |
+| **References** | ADRs and related specs. |
+| **Examples** | Minimal JSON or pseudo-payload + posting sketch. |
+
+Copy the structure from any existing file in this folder when adding a new `event_type`, or start from [_template.md](_template.md).
+
+## Index
+
+| Spec | `event_type` | GL posting |
+| ---- | ------------ | ---------- |
+| [deposit-accepted.md](deposit-accepted.md) | `deposit.accepted` | Yes |
+| [withdrawal-posted.md](withdrawal-posted.md) | `withdrawal.posted` | Yes |
+| [transfer-completed.md](transfer-completed.md) | `transfer.completed` | Yes |
+| [compensating-reversal.md](compensating-reversal.md) | TBD (see spec) | Yes |
+| [hold-placed.md](hold-placed.md) | `hold.placed` | No (typical) |
+| [hold-released.md](hold-released.md) | `hold.released` | No (typical) |
+| [teller-session-opened.md](teller-session-opened.md) | `teller_session.opened` | No |
+| [teller-session-closed.md](teller-session-closed.md) | `teller_session.closed` | No |
+| [override-requested.md](override-requested.md) | `override.requested` | No |
+| [override-approved.md](override-approved.md) | `override.approved` | No |
+
+## Concept layering
+
+[Concept 101](../concepts/101-operational_event_enums_concept.md) parent/component vocabulary is **analytical**; it does not replace the `event_type` strings in this folder. Mapping from `event_type` → concept 101 belongs in documentation or a future mapping table, per ADR-0002 §2.2.
+
+## Domain mapping
+
+These specs describe **MVP / Phase 1** branch-teller behavior per [01-mvp-vs-core.md](../concepts/01-mvp-vs-core.md) and [roadmap.md](../roadmap.md). Owning modules are called out in each spec; the financial kernel remains `Core::OperationalEvents`, `Core::Posting`, and `Core::Ledger`.

--- a/docs/operational_events/_template.md
+++ b/docs/operational_events/_template.md
@@ -1,0 +1,58 @@
+# Title (`event_type.string.here`)
+
+> Copy this file to a new kebab-case name (e.g. `fee-assessed.md` for `fee.assessed`). Replace all placeholders. Remove this block quote when done.
+
+## Summary
+
+(One short paragraph.)
+
+## Registry
+
+| Field | Value |
+| ----- | ----- |
+| **`event_type`** | `…` |
+| **Category** | Financial \| Servicing \| Operational |
+| **Phase** | Draft \| Phase 1 \| … |
+
+## Semantics
+
+(Bullets: preconditions, postconditions, must-never rules.)
+
+## Persistence
+
+| Column / concept | Required | Notes |
+| ---------------- | -------- | ----- |
+| `event_type` | Yes | |
+| … | … | |
+
+## Lifecycle
+
+(`pending` → `posted`, or single-step; note meaning for non-GL types.)
+
+## Posting
+
+(Yes/No; if yes, leg sketch and subledger notes.)
+
+## Idempotency
+
+(Scope `(channel, idempotency_key)`; fingerprint fields.)
+
+## Reversals
+
+(GL reversal pattern or N/A; link to [compensating-reversal.md](compensating-reversal.md) if applicable.)
+
+## Relationships
+
+(Sessions, accounts, holds, FKs.)
+
+## Module ownership
+
+(Which `app/domains/**` owns commands.)
+
+## References
+
+- [ADR-0002](../adr/0002-operational-event-model.md)
+
+## Examples
+
+(JSON or narrative.)

--- a/docs/operational_events/compensating-reversal.md
+++ b/docs/operational_events/compensating-reversal.md
@@ -9,13 +9,13 @@ This document is **pattern-first**. The canonical **`event_type`** string for re
 - **Per original type:** e.g. `deposit.accepted.reversal`
 - **Generic:** e.g. `financial_event.reversed` with payload identifying original event id and rule selection
 
-Implementation **must** pick one approach and register it alongside posting rules.
+Implementation uses a **generic** `posting.reversal` plus `Core::OperationalEvents::Commands::RecordReversal`; posting rules mirror the original journal ([ADR-0012](../adr/0012-posting-rule-registry-and-journal-subledger.md)).
 
 ## Registry
 
 | Field | Value |
 | ----- | ----- |
-| **`event_type`** | **TBD** — single chosen string or small family documented in posting registry. |
+| **`event_type`** | **`posting.reversal`** — generic compensating row; original id in **`reversal_of_event_id`**. |
 | **Category** | Financial (produces GL) |
 | **Phase** | Phase 1 (reversal path + linkage + two journals). |
 

--- a/docs/operational_events/compensating-reversal.md
+++ b/docs/operational_events/compensating-reversal.md
@@ -1,0 +1,87 @@
+# Compensating reversal (financial correction)
+
+## Summary
+
+Describes the **pattern** for undoing a **posted financial** operational event **without** mutating the original row. A **new** operational event is recorded, linked to the original via reversal FKs, and `PostEvent` creates a **compensating** journal (mirror debits/credits) per ADR-0002 §6 and ADR-0003 reversal postings.
+
+This document is **pattern-first**. The canonical **`event_type`** string for reversals is an open product decision (see [roadmap §12](../roadmap.md)); options include:
+
+- **Per original type:** e.g. `deposit.accepted.reversal`
+- **Generic:** e.g. `financial_event.reversed` with payload identifying original event id and rule selection
+
+Implementation **must** pick one approach and register it alongside posting rules.
+
+## Registry
+
+| Field | Value |
+| ----- | ----- |
+| **`event_type`** | **TBD** — single chosen string or small family documented in posting registry. |
+| **Category** | Financial (produces GL) |
+| **Phase** | Phase 1 (reversal path + linkage + two journals). |
+
+## Semantics
+
+- **Original** event must already be **`posted`** with a successful journal.
+- Reversal **never** changes `status` on the original row from `posted`.
+- **“Was reversed”** is derived from `reversal_of_event_id` / `reversed_by_event_id` (when columns exist) and/or presence of the compensating posted event (ADR-0002 §3.2, §6).
+- **At most one** business-meaningful compensating reversal per original unless a future ADR explicitly allows partial/multi-step reversals.
+
+## Persistence
+
+**New reversal row:**
+
+| Column / concept | Required | Notes |
+| ---------------- | -------- | ----- |
+| `event_type` | Yes | Chosen reversal type. |
+| `reversal_of_event_id` | Yes | FK → original `operational_events.id`. |
+| `status` | Yes | `pending` → `posted` after compensating journal commits. |
+| `amount_minor_units` | Typically | Matches original reversal magnitude for full reversal MVP. |
+| `currency`, `channel`, `idempotency_key` | Yes | Same idempotency rules as other events. |
+| `source_account_id` / `destination_account_id` | As needed | Often mirror original for posting rule resolution. |
+
+**Original row (updates allowed only for linkage fields, not business mutation):**
+
+| Column | Notes |
+| ------ | ----- |
+| `reversed_by_event_id` | Set to the compensating event id when reversal posts (ADR-0002 §4.4). |
+
+> Journal-level links `reverses_journal_entry_id` / `reversing_journal_entry_id` on `journal_entries` (ADR-0010 §7) should align with the compensating entry; implementation must respect DB immutability triggers on posted journals.
+
+## Lifecycle
+
+1. Record reversal event **`pending`** (after supervisor gate if required).
+2. `PostEvent` writes compensating lines; batch **`posted`**; event **`posted`**.
+3. Original remains **`posted`**; linkage columns record the relationship.
+
+## Posting
+
+- **Yes** — compensating legs are the **mirror** of the original journal for a full reversal (same amounts, debits become credits and vice versa on the same GL / subledger accounts).
+- **Supervisor:** Phase 1 exit criteria may require approval before `RecordEvent` or `PostEvent` for reversals.
+
+## Idempotency
+
+- Reversal submission **must** be idempotent: same `(channel, idempotency_key)` must not create a second posted compensation for the same original.
+
+## Reversals
+
+- A reversal of a reversal is out of scope for MVP unless explicitly specified; normally **chain** stops at one compensating event.
+
+## Relationships
+
+- **`reversal_of_event_id`** → original financial event.
+- Optional: same `teller_session_id` as original for audit.
+
+## Module ownership
+
+- **Record:** `Core::OperationalEvents` (dedicated command recommended: e.g. `RecordReversal`).
+- **Post:** `Core::Posting` with a rule keyed off reversal `event_type` and/or metadata pointing at original.
+
+## References
+
+- [ADR-0002](../adr/0002-operational-event-model.md) §6, §8.1
+- [ADR-0003](../adr/0003-posting-journal-architecture.md) — reversal postings
+- [ADR-0010](../adr/0010-ledger-persistence-and-seeded-coa.md) §7 — journal reversal FKs
+
+## Examples
+
+**Conceptual:** Original `deposit.accepted` posted Dr 1110 / Cr 2110(acct 42). Compensating reversal posts **Dr 2110(acct 42) / Cr 1110** for the same minor units.

--- a/docs/operational_events/deposit-accepted.md
+++ b/docs/operational_events/deposit-accepted.md
@@ -1,0 +1,90 @@
+# Deposit accepted (`deposit.accepted`)
+
+## Summary
+
+Records that the institution **accepted** a cash deposit and intends to **credit** a specific demand deposit account for the stated amount. Posting completes the economic booking (cash asset up, customer liability up).
+
+## Registry
+
+| Field | Value |
+| ----- | ----- |
+| **`event_type`** | `deposit.accepted` |
+| **Category** | Financial (ADR-0002 §5.1) |
+| **Phase** | Implemented (vertical slice 1); fields may extend in Phase 1 (session FK, actor). |
+
+## Semantics
+
+- **Must** reference an **open** `deposit_accounts` row via `source_account_id` (the account being credited).
+- **Must** carry a positive `amount_minor_units` and supported `currency` (MVP: USD).
+- Represents **cash-in** tender only in the current slice; mixed tender (cash + checks) is a future composition pattern (ADR-0002 §3.3).
+
+## Persistence
+
+| Column / concept | Required | Notes |
+| ---------------- | -------- | ----- |
+| `event_type` | Yes | Literal `deposit.accepted`. |
+| `status` | Yes | `pending` until posting succeeds; then `posted`. Never “un-posted” via row mutation. |
+| `business_date` | Yes | From `Core::BusinessDate` when not supplied. |
+| `channel` | Yes | e.g. `teller`; scopes idempotency. |
+| `idempotency_key` | Yes | Opaque client key; unique with `channel`. |
+| `amount_minor_units` | Yes | Positive integer (ADR-0008 minor units). |
+| `currency` | Yes | MVP: `USD`. |
+| `source_account_id` | Yes | FK → `deposit_accounts` (account credited). |
+| `teller_session_id` | Phase 1 | When teller session discipline exists: ties activity to drawer. |
+| `actor_id` | Later | Per ADR-0002 §8.1 column roadmap. |
+
+## Lifecycle
+
+1. **`pending`** — Row inserted by `RecordEvent`; no balanced journal yet (or batch not `posted`).
+2. **`posted`** — `PostEvent` committed: posting batch `posted`, journal exists, event updated in same transaction.
+
+Failed posting leaves the event **`pending`** (ADR-0002 §3.2: do not overload `operational_events.status` with `failed`).
+
+## Posting
+
+- **Runs through** `Core::Posting::Commands::PostEvent` (or equivalent posting rule).
+- **MVP legs (illustrative):** Debit GL **1110** (cash in vaults / drawer); Credit GL **2110** (DDA liability).
+- **Subledger:** Liability line **must** carry customer attribution (e.g. `journal_lines.deposit_account_id` → same as `source_account_id`) once per-account balance is required for Phase 1.
+
+## Idempotency
+
+- **Scope:** `(channel, idempotency_key)` at most one row (ADR-0002 §7.3).
+- **Fingerprint (material fields):** include `event_type`, `channel`, `idempotency_key`, `amount_minor_units`, `currency`, `source_account_id` (extend when new columns are material to replay semantics).
+
+## Reversals
+
+- Original row stays **`posted`** after a reversal (ADR-0002 §6).
+- Correction is a **new** operational event with compensating journal; see [compensating-reversal.md](compensating-reversal.md). Supervisor approval may be required (Phase 1 RBAC).
+
+## Relationships
+
+- **`source_account_id`:** account credited.
+- **`teller_session_id`:** optional until Phase 1; used for drawer / EOD correlation.
+
+## Module ownership
+
+- **Record / validate:** `Core::OperationalEvents` (with `Accounts` invariants for open account).
+- **Post:** `Core::Posting` (posting rules); journal rows `Core::Ledger`.
+
+## References
+
+- [ADR-0002](../adr/0002-operational-event-model.md) — lifecycle, idempotency, reversals.
+- [ADR-0010](../adr/0010-ledger-persistence-and-seeded-coa.md) — tables, GL seed.
+- [ADR-0011](../adr/0011-accounts-deposit-vertical-slice-mvp.md) — slice 1 deposit path.
+
+## Examples
+
+**Record (conceptual JSON):**
+
+```json
+{
+  "event_type": "deposit.accepted",
+  "channel": "teller",
+  "idempotency_key": "idem-2026-04-22-001",
+  "amount_minor_units": 10000,
+  "currency": "USD",
+  "source_account_id": 42
+}
+```
+
+**Posting sketch:** Dr 1110 / Cr 2110 (`deposit_account_id` on Cr line = 42), amount 10_000.

--- a/docs/operational_events/hold-placed.md
+++ b/docs/operational_events/hold-placed.md
@@ -1,0 +1,80 @@
+# Hold placed (`hold.placed`)
+
+## Summary
+
+Records that an **active hold** was applied against a deposit account so **available** balance drops while **ledger** balance (posted journal total) is unchanged (ADR-0004).
+
+## Registry
+
+| Field | Value |
+| ----- | ----- |
+| **`event_type`** | `hold.placed` |
+| **Category** | Servicing (ADR-0002 §5.2) |
+| **Phase** | Phase 1 (spec; `holds` table ownership to confirm in implementation ADR). |
+
+## Semantics
+
+- Reduces **authorization / available** funds; does **not** by itself post GL lines in the typical model.
+- **Must** reference the deposit account and hold amount; hold lifecycle (active → released/expired) lives primarily on the **`holds`** row if present.
+- This operational event row is the **audit anchor** for “why was available reduced?” and can correlate to `source_operational_event_id` on the hold row (implementation choice).
+
+## Persistence
+
+| Column / concept | Required | Notes |
+| ---------------- | -------- | ----- |
+| `event_type` | Yes | `hold.placed`. |
+| `status` | Yes | See **Lifecycle** — define whether `posted` means “hold row committed” or align with a future convention. |
+| `business_date`, `channel`, `idempotency_key` | Yes | If external retries exist. |
+| `amount_minor_units` | Yes | Hold amount. |
+| `currency` | Yes | |
+| `source_account_id` | Yes | Account under hold (deposit account). |
+| **`holds` table** | Recommended | Columns per ADR-0004 §6: account, amount, status, timestamps, reason, optional link to this event id. |
+
+## Lifecycle
+
+**Option A (recommended for clarity):** `hold.placed` moves to **`posted`** when the `holds` row is persisted in **`active`** status in the same transaction as the event row.
+
+**Option B:** Servicing events use only `posted` without `pending` if there is no async step—document in implementation.
+
+**Must not** imply GL posting unless product explicitly adds a GL-backed hold model (out of MVP scope here).
+
+## Posting
+
+- **No** GL journal in the standard ADR-0004 model for holds.
+
+## Idempotency
+
+- Fingerprint includes account, amount, currency, and any fields that distinguish two legitimate distinct holds (e.g. reason code when added).
+
+## Reversals
+
+- **Not** “reversed” by editing this row. Release is **`hold.released`** (or expiry path) which restores available without changing historical `hold.placed` rows.
+
+## Relationships
+
+- **`source_account_id`:** account whose **available** is reduced.
+- Link to **`holds.id`** via FK on hold row pointing to this event, or `reference_id` when column exists.
+
+## Module ownership
+
+- **`holds` table:** commonly **`Accounts`** or **`Core::OperationalEvents`** — pick one owner and document in ADR; commands should stay out of `Teller` for hold math.
+
+## References
+
+- [ADR-0002](../adr/0002-operational-event-model.md) §5.2
+- [ADR-0004](../adr/0004-account-balance-model.md) §5–6
+
+## Examples
+
+```json
+{
+  "event_type": "hold.placed",
+  "channel": "teller",
+  "idempotency_key": "hold-2026-04-22-001",
+  "amount_minor_units": 2000,
+  "currency": "USD",
+  "source_account_id": 42
+}
+```
+
+**Effect sketch:** `holds` row `active` for 2_000 on account 42; available for authorization decreases by 2_000; no new journal lines.

--- a/docs/operational_events/hold-released.md
+++ b/docs/operational_events/hold-released.md
@@ -1,0 +1,73 @@
+# Hold released (`hold.released`)
+
+## Summary
+
+Records that a previously **active** hold against a deposit account was **released** (operator action or policy), restoring **available** balance without changing posted **ledger** balance (ADR-0004).
+
+## Registry
+
+| Field | Value |
+| ----- | ----- |
+| **`event_type`** | `hold.released` |
+| **Category** | Servicing (ADR-0002 §5.2) |
+| **Phase** | Phase 1 (spec). |
+
+## Semantics
+
+- **Must** reference an existing hold (typically by id in payload / `reference_id` when persisted) that was **`active`**.
+- After success, that hold is **`released`** (or equivalent terminal state); available increases by the released amount.
+- Does **not** delete the original `hold.placed` event or hold history row.
+
+## Persistence
+
+| Column / concept | Required | Notes |
+| ---------------- | -------- | ----- |
+| `event_type` | Yes | `hold.released`. |
+| `status` | Yes | `pending` → `posted` when release is durable (Option A) or single-step `posted`. |
+| `channel`, `idempotency_key` | Yes | For retriable APIs. |
+| `source_account_id` | Yes | Account whose hold is released (consistency check vs hold row). |
+| Hold reference | Yes | FK to `holds` or stable identifier in metadata / `reference_id` when column exists. |
+| `amount_minor_units` | Optional | If partial release is supported later; MVP may be full release only (amount implied by hold). |
+
+## Lifecycle
+
+Same servicing pattern as [hold-placed.md](hold-placed.md): no GL posting; **`posted`** means business state committed.
+
+## Posting
+
+- **No** (typical MVP).
+
+## Idempotency
+
+- Fingerprint includes hold identifier and account; replays return same outcome without double-applying release.
+
+## Reversals
+
+- Releasing a hold is not a “reversal” in the ADR-0002 §6 GL sense; do not use compensating journals for standard release.
+
+## Relationships
+
+- **Pairs with** `hold.placed` and the **`holds`** row being updated.
+
+## Module ownership
+
+- Same as holds placement; **`Accounts`** or **`Core::OperationalEvents`** per chosen ADR.
+
+## References
+
+- [ADR-0002](../adr/0002-operational-event-model.md) §5.2
+- [ADR-0004](../adr/0004-account-balance-model.md) §6.4
+
+## Examples
+
+```json
+{
+  "event_type": "hold.released",
+  "channel": "teller",
+  "idempotency_key": "hold-rel-2026-04-22-001",
+  "source_account_id": 42,
+  "hold_id": 9001
+}
+```
+
+**Effect sketch:** Hold 9001 → `released`; available increases accordingly.

--- a/docs/operational_events/override-approved.md
+++ b/docs/operational_events/override-approved.md
@@ -1,0 +1,71 @@
+# Override approved (`override.approved`)
+
+## Summary
+
+Records that a **supervisor** (or role with equivalent authority) **approved** a previously requested exception. Pairs with [`override.requested`](override-requested.md) when both are modeled as operational events; alternatively approval may live only on `teller_sessions` until you need a separate audit row.
+
+## Registry
+
+| Field | Value |
+| ----- | ----- |
+| **`event_type`** | `override.approved` |
+| **Category** | Operational (ADR-0002 §5.3) |
+| **Phase** | Optional Phase 1 (supervisor gates for variance / reversal). |
+
+## Semantics
+
+- **Must** reference the request or target entity: link to `override.requested` event id, or `reference_id` pointing at session / event under approval.
+- **Must** enforce RBAC: approver has **supervisor** (or configured) role; **must not** allow teller to approve their own material variance if policy forbids it.
+- Grants **permission** for downstream commands to proceed (close session with variance, post reversal, etc.); the downstream command still performs the actual state/GL change.
+
+## Persistence
+
+| Column / concept | Required | Notes |
+| ---------------- | -------- | ----- |
+| `event_type` | Yes | `override.approved`. |
+| `status` | Yes | Typically **`posted`** when approval is committed (audit finality). |
+| `channel` | Yes | Often `teller` or `system`. |
+| `idempotency_key` | Yes | |
+| `reference_id` / request link | Yes | What was approved. |
+| `actor_id` | Yes when available | Approving supervisor. |
+
+## Lifecycle
+
+Usually **single-step `posted`** on insert: approval is immediate once validated.
+
+## Posting
+
+- **No.**
+
+## Idempotency
+
+- Same approval request must not yield two distinct effective approvals; use idempotency or unique constraint on `(request_id, approver_id)` if modeled.
+
+## Reversals
+
+- Revoking approval is a separate policy story; not GL reversal.
+
+## Relationships
+
+- **`override.requested`:** logical predecessor when both exist as rows.
+- **Session / reversal commands** consume this as a prerequisite.
+
+## Module ownership
+
+- **`Teller`** / **`Workflow`** with RBAC enforced at application boundary.
+
+## References
+
+- [ADR-0002](../adr/0002-operational-event-model.md) §5.3
+- [roadmap.md](../roadmap.md) — Phase 1 supervisor approval
+
+## Examples
+
+```json
+{
+  "event_type": "override.approved",
+  "channel": "teller",
+  "idempotency_key": "ovr-appr-session-7-supervisor-12",
+  "reference_id": "override_request:900"
+}
+```

--- a/docs/operational_events/override-requested.md
+++ b/docs/operational_events/override-requested.md
@@ -1,0 +1,68 @@
+# Override requested (`override.requested`)
+
+## Summary
+
+Records that an operator **requested** an exception to normal policy (e.g. large cash variance approval, reversal authorization, limit override). This is a **workflow / audit** artifact; it does not by itself post to the GL.
+
+## Registry
+
+| Field | Value |
+| ----- | ----- |
+| **`event_type`** | `override.requested` |
+| **Category** | Operational (ADR-0002 §5.3) |
+| **Phase** | Optional Phase 1; use when you need a durable request row separate from RBAC logs. |
+
+## Semantics
+
+- **Must** identify **what** is being overridden (session close with variance, specific operational event id, hold policy, etc.) via `reference_id` / JSON metadata when those columns exist.
+- **Does not** grant authority by itself; **`override.approved`** (or session-level supervisor fields) represents acceptance.
+
+## Persistence
+
+| Column / concept | Required | Notes |
+| ---------------- | -------- | ----- |
+| `event_type` | Yes | `override.requested`. |
+| `status` | Yes | Often stays **`pending`** until paired approval or **expires** if you add expiry later; alternatively `posted` when request is merely recorded. **Define one vocabulary** for this type. |
+| `channel` | Yes | |
+| `idempotency_key` | Yes | If API-driven. |
+| `reference_id` | Recommended | Target entity (session id, event id, etc.) when column exists. |
+| `actor_id` | Phase 1+ | Requesting operator (ADR-0002 §8.1). |
+
+## Lifecycle
+
+**Recommended:** `pending` until superseded by `override.approved` or rejection; avoid overloading `posted` unless it only means “request recorded.”
+
+## Posting
+
+- **No.**
+
+## Idempotency
+
+- Fingerprint includes override **kind** and **target reference** so the same key cannot request a different override.
+
+## Reversals
+
+- N/A; use explicit cancel/expire event if needed later.
+
+## Relationships
+
+- May reference **`teller_session_id`**, **`operational_events`** (reversal target), etc., via `reference_id` or dedicated FKs when added.
+
+## Module ownership
+
+- **`Teller`** / **`Workflow`** per product choice; keep **financial posting** out of this path.
+
+## References
+
+- [ADR-0002](../adr/0002-operational-event-model.md) §5.3
+
+## Examples
+
+```json
+{
+  "event_type": "override.requested",
+  "channel": "teller",
+  "idempotency_key": "ovr-req-session-7-variance",
+  "reference_id": "teller_session:7"
+}
+```

--- a/docs/operational_events/teller-session-closed.md
+++ b/docs/operational_events/teller-session-closed.md
@@ -1,0 +1,75 @@
+# Teller session closed (`teller_session.closed`)
+
+## Summary
+
+Records that a teller drawer session **closed**: cash counts captured, **expected vs actual** compared, variance computed, and EOD discipline can require **all sessions closed** before branch day is considered complete.
+
+## Registry
+
+| Field | Value |
+| ----- | ----- |
+| **`event_type`** | `teller_session.closed` |
+| **Category** | Operational (ADR-0002 §5.3) |
+| **Phase** | Phase 1 (spec). |
+
+## Semantics
+
+- **Does not** replace the **`teller_sessions`** row state; the session table typically holds `closed_at`, expected/actual cash in minor units, variance.
+- **Material variance** may require **supervisor approval** before the close is accepted (link to `override.approved` or supervisor fields on session—implementation choice).
+- **Cash shortage/over** as an economic correction may later be a **separate financial** `event_type` if posted to GL; keep session **close** as control state, not mixed with adjustment posting unless ADR says otherwise.
+
+## Persistence
+
+| Column / concept | Required | Notes |
+| ---------------- | -------- | ----- |
+| `event_type` | Yes | `teller_session.closed`. |
+| `status` | Yes | Often `posted` when close succeeds; or `pending` while awaiting supervisor for variance. |
+| `business_date` | Yes | |
+| `channel` | Yes | |
+| `idempotency_key` | Recommended | One close per session attempt. |
+| Session reference | Yes | FK to `teller_sessions` (or embed session id in metadata). |
+
+## Lifecycle
+
+- If supervisor required: **`pending`** until approved, then **`posted`**.
+- If no variance gate: **`posted`** immediately with session row updated atomically.
+
+## Posting
+
+- **No** for the close event itself in MVP.
+- **Future:** separate `cash.adjustment` (or similar) **financial** event if variance hits GL.
+
+## Idempotency
+
+- One successful close per session; replays return stable session state.
+
+## Reversals
+
+- Not a GL reversal pattern. Reopening a day may be a new operational story—defer.
+
+## Relationships
+
+- **`teller_sessions`:** authoritative close timestamps and counts.
+- Links from **cash** operational events during the session via `teller_session_id`.
+
+## Module ownership
+
+- **`Teller`** (session close command); optional audit row in `operational_events` under `Core::OperationalEvents`.
+
+## References
+
+- [ADR-0002](../adr/0002-operational-event-model.md) §5.3
+- [roadmap.md](../roadmap.md) — Phase 1 EOD / session closure
+
+## Examples
+
+```json
+{
+  "event_type": "teller_session.closed",
+  "channel": "teller",
+  "idempotency_key": "session-close-7-2026-04-22",
+  "teller_session_id": 7
+}
+```
+
+**Effect sketch:** Session 7 → `closed`, actual vs expected stored; if variance over threshold, supervisor approval recorded before `posted`.

--- a/docs/operational_events/teller-session-opened.md
+++ b/docs/operational_events/teller-session-opened.md
@@ -1,0 +1,73 @@
+# Teller session opened (`teller_session.opened`)
+
+## Summary
+
+Records that a **teller drawer session** (or equivalent cash accountability session) **opened** for business: the starting point for correlating cash-affecting operational events and EOD checks (Phase 1).
+
+## Registry
+
+| Field | Value |
+| ----- | ----- |
+| **`event_type`** | `teller_session.opened` |
+| **Category** | Operational (ADR-0002 §5.3) |
+| **Phase** | Phase 1 (spec; may coexist with `teller_sessions` table as source of truth). |
+
+## Semantics
+
+- **Does not** by itself move customer GL balances in MVP.
+- Establishes **audit evidence** that a session started (who, when, which drawer/branch).
+- **At most one open session** per teller/drawer (or per policy) should be enforced at the database or command layer—not necessarily via opaque `idempotency_key` alone.
+
+## Persistence
+
+| Column / concept | Required | Notes |
+| ---------------- | -------- | ----- |
+| `event_type` | Yes | `teller_session.opened`. |
+| `status` | Yes | Often **`posted`** immediately if there is no async step; or `pending` if tied to supervisor approval (unusual for open). |
+| `business_date` | Yes | |
+| `channel` | Yes | Typically `teller`. |
+| `idempotency_key` | Policy | May be less central than for money events; uniqueness of “open session” may use DB constraint on `teller_sessions`. |
+| `amount_minor_units` | Optional | Opening float could be modeled here or only on `teller_sessions`; if unused, null. |
+| **`teller_sessions` row** | Recommended | Holds `opened_at`, drawer/branch ids, expected counts—see Teller module catalog. |
+
+## Lifecycle
+
+Define explicitly whether this row is always **`posted`** on insert or uses **`pending`**. Prefer **single-step `posted`** when open is synchronous and session table holds detailed state.
+
+## Posting
+
+- **No** GL in MVP for session open itself.
+
+## Idempotency
+
+- Prefer **structural** uniqueness (one open session per drawer) over replaying the same idempotency key for different opens.
+
+## Reversals
+
+- **Not** GL-reversed. Closing a session is a separate event ([teller-session-closed.md](teller-session-closed.md)); erroneous open may be corrected by operational procedure or a future `session.voided` pattern—out of Phase 1 unless specified.
+
+## Relationships
+
+- Money events (`deposit.accepted`, `withdrawal.posted`, …) may carry **`teller_session_id`** pointing at the session opened here.
+
+## Module ownership
+
+- **`Teller`** module: `teller_sessions`, session commands; `Core::OperationalEvents` may only persist the audit row if you dual-write.
+
+## References
+
+- [ADR-0002](../adr/0002-operational-event-model.md) §5.3
+- [bankcore-module-catalog.md](../architecture/bankcore-module-catalog.md) — `Teller`, `Cash`
+
+## Examples
+
+```json
+{
+  "event_type": "teller_session.opened",
+  "channel": "teller",
+  "idempotency_key": "session-open-drawer-3-2026-04-22",
+  "business_date": "2026-04-22"
+}
+```
+
+**Note:** Drawer id, `actor_id`, and branch may live on `teller_sessions` or JSON metadata once columns exist.

--- a/docs/operational_events/transfer-completed.md
+++ b/docs/operational_events/transfer-completed.md
@@ -1,0 +1,84 @@
+# Transfer completed (`transfer.completed`)
+
+## Summary
+
+Records an **internal transfer** of funds between two deposit accounts (same institution, same currency in MVP): liability decreases on the source account and increases on the destination account, with **no** cash GL leg.
+
+## Registry
+
+| Field | Value |
+| ----- | ----- |
+| **`event_type`** | `transfer.completed` |
+| **Category** | Financial (ADR-0002 §5.1) |
+| **Phase** | Phase 1 (spec ahead of implementation). |
+
+## Semantics
+
+- **Both** `source_account_id` and `destination_account_id` **must** be set to **distinct**, **open** deposit accounts.
+- **Same currency** as both accounts (MVP: enforce USD).
+- **Positive** `amount_minor_units`.
+- **Authorization:** Source account **available** balance must cover the amount (ADR-0004).
+- Optional: policy that both accounts belong to the same branch or party—document when introduced.
+
+## Persistence
+
+| Column / concept | Required | Notes |
+| ---------------- | -------- | ----- |
+| `event_type` | Yes | `transfer.completed`. |
+| `status` | Yes | `pending` → `posted`. |
+| `business_date`, `channel`, `idempotency_key` | Yes | |
+| `amount_minor_units`, `currency` | Yes | |
+| `source_account_id` | Yes | From account (debited in economic sense on liability). |
+| `destination_account_id` | Yes | To account (credited). |
+| `teller_session_id` | Optional | May be omitted for internal transfer; policy choice. |
+
+> **`destination_account_id`** on `operational_events` is required for this type once the column exists (ADR-0002 §8.1 roadmap).
+
+## Lifecycle
+
+`pending` → `posted` when posting succeeds; immutability after `posted` per ADR-0002 §6.
+
+## Posting
+
+- **Yes** — one balanced journal entry (single batch).
+- **MVP legs (illustrative):** Debit GL **2110** with subledger **source** account; Credit GL **2110** with subledger **destination** account. **Both** liability lines must carry distinct `deposit_account_id` (or equivalent subledger) so per-customer balances reconcile; posting only to aggregate 2110 without subledger is **not** sufficient for two-party transfers.
+
+## Idempotency
+
+- **Scope:** `(channel, idempotency_key)`.
+- **Fingerprint:** include `event_type`, `channel`, `idempotency_key`, `amount_minor_units`, `currency`, `source_account_id`, `destination_account_id`.
+
+## Reversals
+
+- Compensating reversal event (see [compensating-reversal.md](compensating-reversal.md)); original transfer row remains `posted`.
+
+## Relationships
+
+- Two deposit accounts; no cash account for the simple internal transfer.
+
+## Module ownership
+
+- **Record / validate:** `Core::OperationalEvents` + `Accounts`.
+- **Post:** `Core::Posting` / `Core::Ledger`.
+
+## References
+
+- [ADR-0002](../adr/0002-operational-event-model.md)
+- [ADR-0004](../adr/0004-account-balance-model.md)
+- [ADR-0010](../adr/0010-ledger-persistence-and-seeded-coa.md)
+
+## Examples
+
+```json
+{
+  "event_type": "transfer.completed",
+  "channel": "teller",
+  "idempotency_key": "xfer-2026-04-22-001",
+  "amount_minor_units": 3000,
+  "currency": "USD",
+  "source_account_id": 42,
+  "destination_account_id": 99
+}
+```
+
+**Posting sketch:** Dr 2110 + `deposit_account_id` 42 / Cr 2110 + `deposit_account_id` 99, amount 3_000.

--- a/docs/operational_events/withdrawal-posted.md
+++ b/docs/operational_events/withdrawal-posted.md
@@ -1,0 +1,88 @@
+# Withdrawal posted (`withdrawal.posted`)
+
+## Summary
+
+Records that the institution **disbursed cash** to the customer and **debited** their demand deposit account for the stated amount. This is the inverse economic pattern of `deposit.accepted`: customer liability down, cash on hand down.
+
+> **Naming:** ADR-0002 §5.1 lists `withdrawal.posted`. If the codebase uses an alternate string (e.g. `withdrawal.disbursed`), update this spec and the registry index in [README.md](README.md) in one change set so `event_type`, posting rules, and tests stay aligned.
+
+## Registry
+
+| Field | Value |
+| ----- | ----- |
+| **`event_type`** | `withdrawal.posted` |
+| **Category** | Financial |
+| **Phase** | Phase 1 (spec ahead of implementation). |
+
+## Semantics
+
+- **Must** reference an **open** deposit account via `source_account_id` (the account debited).
+- **Must** carry positive `amount_minor_units` and supported `currency`.
+- **Authorization:** Available balance (ledger minus active holds, per ADR-0004) **must** be at least the withdrawal amount before posting (enforce in `RecordEvent` and/or `PostEvent`).
+- Cash-out path: typically requires an **open teller session** when drawer control is enabled.
+
+## Persistence
+
+| Column / concept | Required | Notes |
+| ---------------- | -------- | ----- |
+| `event_type` | Yes | `withdrawal.posted`. |
+| `status` | Yes | `pending` → `posted`. |
+| `business_date` | Yes | |
+| `channel` | Yes | |
+| `idempotency_key` | Yes | |
+| `amount_minor_units` | Yes | Positive. |
+| `currency` | Yes | MVP: USD. |
+| `source_account_id` | Yes | Account debited. |
+| `teller_session_id` | Recommended | When Phase 1 teller sessions exist. |
+| `destination_account_id` | No | Not used for simple cash withdrawal. |
+
+## Lifecycle
+
+Same pattern as `deposit.accepted`: **`pending`** until posting completes, then **`posted`**. No silent edits after `posted`.
+
+## Posting
+
+- **Yes** — balanced journal.
+- **MVP legs (illustrative):** Debit GL **2110** (DDA liability, tagged with `deposit_account_id` = `source_account_id`); Credit GL **1110** (cash).
+- Amounts mirror the deposit rule with debits/credits swapped vs `deposit.accepted`.
+
+## Idempotency
+
+- **Scope:** `(channel, idempotency_key)`.
+- **Fingerprint:** at minimum `event_type`, `channel`, `idempotency_key`, `amount_minor_units`, `currency`, `source_account_id`; add `teller_session_id` when it becomes material to replay semantics.
+
+## Reversals
+
+- Reversed only via a **new** compensating event linked to the original (see [compensating-reversal.md](compensating-reversal.md)); original stays `posted`.
+
+## Relationships
+
+- **`source_account_id`:** account debited.
+- **`teller_session_id`:** ties cash movement to drawer accountability.
+
+## Module ownership
+
+- **Record / validate:** `Core::OperationalEvents` + `Accounts` (and holds query for available balance).
+- **Post:** `Core::Posting` / `Core::Ledger`.
+
+## References
+
+- [ADR-0002](../adr/0002-operational-event-model.md)
+- [ADR-0004](../adr/0004-account-balance-model.md) — available balance.
+- [ADR-0010](../adr/0010-ledger-persistence-and-seeded-coa.md)
+
+## Examples
+
+```json
+{
+  "event_type": "withdrawal.posted",
+  "channel": "teller",
+  "idempotency_key": "wd-2026-04-22-001",
+  "amount_minor_units": 5000,
+  "currency": "USD",
+  "source_account_id": 42,
+  "teller_session_id": 7
+}
+```
+
+**Posting sketch:** Dr 2110 (acct 42) / Cr 1110, amount 5_000.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -149,7 +149,7 @@ After **1A (posting rules)**, ship **1B (withdrawal)** together with **1C (sessi
 
 ## 12. Open decisions (track in ADRs or short design notes)
 
-- Canonical **`event_type`** strings for each reversal variant vs [ADR-0002](adr/0002-operational-event-model.md) registry.  
+- ~~Canonical **`event_type`** strings for each reversal variant~~ — **`posting.reversal`** + `RecordReversal` ([ADR-0012](adr/0012-posting-rule-registry-and-journal-subledger.md)); see [compensating-reversal.md](operational_events/compensating-reversal.md).  
 - **Module ownership** for drawer cash vs approval workflow.  
 - **Available balance**: compute-on-read vs materialized projection for volume.  
 - How **trial balance** is exposed (internal JSON vs operator report vs both).

--- a/script/development_sample_data.rb
+++ b/script/development_sample_data.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# Populates the development database with sample domain data (party, deposit account,
+# operational events). Run from the app root:
+#
+#   bin/rails runner script/development_sample_data.rb
+#
+# In Docker (development Compose):
+#
+#   docker compose run --rm web bin/rails runner script/development_sample_data.rb
+#
+# Or: bin/dev-seed-sample-data
+
+unless Rails.env.development?
+  warn "development_sample_data.rb is for development only (current RAILS_ENV=#{Rails.env.inspect})."
+  exit 1
+end
+
+BankCore::Seeds::GlCoa.seed!
+
+if Core::BusinessDate::Models::BusinessDateSetting.none?
+  Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.current)
+end
+
+stamp = Time.now.utc.strftime("%Y%m%d-%H%M%S")
+
+party = Party::Commands::CreateParty.call(
+  party_type: "individual",
+  first_name: "Dev",
+  middle_name: "Sample",
+  last_name: "Customer-#{stamp}"
+)
+
+account = Accounts::Commands::OpenAccount.call(party_record_id: party.id)
+
+posted = Core::OperationalEvents::Commands::RecordEvent.call(
+  event_type: "deposit.accepted",
+  channel: "teller",
+  idempotency_key: "dev-seed-#{stamp}-posted",
+  amount_minor_units: 100_00,
+  currency: "USD",
+  source_account_id: account.id
+)
+
+posted_result = Core::Posting::Commands::PostEvent.call(operational_event_id: posted[:event].id)
+
+pending = Core::OperationalEvents::Commands::RecordEvent.call(
+  event_type: "deposit.accepted",
+  channel: "teller",
+  idempotency_key: "dev-seed-#{stamp}-pending",
+  amount_minor_units: 25_00,
+  currency: "USD",
+  source_account_id: account.id
+)
+
+puts <<~SUMMARY
+  Development sample data created.
+
+    party_id:              #{party.id}
+    party_name:            #{party.name}
+    deposit_account_id:    #{account.id}
+    deposit_account_number: #{account.account_number}
+
+    operational_event (posted):   id=#{posted[:event].id}  outcome=#{posted_result[:outcome]}  amount_minor_units=10000
+    operational_event (pending): id=#{pending[:event].id}  status=#{pending[:event].status}  amount_minor_units=2500
+
+  Re-run anytime; each run uses a new idempotency stamp and adds new rows.
+SUMMARY

--- a/test/domains/core/posting/post_event_test.rb
+++ b/test/domains/core/posting/post_event_test.rb
@@ -24,7 +24,9 @@ class CorePostingPostEventTest < ActiveSupport::TestCase
     assert_equal 12_34, lines.sum { |l| l.side == "debit" ? l.amount_minor_units : 0 }
     assert_equal 12_34, lines.sum { |l| l.side == "credit" ? l.amount_minor_units : 0 }
     assert_equal Core::Ledger::Models::GlAccount.find_by!(account_number: "1110").id, lines.find_by(side: "debit").gl_account_id
-    assert_equal Core::Ledger::Models::GlAccount.find_by!(account_number: "2110").id, lines.find_by(side: "credit").gl_account_id
+    credit = lines.find_by(side: "credit")
+    assert_equal Core::Ledger::Models::GlAccount.find_by!(account_number: "2110").id, credit.gl_account_id
+    assert_equal @account.id, credit.deposit_account_id
   end
 
   test "second post is idempotent" do

--- a/test/integration/operational_events_money_flows_test.rb
+++ b/test/integration/operational_events_money_flows_test.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class OperationalEventsMoneyFlowsTest < ActionDispatch::IntegrationTest
+  setup do
+    BankCore::Seeds::GlCoa.seed!
+    Core::BusinessDate::Models::BusinessDateSetting.delete_all
+    Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.new(2026, 4, 22))
+
+    @party_a = Party::Commands::CreateParty.call(party_type: "individual", first_name: "A", last_name: "One")
+    @party_b = Party::Commands::CreateParty.call(party_type: "individual", first_name: "B", last_name: "Two")
+    @account_a = Accounts::Commands::OpenAccount.call(party_record_id: @party_a.id)
+    @account_b = Accounts::Commands::OpenAccount.call(party_record_id: @party_b.id)
+
+    record_and_post_deposit!(@account_a, 50_000, "seed-a-#{SecureRandom.hex(4)}")
+  end
+
+  test "withdrawal posts dr 2110 cr 1110 with subledger" do
+    idem = "wd-#{SecureRandom.hex(6)}"
+    post "/teller/operational_events",
+      params: {
+        operational_event: {
+          event_type: "withdrawal.posted",
+          channel: "teller",
+          idempotency_key: idem,
+          amount_minor_units: 5_000,
+          currency: "USD",
+          source_account_id: @account_a.id
+        }
+      }.to_json,
+      headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :created
+    ev_id = response.parsed_body["id"]
+    post "/teller/operational_events/#{ev_id}/post", headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :created
+
+    ev = Core::OperationalEvents::Models::OperationalEvent.find(ev_id)
+    lines = ev.posting_batches.sole.journal_entries.sole.journal_lines.order(:sequence_no)
+    dr = lines.find_by(side: "debit")
+    cr = lines.find_by(side: "credit")
+    assert_equal @account_a.id, dr.deposit_account_id
+    assert_nil cr.deposit_account_id
+    assert_equal "2110", dr.gl_account.account_number
+    assert_equal "1110", cr.gl_account.account_number
+  end
+
+  test "transfer moves balance between accounts with two 2110 subledgers" do
+    record_and_post_deposit!(@account_b, 20_000, "seed-b-#{SecureRandom.hex(4)}")
+
+    idem = "xfer-#{SecureRandom.hex(6)}"
+    post "/teller/operational_events",
+      params: {
+        operational_event: {
+          event_type: "transfer.completed",
+          channel: "teller",
+          idempotency_key: idem,
+          amount_minor_units: 3_000,
+          currency: "USD",
+          source_account_id: @account_a.id,
+          destination_account_id: @account_b.id
+        }
+      }.to_json,
+      headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :created
+    ev_id = response.parsed_body["id"]
+    post "/teller/operational_events/#{ev_id}/post", headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :created
+
+    ev = Core::OperationalEvents::Models::OperationalEvent.find(ev_id)
+    lines = ev.posting_batches.sole.journal_entries.sole.journal_lines.order(:sequence_no)
+    assert_equal 2, lines.size
+    assert_equal @account_a.id, lines.find_by(side: "debit").deposit_account_id
+    assert_equal @account_b.id, lines.find_by(side: "credit").deposit_account_id
+  end
+
+  test "reversal creates compensating journal and links entries" do
+    idem = "dep-rev-#{SecureRandom.hex(6)}"
+    post "/teller/operational_events",
+      params: {
+        operational_event: {
+          event_type: "deposit.accepted",
+          channel: "teller",
+          idempotency_key: idem,
+          amount_minor_units: 8_000,
+          currency: "USD",
+          source_account_id: @account_a.id
+        }
+      }.to_json,
+      headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :created
+    dep_id = response.parsed_body["id"]
+    post "/teller/operational_events/#{dep_id}/post", headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :created
+
+    post "/teller/reversals",
+      params: {
+        reversal: {
+          original_operational_event_id: dep_id,
+          channel: "teller",
+          idempotency_key: "rev-#{SecureRandom.hex(6)}"
+        }
+      }.to_json,
+      headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :created
+    rev_id = response.parsed_body["id"]
+    post "/teller/operational_events/#{rev_id}/post", headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :created
+
+    dep = Core::OperationalEvents::Models::OperationalEvent.find(dep_id)
+    rev = Core::OperationalEvents::Models::OperationalEvent.find(rev_id)
+    assert_equal rev.id, dep.reversed_by_event_id
+    assert_equal dep.id, rev.reversal_of_event_id
+
+    orig_entry = dep.journal_entries.sole
+    rev_entry = rev.journal_entries.sole
+    assert_equal orig_entry.id, rev_entry.reverses_journal_entry_id
+    assert_equal rev_entry.id, orig_entry.reversing_journal_entry_id
+  end
+
+  test "hold reduces available and withdrawal fails when insufficient" do
+    post "/teller/holds",
+      params: {
+        hold: {
+          deposit_account_id: @account_a.id,
+          amount_minor_units: 49_000,
+          currency: "USD",
+          channel: "teller",
+          idempotency_key: "hold-#{SecureRandom.hex(6)}"
+        }
+      }.to_json,
+      headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :created
+
+    post "/teller/operational_events",
+      params: {
+        operational_event: {
+          event_type: "withdrawal.posted",
+          channel: "teller",
+          idempotency_key: "wd-big-#{SecureRandom.hex(6)}",
+          amount_minor_units: 5_000,
+          currency: "USD",
+          source_account_id: @account_a.id
+        }
+      }.to_json,
+      headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :unprocessable_entity
+    assert_match(/insufficient/i, response.parsed_body["message"].to_s)
+  end
+
+  test "teller session open close and override record" do
+    post "/teller/teller_sessions", params: {}.to_json, headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :created
+    sid = response.parsed_body["id"]
+
+    post "/teller/teller_sessions/close",
+      params: {
+        teller_session_close: {
+          teller_session_id: sid,
+          expected_cash_minor_units: 100,
+          actual_cash_minor_units: 100
+        }
+      }.to_json,
+      headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :success
+
+    post "/teller/overrides",
+      params: {
+        override: {
+          event_type: "override.approved",
+          channel: "teller",
+          idempotency_key: "ovr-#{SecureRandom.hex(6)}",
+          reference_id: "teller_session:#{sid}"
+        }
+      }.to_json,
+      headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :created
+    assert_equal "override.approved", Core::OperationalEvents::Models::OperationalEvent.order(:id).last.event_type
+  end
+
+  private
+
+  def record_and_post_deposit!(account, amount, idem)
+    r = Core::OperationalEvents::Commands::RecordEvent.call(
+      event_type: "deposit.accepted",
+      channel: "teller",
+      idempotency_key: idem,
+      amount_minor_units: amount,
+      currency: "USD",
+      source_account_id: account.id
+    )
+    Core::Posting::Commands::PostEvent.call(operational_event_id: r[:event].id)
+    r[:event]
+  end
+end

--- a/test/integration/slice1_vertical_slice_proof_test.rb
+++ b/test/integration/slice1_vertical_slice_proof_test.rb
@@ -76,6 +76,7 @@ class Slice1VerticalSliceProofTest < ActionDispatch::IntegrationTest
     assert_equal 10_000, debits
     gl_nums = lines.includes(:gl_account).map { |l| l.gl_account.account_number }.sort
     assert_equal %w[1110 2110], gl_nums
+    assert_equal account_id, lines.find_by(side: "credit").deposit_account_id
     assert_equal account_number, account.account_number
   end
 end


### PR DESCRIPTION
## Summary

Implements the `docs/operational_events` plan tracks A–G on one branch: posting rule registry with `journal_lines.deposit_account_id`, `withdrawal.posted` / `transfer.completed`, `posting.reversal` via `RecordReversal`, holds and available balance, teller sessions, and thin override control events.

## Key changes

- **Posting:** `Core::Posting::PostingRules::Registry` + `PostEvent` refactor; `SET CONSTRAINTS ALL DEFERRED` for balanced multi-line inserts; reversal journal link trigger exception (migration `AllowJournalEntryReversalLinkUpdate`).
- **Record paths:** `RecordEvent` extended; `RecordReversal`; `PlaceHold` / `ReleaseHold`; `RecordControlEvent`; `OpenSession` / `CloseSession`.
- **API:** New teller routes for reversals, holds, teller sessions, overrides (see `docs/operational_events/README.md`).
- **Docs:** ADR-0012, 0013, 0014; updates to ADR-0002, ADR-0010, roadmap §12, module catalog (`holds` → Accounts).

## Testing

- `bin/rails test` (36 tests) and `zeitwerk:check` pass in Docker.

## Migrations

Run `db:migrate` / `db:schema:dump` as usual; `db/structure.sql` updated.

Made with [Cursor](https://cursor.com)