### PR TITLE
Phase 1: RBAC foundation (operators, teller auth, ADR-0015)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,10 @@ docker compose run --rm web bin/rubocop -A
 
 - Remote target: **`BankEncore/bankcore-4`** (public). Create/push with `gh` only after you are authenticated (`gh auth login`); do not paste tokens into chat.
 
+## Teller JSON workspace (local / curl)
+
+After `bin/rails db:seed` in **development**, sample **`operators`** rows exist (teller and supervisor). Send **`X-Operator-Id: <id>`** on every `POST /teller/…` request (`Content-Type: application/json`). Use a **supervisor** operator id for **`POST /teller/reversals`** and for **`override.approved`** on **`POST /teller/overrides`**. See [docs/adr/0015-teller-workspace-authentication.md](docs/adr/0015-teller-workspace-authentication.md).
+
 ## Documentation pointers
 
 - **[docs/concepts/01-mvp-vs-core.md](docs/concepts/01-mvp-vs-core.md)** — MVP vs full-system boundaries (“branch safely”).

--- a/app/controllers/concerns/teller/authenticate_operator.rb
+++ b/app/controllers/concerns/teller/authenticate_operator.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Teller
+  module AuthenticateOperator
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :require_operator!
+    end
+
+    private
+
+    def require_operator!
+      return if performed?
+
+      raw = request.headers["X-Operator-Id"].to_s.strip
+      unless raw.match?(/\A\d+\z/)
+        render json: { error: "unauthorized", message: "X-Operator-Id header is required" }, status: :unauthorized
+        return
+      end
+
+      @current_operator = Workspace::Models::Operator.find_by(id: raw.to_i, active: true)
+      return if @current_operator
+
+      render json: { error: "unauthorized", message: "unknown or inactive operator" }, status: :unauthorized
+    end
+
+    def require_supervisor!
+      return if performed?
+      return if current_operator&.supervisor?
+
+      render json: { error: "forbidden", message: "supervisor role required" }, status: :forbidden
+    end
+
+    def current_operator
+      @current_operator
+    end
+  end
+end

--- a/app/controllers/teller/application_controller.rb
+++ b/app/controllers/teller/application_controller.rb
@@ -4,5 +4,6 @@ module Teller
   # Style-A JSON workspace. CSRF is not applied on ActionController::API; protect this
   # surface in production with mutual TLS, network policy, and/or API authentication.
   class ApplicationController < ActionController::API
+    include Teller::AuthenticateOperator
   end
 end

--- a/app/controllers/teller/operational_events_controller.rb
+++ b/app/controllers/teller/operational_events_controller.rb
@@ -25,7 +25,7 @@ module Teller
         attrs.delete(:business_date)
       end
 
-      result = Core::OperationalEvents::Commands::RecordEvent.call(**attrs)
+      result = Core::OperationalEvents::Commands::RecordEvent.call(**attrs, actor_id: current_operator.id)
       status = result[:outcome] == :created ? :created : :ok
       render json: {
         id: result[:event].id,

--- a/app/controllers/teller/overrides_controller.rb
+++ b/app/controllers/teller/overrides_controller.rb
@@ -2,9 +2,11 @@
 
 module Teller
   class OverridesController < ApplicationController
+    before_action :require_supervisor_for_override_approval!, only: [ :create ]
+
     def create
-      attrs = params.require(:override).permit(:event_type, :channel, :idempotency_key, :reference_id, :actor_id, :business_date).to_h.symbolize_keys
-      attrs[:actor_id] = attrs[:actor_id].to_i if attrs[:actor_id].present?
+      attrs = params.require(:override).permit(:event_type, :channel, :idempotency_key, :reference_id, :business_date).to_h.symbolize_keys
+      attrs[:actor_id] = current_operator.id
       if attrs[:business_date].present?
         attrs[:business_date] = Date.iso8601(attrs[:business_date].to_s)
       else
@@ -18,6 +20,15 @@ module Teller
       render json: { error: "invalid_request", message: e.message }, status: :unprocessable_entity
     rescue Core::OperationalEvents::Commands::RecordControlEvent::MismatchedIdempotency => e
       render json: { error: "idempotency_conflict", fingerprint: e.fingerprint }, status: :conflict
+    end
+
+    private
+
+    def require_supervisor_for_override_approval!
+      return if performed?
+      return unless params.dig(:override, :event_type).to_s == "override.approved"
+
+      require_supervisor!
     end
   end
 end

--- a/app/controllers/teller/reversals_controller.rb
+++ b/app/controllers/teller/reversals_controller.rb
@@ -2,6 +2,8 @@
 
 module Teller
   class ReversalsController < ApplicationController
+    before_action :require_supervisor!, only: [ :create ]
+
     def create
       attrs = params.require(:reversal).permit(:original_operational_event_id, :channel, :idempotency_key, :business_date).to_h.symbolize_keys
       attrs[:original_operational_event_id] = attrs[:original_operational_event_id].to_i
@@ -11,7 +13,7 @@ module Teller
         attrs.delete(:business_date)
       end
 
-      result = Core::OperationalEvents::Commands::RecordReversal.call(**attrs)
+      result = Core::OperationalEvents::Commands::RecordReversal.call(**attrs, actor_id: current_operator.id)
       status = result[:outcome] == :created ? :created : :ok
       render json: { id: result[:event].id, outcome: result[:outcome] }, status: status
     rescue Core::OperationalEvents::Commands::RecordReversal::InvalidRequest => e

--- a/app/domains/core/operational_events/commands/record_event.rb
+++ b/app/domains/core/operational_events/commands/record_event.rb
@@ -36,7 +36,8 @@ module Core
           source_account_id:,
           destination_account_id: nil,
           business_date: nil,
-          teller_session_id: nil
+          teller_session_id: nil,
+          actor_id: nil
         )
           validate_channel!(channel)
           validate_event_type!(event_type)
@@ -75,7 +76,8 @@ module Core
                 currency: currency,
                 source_account_id: source_account_id,
                 destination_account_id: destination_account_id,
-                teller_session_id: teller_session_id
+                teller_session_id: teller_session_id,
+                actor_id: actor_id
               )
               { outcome: :created, event: event }
             end

--- a/app/domains/core/operational_events/commands/record_reversal.rb
+++ b/app/domains/core/operational_events/commands/record_reversal.rb
@@ -23,7 +23,7 @@ module Core
 
         REVERSIBLE_TYPES = %w[deposit.accepted withdrawal.posted transfer.completed].freeze
 
-        def self.call(original_operational_event_id:, channel:, idempotency_key:, business_date: nil)
+        def self.call(original_operational_event_id:, channel:, idempotency_key:, business_date: nil, actor_id: nil)
           RecordEvent.validate_channel!(channel)
 
           original = Models::OperationalEvent.find_by(id: original_operational_event_id)
@@ -59,7 +59,8 @@ module Core
                 currency: original.currency,
                 source_account_id: original.source_account_id,
                 destination_account_id: original.destination_account_id,
-                reversal_of_event_id: original.id
+                reversal_of_event_id: original.id,
+                actor_id: actor_id
               )
               { outcome: :created, event: event }
             end

--- a/app/domains/core/operational_events/models/operational_event.rb
+++ b/app/domains/core/operational_events/models/operational_event.rb
@@ -14,6 +14,7 @@ module Core
         belongs_to :reversal_of_event, class_name: "Core::OperationalEvents::Models::OperationalEvent", optional: true
         belongs_to :reversed_by_event, class_name: "Core::OperationalEvents::Models::OperationalEvent", optional: true
         belongs_to :teller_session, class_name: "Teller::Models::TellerSession", optional: true
+        belongs_to :actor, class_name: "Workspace::Models::Operator", foreign_key: :actor_id, optional: true
 
         has_many :posting_batches, class_name: "Core::Posting::Models::PostingBatch", dependent: :restrict_with_exception
         has_many :journal_entries, class_name: "Core::Ledger::Models::JournalEntry", dependent: :restrict_with_exception

--- a/app/domains/workspace.rb
+++ b/app/domains/workspace.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module Workspace
+end

--- a/app/domains/workspace/models/operator.rb
+++ b/app/domains/workspace/models/operator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Models
+    class Operator < ApplicationRecord
+      self.table_name = "operators"
+
+      ROLES = %w[teller supervisor].freeze
+
+      validates :role, presence: true, inclusion: { in: ROLES }
+
+      def teller?
+        role == "teller"
+      end
+
+      def supervisor?
+        role == "supervisor"
+      end
+    end
+  end
+end

--- a/db/migrate/20260424120000_create_operators_and_operational_events_actor_fk.rb
+++ b/db/migrate/20260424120000_create_operators_and_operational_events_actor_fk.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateOperatorsAndOperationalEventsActorFk < ActiveRecord::Migration[8.1]
+  def change
+    create_table :operators do |t|
+      t.string :role, null: false
+      t.string :display_name
+      t.boolean :active, null: false, default: true
+      t.timestamps
+    end
+
+    add_check_constraint :operators, "role IN ('teller', 'supervisor')", name: "operators_role_check"
+
+    add_foreign_key :operational_events, :operators, column: :actor_id, validate: true
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,3 +11,14 @@ BankCore::Seeds::GlCoa.seed!
 if Core::BusinessDate::Models::BusinessDateSetting.none?
   Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.current)
 end
+
+if Rails.env.development?
+  Workspace::Models::Operator.find_or_create_by!(role: "teller") do |op|
+    op.display_name = "Development Teller"
+    op.active = true
+  end
+  Workspace::Models::Operator.find_or_create_by!(role: "supervisor") do |op|
+    op.display_name = "Development Supervisor"
+    op.active = true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -408,6 +408,40 @@ ALTER SEQUENCE public.operational_events_id_seq OWNED BY public.operational_even
 
 
 --
+-- Name: operators; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.operators (
+    id bigint NOT NULL,
+    role character varying NOT NULL,
+    display_name character varying,
+    active boolean DEFAULT true NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    CONSTRAINT operators_role_check CHECK (((role)::text = ANY ((ARRAY['teller'::character varying, 'supervisor'::character varying])::text[])))
+);
+
+
+--
+-- Name: operators_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.operators_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: operators_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.operators_id_seq OWNED BY public.operators.id;
+
+
+--
 -- Name: party_individual_profiles; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -616,6 +650,13 @@ ALTER TABLE ONLY public.operational_events ALTER COLUMN id SET DEFAULT nextval('
 
 
 --
+-- Name: operators id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.operators ALTER COLUMN id SET DEFAULT nextval('public.operators_id_seq'::regclass);
+
+
+--
 -- Name: party_individual_profiles id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -713,6 +754,14 @@ ALTER TABLE ONLY public.journal_lines
 
 ALTER TABLE ONLY public.operational_events
     ADD CONSTRAINT operational_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: operators operators_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.operators
+    ADD CONSTRAINT operators_pkey PRIMARY KEY (id);
 
 
 --
@@ -1034,6 +1083,14 @@ ALTER TABLE ONLY public.journal_lines
 
 
 --
+-- Name: operational_events fk_rails_a650da481b; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.operational_events
+    ADD CONSTRAINT fk_rails_a650da481b FOREIGN KEY (actor_id) REFERENCES public.operators(id);
+
+
+--
 -- Name: deposit_account_parties fk_rails_bf2b31365a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1096,6 +1153,7 @@ ALTER TABLE ONLY public.operational_events
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260424120000'),
 ('20260423120005'),
 ('20260423120004'),
 ('20260423120003'),

--- a/docs/adr/0010-ledger-persistence-and-seeded-coa.md
+++ b/docs/adr/0010-ledger-persistence-and-seeded-coa.md
@@ -75,7 +75,7 @@ Full lifecycle, idempotency scope, status vocabulary, column roadmap, and compos
 | `reversal_of_event_id` / `reversed_by_event_id` | bigint | nullable, self-FK — compensating **`posting.reversal`** linkage (ADR-0002 §6). |
 | `teller_session_id` | bigint | nullable, FK → **`teller_sessions`**. |
 | `reference_id` | string | nullable — control events, external correlation. |
-| `actor_id` | bigint | nullable — operator stub until identity tables land. |
+| `actor_id` | bigint | nullable, FK → **`operators`** — who acted; populated from authenticated operator on teller JSON and similar paths ([ADR-0015](0015-teller-workspace-authentication.md)). |
 | `created_at` / `updated_at` | datetime | |
 
 ---

--- a/docs/adr/0014-teller-sessions-and-control-events.md
+++ b/docs/adr/0014-teller-sessions-and-control-events.md
@@ -16,4 +16,4 @@
 
 ## 2. API
 
-Teller JSON routes are listed in [docs/operational_events/README.md](../operational_events/README.md).
+Teller JSON routes are listed in [docs/operational_events/README.md](../operational_events/README.md). **Authentication and supervisor gates** for the teller workspace (`X-Operator-Id`, reversal / `override.approved`, and future variance approval) are defined in [ADR-0015](0015-teller-workspace-authentication.md).

--- a/docs/adr/0015-teller-workspace-authentication.md
+++ b/docs/adr/0015-teller-workspace-authentication.md
@@ -1,0 +1,23 @@
+# ADR-0015: Teller workspace authentication (operators)
+
+**Status:** Accepted  
+**Date:** 2026-04-24  
+**Aligns with:** [module catalog](../architecture/bankcore-module-catalog.md) §10, [ADR-0014](0014-teller-sessions-and-control-events.md), [ADR-0002](0002-operational-event-model.md)
+
+---
+
+## 1. Decision
+
+- **`operators`** is the canonical **system-wide** table for “who acted?” (teller workspace today; other channels later). It is owned by **`Workspace`** (`Workspace::Models::Operator`). **`Teller`** owns **sessions and drawer state** and may reference operators; it does not own the operator row.
+- **Teller JSON** requests require header **`X-Operator-Id`** with a **numeric** primary key of an **active** operator row. Missing/invalid/unknown/inactive → **401** with JSON `{ "error": "unauthorized", … }`.
+- **Role** (`teller` \| `supervisor`) is read **only from the database** on that row. Clients must **not** send a trusted role header; spoofing is rejected by design.
+- **Supervisor-only HTTP actions** (Phase 1): creating a **`posting.reversal`** operational event via `POST /teller/reversals`, and **`override.approved`** via `POST /teller/overrides`. Other teller actions allow any active operator with either role (supervisors may perform teller duties).
+- **`operational_events.actor_id`** references **`operators.id`** (FK). Controllers pass **`current_operator.id`** into **`RecordEvent`**, **`RecordReversal`**, and **`RecordControlEvent`** where applicable.
+- **Production** trust boundary: mutual TLS, network policy, and/or future OAuth/JWT remain out of scope for this ADR; the MVP contract is explicit headers plus DB-backed identity.
+
+---
+
+## 2. Consequences
+
+- Development seeds create sample teller and supervisor operators (`db/seeds.rb` when `Rails.env.development?`).
+- Integration tests must send **`X-Operator-Id`** on all teller workspace requests.

--- a/docs/architecture/bankcore-module-catalog.md
+++ b/docs/architecture/bankcore-module-catalog.md
@@ -838,6 +838,7 @@ Each table family should have **one owning domain** even if all tables live in o
 | `journal_entries`, `journal_lines`, `gl_accounts`            | `Core::Ledger`            |
 | `holds`                                                      | `Accounts`                |
 | `authorization_decisions`                                    | `Limits`                  |
+| `operators`                                                  | `Workspace`               |
 | `teller_sessions`, `teller_transactions`                     | `Teller`                  |
 | `cash_locations`, `vault_transfers`, `cash_counts`           | `Cash`                    |
 | `approval_requests`, `approval_decisions`                    | `Workflow`                |

--- a/docs/operational_events/README.md
+++ b/docs/operational_events/README.md
@@ -45,6 +45,8 @@ Copy the structure from any existing file in this folder when adding a new `even
 
 **Teller JSON routes (workspace):** `POST /teller/operational_events`, `POST /teller/operational_events/:id/post`, `POST /teller/reversals`, `POST /teller/holds`, `POST /teller/holds/release`, `POST /teller/teller_sessions`, `POST /teller/teller_sessions/close`, `POST /teller/overrides` (see [config/routes.rb](../../config/routes.rb)).
 
+**Request identity:** every teller JSON request must include header **`X-Operator-Id`** with the id of an active row in **`operators`** (see [ADR-0015](../adr/0015-teller-workspace-authentication.md)). **`POST /teller/reversals`** and **`override.approved`** on `POST /teller/overrides` require a **supervisor** operator; role is enforced from the database, not from client-supplied role headers.
+
 ## Concept layering
 
 [Concept 101](../concepts/101-operational_event_enums_concept.md) parent/component vocabulary is **analytical**; it does not replace the `event_type` strings in this folder. Mapping from `event_type` → concept 101 belongs in documentation or a future mapping table, per ADR-0002 §2.2.

--- a/docs/operational_events/compensating-reversal.md
+++ b/docs/operational_events/compensating-reversal.md
@@ -38,6 +38,7 @@ Implementation uses a **generic** `posting.reversal` plus `Core::OperationalEven
 | `amount_minor_units` | Typically | Matches original reversal magnitude for full reversal MVP. |
 | `currency`, `channel`, `idempotency_key` | Yes | Same idempotency rules as other events. |
 | `source_account_id` / `destination_account_id` | As needed | Often mirror original for posting rule resolution. |
+| `actor_id` | Optional | Nullable FK → **`operators`**. On **`POST /teller/reversals`**, set from **`X-Operator-Id`**; HTTP requires **supervisor** ([ADR-0015](../adr/0015-teller-workspace-authentication.md)). |
 
 **Original row (updates allowed only for linkage fields, not business mutation):**
 
@@ -49,14 +50,14 @@ Implementation uses a **generic** `posting.reversal` plus `Core::OperationalEven
 
 ## Lifecycle
 
-1. Record reversal event **`pending`** (after supervisor gate if required).
+1. Record reversal event **`pending`** (teller JSON: **supervisor** gate before `RecordReversal`; see [ADR-0015](../adr/0015-teller-workspace-authentication.md)).
 2. `PostEvent` writes compensating lines; batch **`posted`**; event **`posted`**.
 3. Original remains **`posted`**; linkage columns record the relationship.
 
 ## Posting
 
 - **Yes** — compensating legs are the **mirror** of the original journal for a full reversal (same amounts, debits become credits and vice versa on the same GL / subledger accounts).
-- **Supervisor:** Phase 1 exit criteria may require approval before `RecordEvent` or `PostEvent` for reversals.
+- **Supervisor:** Teller workspace enforces supervisor before recording the reversal event ([ADR-0015](../adr/0015-teller-workspace-authentication.md)); command layer does not re-check for MVP.
 
 ## Idempotency
 
@@ -81,6 +82,7 @@ Implementation uses a **generic** `posting.reversal` plus `Core::OperationalEven
 - [ADR-0002](../adr/0002-operational-event-model.md) §6, §8.1
 - [ADR-0003](../adr/0003-posting-journal-architecture.md) — reversal postings
 - [ADR-0010](../adr/0010-ledger-persistence-and-seeded-coa.md) §7 — journal reversal FKs
+- [ADR-0015](../adr/0015-teller-workspace-authentication.md) — teller `X-Operator-Id`, supervisor gate on reversals
 
 ## Examples
 

--- a/docs/operational_events/deposit-accepted.md
+++ b/docs/operational_events/deposit-accepted.md
@@ -10,7 +10,7 @@ Records that the institution **accepted** a cash deposit and intends to **credit
 | ----- | ----- |
 | **`event_type`** | `deposit.accepted` |
 | **Category** | Financial (ADR-0002 §5.1) |
-| **Phase** | Implemented (vertical slice 1); fields may extend in Phase 1 (session FK, actor). |
+| **Phase** | Implemented (vertical slice 1); Phase 1 may add `teller_session_id` discipline. **`actor_id`** populated on teller JSON per [ADR-0015](../adr/0015-teller-workspace-authentication.md). |
 
 ## Semantics
 
@@ -31,7 +31,7 @@ Records that the institution **accepted** a cash deposit and intends to **credit
 | `currency` | Yes | MVP: `USD`. |
 | `source_account_id` | Yes | FK → `deposit_accounts` (account credited). |
 | `teller_session_id` | Phase 1 | When teller session discipline exists: ties activity to drawer. |
-| `actor_id` | Later | Per ADR-0002 §8.1 column roadmap. |
+| `actor_id` | Optional | Nullable FK → **`operators`**. On **`POST /teller/operational_events`**, set from **`X-Operator-Id`** when present ([ADR-0015](../adr/0015-teller-workspace-authentication.md)); other channels may omit until they authenticate. |
 
 ## Lifecycle
 
@@ -71,6 +71,7 @@ Failed posting leaves the event **`pending`** (ADR-0002 §3.2: do not overload `
 - [ADR-0002](../adr/0002-operational-event-model.md) — lifecycle, idempotency, reversals.
 - [ADR-0010](../adr/0010-ledger-persistence-and-seeded-coa.md) — tables, GL seed.
 - [ADR-0011](../adr/0011-accounts-deposit-vertical-slice-mvp.md) — slice 1 deposit path.
+- [ADR-0015](../adr/0015-teller-workspace-authentication.md) — teller JSON `X-Operator-Id`, `actor_id` → `operators`.
 
 ## Examples
 

--- a/docs/operational_events/override-approved.md
+++ b/docs/operational_events/override-approved.md
@@ -27,7 +27,7 @@ Records that a **supervisor** (or role with equivalent authority) **approved** a
 | `channel` | Yes | Often `teller` or `system`. |
 | `idempotency_key` | Yes | |
 | `reference_id` / request link | Yes | What was approved. |
-| `actor_id` | Yes when available | Approving supervisor. |
+| `actor_id` | Yes (teller workspace) | Approving supervisor: FK → **`operators`**; HTTP **requires** supervisor role; value is server-derived from **`X-Operator-Id`**, not client body ([ADR-0015](../adr/0015-teller-workspace-authentication.md)). |
 
 ## Lifecycle
 
@@ -57,6 +57,7 @@ Usually **single-step `posted`** on insert: approval is immediate once validated
 ## References
 
 - [ADR-0002](../adr/0002-operational-event-model.md) §5.3
+- [ADR-0015](../adr/0015-teller-workspace-authentication.md) — teller headers and supervisor-only approval
 - [roadmap.md](../roadmap.md) — Phase 1 supervisor approval
 
 ## Examples

--- a/docs/operational_events/override-requested.md
+++ b/docs/operational_events/override-requested.md
@@ -26,7 +26,7 @@ Records that an operator **requested** an exception to normal policy (e.g. large
 | `channel` | Yes | |
 | `idempotency_key` | Yes | If API-driven. |
 | `reference_id` | Recommended | Target entity (session id, event id, etc.) when column exists. |
-| `actor_id` | Phase 1+ | Requesting operator (ADR-0002 §8.1). |
+| `actor_id` | Recommended | Requesting operator: FK → **`operators`**, set from authenticated operator on teller **`POST /teller/overrides`** ([ADR-0015](../adr/0015-teller-workspace-authentication.md)). |
 
 ## Lifecycle
 
@@ -55,6 +55,7 @@ Records that an operator **requested** an exception to normal policy (e.g. large
 ## References
 
 - [ADR-0002](../adr/0002-operational-event-model.md) §5.3
+- [ADR-0015](../adr/0015-teller-workspace-authentication.md) — teller headers and `actor_id`
 
 ## Examples
 

--- a/docs/operational_events/teller-session-opened.md
+++ b/docs/operational_events/teller-session-opened.md
@@ -70,4 +70,4 @@ Define explicitly whether this row is always **`posted`** on insert or uses **`p
 }
 ```
 
-**Note:** Drawer id, `actor_id`, and branch may live on `teller_sessions` or JSON metadata once columns exist.
+**Note:** Drawer id and branch may live on `teller_sessions` or JSON metadata once columns exist. **Who opened the session** may later reference **`operators.id`** (same table as `operational_events.actor_id` per [ADR-0015](../adr/0015-teller-workspace-authentication.md)); table-first MVP may omit a dedicated OE row.

--- a/docs/operational_events/transfer-completed.md
+++ b/docs/operational_events/transfer-completed.md
@@ -31,6 +31,7 @@ Records an **internal transfer** of funds between two deposit accounts (same ins
 | `source_account_id` | Yes | From account (debited in economic sense on liability). |
 | `destination_account_id` | Yes | To account (credited). |
 | `teller_session_id` | Optional | May be omitted for internal transfer; policy choice. |
+| `actor_id` | Optional | Nullable FK → **`operators`**. On teller JSON, set from **`X-Operator-Id`** ([ADR-0015](../adr/0015-teller-workspace-authentication.md)). |
 
 > **`destination_account_id`** on `operational_events` is required for this type once the column exists (ADR-0002 §8.1 roadmap).
 
@@ -66,6 +67,7 @@ Records an **internal transfer** of funds between two deposit accounts (same ins
 - [ADR-0002](../adr/0002-operational-event-model.md)
 - [ADR-0004](../adr/0004-account-balance-model.md)
 - [ADR-0010](../adr/0010-ledger-persistence-and-seeded-coa.md)
+- [ADR-0015](../adr/0015-teller-workspace-authentication.md) — teller `X-Operator-Id`, `actor_id`
 
 ## Examples
 

--- a/docs/operational_events/withdrawal-posted.md
+++ b/docs/operational_events/withdrawal-posted.md
@@ -35,6 +35,7 @@ Records that the institution **disbursed cash** to the customer and **debited** 
 | `source_account_id` | Yes | Account debited. |
 | `teller_session_id` | Recommended | When Phase 1 teller sessions exist. |
 | `destination_account_id` | No | Not used for simple cash withdrawal. |
+| `actor_id` | Optional | Nullable FK → **`operators`**. On teller JSON, set from **`X-Operator-Id`** ([ADR-0015](../adr/0015-teller-workspace-authentication.md)). |
 
 ## Lifecycle
 
@@ -70,6 +71,7 @@ Same pattern as `deposit.accepted`: **`pending`** until posting completes, then 
 - [ADR-0002](../adr/0002-operational-event-model.md)
 - [ADR-0004](../adr/0004-account-balance-model.md) — available balance.
 - [ADR-0010](../adr/0010-ledger-persistence-and-seeded-coa.md)
+- [ADR-0015](../adr/0015-teller-workspace-authentication.md) — teller `X-Operator-Id`, `actor_id`
 
 ## Examples
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 # BankCORE development roadmap
 
 **Status:** Draft  
-**Last reviewed:** 2026-04-22  
+**Last reviewed:** 2026-04-24  
 
 This document **sequences** engineering work. It does **not** redefine scope: MVP boundaries stay in [docs/concepts/01-mvp-vs-core.md](concepts/01-mvp-vs-core.md); boundaries and ownership stay in [docs/architecture/bankcore-module-catalog.md](architecture/bankcore-module-catalog.md) and the ADRs under [docs/adr/](adr/).
 
@@ -64,7 +64,7 @@ Verified by [`test/integration/slice1_vertical_slice_proof_test.rb`](../test/int
 - End-to-end reversals (including `reversal_of_event_id` / `reversed_by_event_id` per [ADR-0002 §4 / column roadmap](adr/0002-operational-event-model.md))  
 - Available balance and holds ([ADR-0004](adr/0004-account-balance-model.md))  
 - Trial balance visibility and EOD reconciliation discipline  
-- Teller vs supervisor roles and approval paths  
+- Teller vs supervisor roles and approval paths — **partial:** teller workspace identity + supervisor gates for reversal and `override.approved` ([ADR-0015](adr/0015-teller-workspace-authentication.md)); variance approval workflow, EOD gates, and finer-grained RBAC still to align with product.  
 - Joint and multi-party accounts (deferred in ADR-0011; listed under MVP in the concept doc for the **full** institution MVP)
 
 ---
@@ -92,7 +92,7 @@ Verified by [`test/integration/slice1_vertical_slice_proof_test.rb`](../test/int
 | **1D** | **Reversals** | Implement reversal FKs from [ADR-0002](adr/0002-operational-event-model.md) column roadmap; compensating journals only; original event stays `posted`. |
 | **1E** | **Minimum balance model** | `holds` + derived or persisted **available** for authorization: `available = ledger - holds` ([ADR-0004](adr/0004-account-balance-model.md)). |
 | **1F** | **Trial balance + EOD gates** | Read model or report: GL trial balance; branch checks (sessions closed, books balanced). |
-| **1G** | **RBAC** | Actor on events; roles **teller** / **supervisor**; approvals for reversal, override, variance. |
+| **1G** | **RBAC** | Actor on events; roles **teller** / **supervisor**; approvals for reversal, override, variance. **Foundation shipped:** **`operators`** table, teller JSON **`X-Operator-Id`**, supervisor HTTP gates on **`POST /teller/reversals`** and **`override.approved`** ([ADR-0015](adr/0015-teller-workspace-authentication.md)). Variance / EOD / richer policy layers remain as needed. |
 
 ### 6.2 Phase 1 exit criteria
 
@@ -165,3 +165,4 @@ After **1A (posting rules)**, ship **1B (withdrawal)** together with **1C (sessi
 | [bankcore-module-catalog.md](architecture/bankcore-module-catalog.md) | Monolith boundaries |
 | [101-operational_event_enums_concept.md](concepts/101-operational_event_enums_concept.md) | Longer-term parent/component event modeling ideas |
 | [AGENTS.md](../AGENTS.md) | Stack, Docker, Cursor rules index |
+| [ADR-0015](adr/0015-teller-workspace-authentication.md) | Teller workspace `operators`, `X-Operator-Id`, supervisor gates |

--- a/test/integration/operational_events_money_flows_test.rb
+++ b/test/integration/operational_events_money_flows_test.rb
@@ -13,7 +13,26 @@ class OperationalEventsMoneyFlowsTest < ActionDispatch::IntegrationTest
     @account_a = Accounts::Commands::OpenAccount.call(party_record_id: @party_a.id)
     @account_b = Accounts::Commands::OpenAccount.call(party_record_id: @party_b.id)
 
+    @teller_operator, @supervisor_operator = create_workspace_operators!
+
     record_and_post_deposit!(@account_a, 50_000, "seed-a-#{SecureRandom.hex(4)}")
+  end
+
+  test "missing X-Operator-Id returns unauthorized for teller JSON" do
+    post "/teller/operational_events",
+      params: {
+        operational_event: {
+          event_type: "withdrawal.posted",
+          channel: "teller",
+          idempotency_key: "wd-no-op-#{SecureRandom.hex(4)}",
+          amount_minor_units: 100,
+          currency: "USD",
+          source_account_id: @account_a.id
+        }
+      }.to_json,
+      headers: { "CONTENT_TYPE" => "application/json" }
+    assert_response :unauthorized
+    assert_equal "unauthorized", response.parsed_body["error"]
   end
 
   test "withdrawal posts dr 2110 cr 1110 with subledger" do
@@ -29,13 +48,16 @@ class OperationalEventsMoneyFlowsTest < ActionDispatch::IntegrationTest
           source_account_id: @account_a.id
         }
       }.to_json,
-      headers: { "CONTENT_TYPE" => "application/json" }
+      headers: teller_json_headers(@teller_operator)
     assert_response :created
     ev_id = response.parsed_body["id"]
-    post "/teller/operational_events/#{ev_id}/post", headers: { "CONTENT_TYPE" => "application/json" }
+    ev = Core::OperationalEvents::Models::OperationalEvent.find(ev_id)
+    assert_equal @teller_operator.id, ev.actor_id
+
+    post "/teller/operational_events/#{ev_id}/post", headers: teller_json_headers(@teller_operator)
     assert_response :created
 
-    ev = Core::OperationalEvents::Models::OperationalEvent.find(ev_id)
+    ev.reload
     lines = ev.posting_batches.sole.journal_entries.sole.journal_lines.order(:sequence_no)
     dr = lines.find_by(side: "debit")
     cr = lines.find_by(side: "credit")
@@ -61,10 +83,10 @@ class OperationalEventsMoneyFlowsTest < ActionDispatch::IntegrationTest
           destination_account_id: @account_b.id
         }
       }.to_json,
-      headers: { "CONTENT_TYPE" => "application/json" }
+      headers: teller_json_headers(@teller_operator)
     assert_response :created
     ev_id = response.parsed_body["id"]
-    post "/teller/operational_events/#{ev_id}/post", headers: { "CONTENT_TYPE" => "application/json" }
+    post "/teller/operational_events/#{ev_id}/post", headers: teller_json_headers(@teller_operator)
     assert_response :created
 
     ev = Core::OperationalEvents::Models::OperationalEvent.find(ev_id)
@@ -74,7 +96,39 @@ class OperationalEventsMoneyFlowsTest < ActionDispatch::IntegrationTest
     assert_equal @account_b.id, lines.find_by(side: "credit").deposit_account_id
   end
 
-  test "reversal creates compensating journal and links entries" do
+  test "reversal returns forbidden for teller operator" do
+    idem = "dep-rev-teller-#{SecureRandom.hex(6)}"
+    post "/teller/operational_events",
+      params: {
+        operational_event: {
+          event_type: "deposit.accepted",
+          channel: "teller",
+          idempotency_key: idem,
+          amount_minor_units: 8_000,
+          currency: "USD",
+          source_account_id: @account_a.id
+        }
+      }.to_json,
+      headers: teller_json_headers(@teller_operator)
+    assert_response :created
+    dep_id = response.parsed_body["id"]
+    post "/teller/operational_events/#{dep_id}/post", headers: teller_json_headers(@teller_operator)
+    assert_response :created
+
+    post "/teller/reversals",
+      params: {
+        reversal: {
+          original_operational_event_id: dep_id,
+          channel: "teller",
+          idempotency_key: "rev-#{SecureRandom.hex(6)}"
+        }
+      }.to_json,
+      headers: teller_json_headers(@teller_operator)
+    assert_response :forbidden
+    assert_equal "forbidden", response.parsed_body["error"]
+  end
+
+  test "reversal creates compensating journal and links entries for supervisor" do
     idem = "dep-rev-#{SecureRandom.hex(6)}"
     post "/teller/operational_events",
       params: {
@@ -87,10 +141,10 @@ class OperationalEventsMoneyFlowsTest < ActionDispatch::IntegrationTest
           source_account_id: @account_a.id
         }
       }.to_json,
-      headers: { "CONTENT_TYPE" => "application/json" }
+      headers: teller_json_headers(@teller_operator)
     assert_response :created
     dep_id = response.parsed_body["id"]
-    post "/teller/operational_events/#{dep_id}/post", headers: { "CONTENT_TYPE" => "application/json" }
+    post "/teller/operational_events/#{dep_id}/post", headers: teller_json_headers(@teller_operator)
     assert_response :created
 
     post "/teller/reversals",
@@ -101,10 +155,13 @@ class OperationalEventsMoneyFlowsTest < ActionDispatch::IntegrationTest
           idempotency_key: "rev-#{SecureRandom.hex(6)}"
         }
       }.to_json,
-      headers: { "CONTENT_TYPE" => "application/json" }
+      headers: teller_json_headers(@supervisor_operator)
     assert_response :created
     rev_id = response.parsed_body["id"]
-    post "/teller/operational_events/#{rev_id}/post", headers: { "CONTENT_TYPE" => "application/json" }
+    assert_equal @supervisor_operator.id,
+      Core::OperationalEvents::Models::OperationalEvent.find(rev_id).actor_id
+
+    post "/teller/operational_events/#{rev_id}/post", headers: teller_json_headers(@supervisor_operator)
     assert_response :created
 
     dep = Core::OperationalEvents::Models::OperationalEvent.find(dep_id)
@@ -129,7 +186,7 @@ class OperationalEventsMoneyFlowsTest < ActionDispatch::IntegrationTest
           idempotency_key: "hold-#{SecureRandom.hex(6)}"
         }
       }.to_json,
-      headers: { "CONTENT_TYPE" => "application/json" }
+      headers: teller_json_headers(@teller_operator)
     assert_response :created
 
     post "/teller/operational_events",
@@ -143,13 +200,13 @@ class OperationalEventsMoneyFlowsTest < ActionDispatch::IntegrationTest
           source_account_id: @account_a.id
         }
       }.to_json,
-      headers: { "CONTENT_TYPE" => "application/json" }
+      headers: teller_json_headers(@teller_operator)
     assert_response :unprocessable_entity
     assert_match(/insufficient/i, response.parsed_body["message"].to_s)
   end
 
-  test "teller session open close and override record" do
-    post "/teller/teller_sessions", params: {}.to_json, headers: { "CONTENT_TYPE" => "application/json" }
+  test "teller session open close override requested teller override approved supervisor" do
+    post "/teller/teller_sessions", params: {}.to_json, headers: teller_json_headers(@teller_operator)
     assert_response :created
     sid = response.parsed_body["id"]
 
@@ -161,21 +218,48 @@ class OperationalEventsMoneyFlowsTest < ActionDispatch::IntegrationTest
           actual_cash_minor_units: 100
         }
       }.to_json,
-      headers: { "CONTENT_TYPE" => "application/json" }
+      headers: teller_json_headers(@teller_operator)
     assert_response :success
+
+    post "/teller/overrides",
+      params: {
+        override: {
+          event_type: "override.requested",
+          channel: "teller",
+          idempotency_key: "ovr-req-#{SecureRandom.hex(6)}",
+          reference_id: "teller_session:#{sid}"
+        }
+      }.to_json,
+      headers: teller_json_headers(@teller_operator)
+    assert_response :created
+    assert_equal "override.requested", Core::OperationalEvents::Models::OperationalEvent.order(:id).last.event_type
 
     post "/teller/overrides",
       params: {
         override: {
           event_type: "override.approved",
           channel: "teller",
-          idempotency_key: "ovr-#{SecureRandom.hex(6)}",
+          idempotency_key: "ovr-app-teller-#{SecureRandom.hex(6)}",
           reference_id: "teller_session:#{sid}"
         }
       }.to_json,
-      headers: { "CONTENT_TYPE" => "application/json" }
+      headers: teller_json_headers(@teller_operator)
+    assert_response :forbidden
+
+    post "/teller/overrides",
+      params: {
+        override: {
+          event_type: "override.approved",
+          channel: "teller",
+          idempotency_key: "ovr-app-sup-#{SecureRandom.hex(6)}",
+          reference_id: "teller_session:#{sid}"
+        }
+      }.to_json,
+      headers: teller_json_headers(@supervisor_operator)
     assert_response :created
-    assert_equal "override.approved", Core::OperationalEvents::Models::OperationalEvent.order(:id).last.event_type
+    last = Core::OperationalEvents::Models::OperationalEvent.order(:id).last
+    assert_equal "override.approved", last.event_type
+    assert_equal @supervisor_operator.id, last.actor_id
   end
 
   private

--- a/test/integration/slice1_vertical_slice_proof_test.rb
+++ b/test/integration/slice1_vertical_slice_proof_test.rb
@@ -8,6 +8,9 @@ class Slice1VerticalSliceProofTest < ActionDispatch::IntegrationTest
     Core::BusinessDate::Models::BusinessDateSetting.delete_all
     Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.new(2026, 4, 21))
 
+    teller_operator, = create_workspace_operators!
+    auth = teller_json_headers(teller_operator)
+
     post "/teller/parties",
       params: {
         party_type: "individual",
@@ -16,7 +19,7 @@ class Slice1VerticalSliceProofTest < ActionDispatch::IntegrationTest
         last_name: "Customer",
         name_suffix: "Sr."
       }.to_json,
-      headers: { "CONTENT_TYPE" => "application/json" }
+      headers: auth
     assert_response :created
     party_json = response.parsed_body
     party_id = party_json["id"]
@@ -24,7 +27,7 @@ class Slice1VerticalSliceProofTest < ActionDispatch::IntegrationTest
 
     post "/teller/deposit_accounts",
       params: { deposit_account: { party_record_id: party_id } }.to_json,
-      headers: { "CONTENT_TYPE" => "application/json" }
+      headers: auth
     assert_response :created
     account_id = response.parsed_body["id"]
     account_number = response.parsed_body["account_number"]
@@ -50,18 +53,19 @@ class Slice1VerticalSliceProofTest < ActionDispatch::IntegrationTest
           source_account_id: account_id
         }
       }.to_json,
-      headers: { "CONTENT_TYPE" => "application/json" }
+      headers: auth
     assert_response :created
     event_id = response.parsed_body["id"]
 
     event = Core::OperationalEvents::Models::OperationalEvent.find(event_id)
+    assert_equal teller_operator.id, event.actor_id
     assert_equal "pending", event.status
     assert_equal "teller", event.channel
     assert_equal idem, event.idempotency_key
     assert_equal account_id, event.source_account_id
     assert_equal account.id, event.source_account.id
 
-    post "/teller/operational_events/#{event_id}/post", headers: { "CONTENT_TYPE" => "application/json" }
+    post "/teller/operational_events/#{event_id}/post", headers: auth
     assert_response :created
 
     event.reload

--- a/test/integration/teller/teller_requests_test.rb
+++ b/test/integration/teller/teller_requests_test.rb
@@ -7,18 +7,19 @@ class TellerRequestsTest < ActionDispatch::IntegrationTest
     BankCore::Seeds::GlCoa.seed!
     Core::BusinessDate::Models::BusinessDateSetting.delete_all
     Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.new(2026, 4, 22))
+    @teller_operator, = create_workspace_operators!
   end
 
   test "party and deposit account happy path" do
     post "/teller/parties",
       params: { party_type: "individual", first_name: "Sam", last_name: "Rivera" }.to_json,
-      headers: { "CONTENT_TYPE" => "application/json" }
+      headers: teller_json_headers(@teller_operator)
     assert_response :created
     party_id = response.parsed_body["id"]
 
     post "/teller/deposit_accounts",
       params: { deposit_account: { party_record_id: party_id } }.to_json,
-      headers: { "CONTENT_TYPE" => "application/json" }
+      headers: teller_json_headers(@teller_operator)
     assert_response :created
     assert_predicate response.parsed_body["account_number"], :present?
   end
@@ -37,19 +38,19 @@ class TellerRequestsTest < ActionDispatch::IntegrationTest
         source_account_id: account_id
       }
     }
-    post "/teller/operational_events", params: body.to_json, headers: { "CONTENT_TYPE" => "application/json" }
+    post "/teller/operational_events", params: body.to_json, headers: teller_json_headers(@teller_operator)
     assert_response :created
     event_id = response.parsed_body["id"]
 
-    post "/teller/operational_events", params: body.to_json, headers: { "CONTENT_TYPE" => "application/json" }
+    post "/teller/operational_events", params: body.to_json, headers: teller_json_headers(@teller_operator)
     assert_response :success
     assert_equal "replay", response.parsed_body["outcome"]
 
-    post "/teller/operational_events/#{event_id}/post", headers: { "CONTENT_TYPE" => "application/json" }
+    post "/teller/operational_events/#{event_id}/post", headers: teller_json_headers(@teller_operator)
     assert_response :created
     assert_equal "posted", response.parsed_body["outcome"]
 
-    post "/teller/operational_events/#{event_id}/post", headers: { "CONTENT_TYPE" => "application/json" }
+    post "/teller/operational_events/#{event_id}/post", headers: teller_json_headers(@teller_operator)
     assert_response :success
     assert_equal "already_posted", response.parsed_body["outcome"]
   end
@@ -57,7 +58,7 @@ class TellerRequestsTest < ActionDispatch::IntegrationTest
   test "deposit account returns 404 for unknown party" do
     post "/teller/deposit_accounts",
       params: { deposit_account: { party_record_id: 0 } }.to_json,
-      headers: { "CONTENT_TYPE" => "application/json" }
+      headers: teller_json_headers(@teller_operator)
     assert_response :not_found
   end
 
@@ -66,7 +67,7 @@ class TellerRequestsTest < ActionDispatch::IntegrationTest
   def create_party!
     post "/teller/parties",
       params: { party_type: "individual", first_name: "A", last_name: "B" }.to_json,
-      headers: { "CONTENT_TYPE" => "application/json" }
+      headers: teller_json_headers(@teller_operator)
     assert_response :created
     response.parsed_body["id"]
   end
@@ -74,7 +75,7 @@ class TellerRequestsTest < ActionDispatch::IntegrationTest
   def open_account!(party_id)
     post "/teller/deposit_accounts",
       params: { deposit_account: { party_record_id: party_id } }.to_json,
-      headers: { "CONTENT_TYPE" => "application/json" }
+      headers: teller_json_headers(@teller_operator)
     assert_response :created
     response.parsed_body["id"]
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,3 +14,18 @@ module ActiveSupport
     # Add more helper methods to be used by all tests here...
   end
 end
+
+class ActionDispatch::IntegrationTest
+  def teller_json_headers(operator)
+    {
+      "CONTENT_TYPE" => "application/json",
+      "X-Operator-Id" => operator.id.to_s
+    }
+  end
+
+  def create_workspace_operators!
+    teller = Workspace::Models::Operator.create!(role: "teller", display_name: "Test Teller", active: true)
+    supervisor = Workspace::Models::Operator.create!(role: "supervisor", display_name: "Test Supervisor", active: true)
+    [ teller, supervisor ]
+  end
+end


### PR DESCRIPTION
## Summary

Implements **Workstream 3 / RBAC foundation** for the teller JSON workspace: system-wide `operators` (owned by **Workspace**), required **`X-Operator-Id`**, database-backed roles, and supervisor-only gates for **`POST /teller/reversals`** and **`override.approved`**.

## Changes

- **Migration:** `operators` table with role CHECK; FK `operational_events.actor_id` → `operators`.
- **Domain:** `Workspace::Models::Operator`; optional `OperationalEvent#actor` association.
- **HTTP:** `Teller::AuthenticateOperator` on `Teller::ApplicationController`; `actor_id` wired from `current_operator` in financial events, reversals, and overrides (client cannot spoof override approver).
- **Seeds:** development sample teller + supervisor operators.
- **Docs:** new **ADR-0015**; ADR-0010 (`actor_id`), ADR-0014, module catalog, roadmap, operational event specs, `AGENTS.md`, operational events README.
- **Tests:** integration helpers; all teller requests send operator header; 401 / 403 / supervisor success coverage.

## Review notes

- Production trust boundary remains mTLS / network policy / future OAuth per ADR-0015.
- Run `bin/rails db:migrate` (or `db:prepare`) after merge.

Made with [Cursor](https://cursor.com)