### PR TITLE
Phase 3.5b workspace refinement

### DIFF
--- a/app/controllers/admin/deposit_products_controller.rb
+++ b/app/controllers/admin/deposit_products_controller.rb
@@ -19,8 +19,43 @@ module Admin
       @deposit_product = Products::Models::DepositProduct.includes(
         :deposit_product_fee_rules,
         :deposit_product_overdraft_policies,
+        :deposit_product_statement_profiles,
+        :deposit_accounts
+      ).find(params[:id])
+      @account_counts = @deposit_product.deposit_accounts.group(:status).count
+      @recent_accounts = @deposit_product.deposit_accounts.order(created_at: :desc, id: :desc).limit(10)
+    end
+
+    def readiness
+      @deposit_product = Products::Models::DepositProduct.includes(
+        :deposit_product_fee_rules,
+        :deposit_product_overdraft_policies,
         :deposit_product_statement_profiles
       ).find(params[:id])
+      @as_of = parse_optional_date_param(:as_of) || Core::BusinessDate::Services::CurrentBusinessDate.call
+      return if @error_message.present?
+
+      @checks = product_readiness_checks(@deposit_product, @as_of)
+    rescue Core::BusinessDate::Errors::NotSet => e
+      @error_message = e.message
+    end
+
+    private
+
+    def product_readiness_checks(product, as_of)
+      [
+        readiness_check("Product active", product.status == Products::Models::DepositProduct::STATUS_ACTIVE),
+        readiness_check("Active monthly maintenance fee rule",
+          Products::Queries::ActiveFeeRules.monthly_maintenance(business_date: as_of, deposit_product_id: product.id).exists?),
+        readiness_check("Active deny-NSF overdraft policy",
+          Products::Queries::ActiveOverdraftPolicies.deny_nsf_for_product(business_date: as_of, deposit_product_id: product.id).present?),
+        readiness_check("Active monthly statement profile",
+          Products::Queries::ActiveStatementProfiles.monthly(business_date: as_of, deposit_product_id: product.id).exists?)
+      ]
+    end
+
+    def readiness_check(label, ready)
+      { label: label, ready: ready }
     end
   end
 end

--- a/app/controllers/branch/application_controller.rb
+++ b/app/controllers/branch/application_controller.rb
@@ -19,5 +19,11 @@ module Branch
     def parse_optional_integer(value)
       value.presence&.to_i
     end
+
+    def require_branch_supervisor!
+      return if current_operator&.supervisor?
+
+      redirect_to branch_path, alert: "Supervisor role required"
+    end
   end
 end

--- a/app/controllers/branch/holds_controller.rb
+++ b/app/controllers/branch/holds_controller.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Branch
+  class HoldsController < ApplicationController
+    def new
+      @hold = default_hold_params("branch-hold")
+    end
+
+    def create
+      @hold = hold_params
+      result = Accounts::Commands::PlaceHold.call(
+        deposit_account_id: @hold[:deposit_account_id].to_i,
+        amount_minor_units: @hold[:amount_minor_units].to_i,
+        currency: @hold[:currency],
+        channel: "teller",
+        idempotency_key: @hold[:idempotency_key],
+        placed_for_operational_event_id: parse_optional_integer(@hold[:placed_for_operational_event_id])
+      )
+      @event = result[:event]
+      @hold_record = result[:hold]
+      @outcome = result[:outcome]
+      render :result, status: @outcome == :created ? :created : :ok
+    rescue Accounts::Commands::PlaceHold::InvalidRequest => e
+      @error_message = e.message
+      render :new, status: :unprocessable_entity
+    end
+
+    def release
+      @hold_release = default_release_params("branch-hold-release")
+    end
+
+    def create_release
+      @hold_release = release_params
+      result = Accounts::Commands::ReleaseHold.call(
+        hold_id: @hold_release[:hold_id].to_i,
+        channel: "teller",
+        idempotency_key: @hold_release[:idempotency_key]
+      )
+      @event = result[:event]
+      @hold_record = result[:hold]
+      @outcome = result[:outcome]
+      render :result, status: @outcome == :created ? :created : :ok
+    rescue Accounts::Commands::ReleaseHold::InvalidRequest,
+      Accounts::Commands::ReleaseHold::HoldNotFound => e
+      @error_message = e.message
+      render :release, status: :unprocessable_entity
+    end
+
+    private
+
+    def default_hold_params(prefix)
+      {
+        "deposit_account_id" => params[:deposit_account_id],
+        "placed_for_operational_event_id" => params[:placed_for_operational_event_id],
+        "amount_minor_units" => nil,
+        "currency" => "USD",
+        "idempotency_key" => default_idempotency_key(prefix)
+      }
+    end
+
+    def default_release_params(prefix)
+      {
+        "hold_id" => params[:hold_id],
+        "idempotency_key" => default_idempotency_key(prefix)
+      }
+    end
+
+    def hold_params
+      params.require(:hold).permit(
+        :deposit_account_id, :placed_for_operational_event_id, :amount_minor_units, :currency, :idempotency_key
+      ).to_h.symbolize_keys
+    end
+
+    def release_params
+      params.require(:hold_release).permit(:hold_id, :idempotency_key).to_h.symbolize_keys
+    end
+  end
+end

--- a/app/controllers/branch/operational_event_posts_controller.rb
+++ b/app/controllers/branch/operational_event_posts_controller.rb
@@ -4,11 +4,11 @@ module Branch
   class OperationalEventPostsController < ApplicationController
     def create
       result = Core::Posting::Commands::PostEvent.call(operational_event_id: params[:id].to_i)
-      redirect_to branch_path, notice: "Posted operational event ##{result[:event].id} (#{result[:outcome]})."
+      redirect_back fallback_location: branch_path, notice: "Posted operational event ##{result[:event].id} (#{result[:outcome]})."
     rescue Core::Posting::Commands::PostEvent::NotFound
-      redirect_to branch_path, alert: "Operational event not found."
+      redirect_back fallback_location: branch_path, alert: "Operational event not found."
     rescue Core::Posting::Commands::PostEvent::InvalidState => e
-      redirect_to branch_path, alert: e.message
+      redirect_back fallback_location: branch_path, alert: e.message
     end
   end
 end

--- a/app/controllers/branch/operational_events_controller.rb
+++ b/app/controllers/branch/operational_events_controller.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Branch
+  class OperationalEventsController < ApplicationController
+    def index
+      @query_params = permitted_query_params
+      @event_search = Core::OperationalEvents::Queries::ListOperationalEvents.call(**@query_params)
+    rescue Core::OperationalEvents::Queries::ListOperationalEvents::InvalidQuery => e
+      @error_message = e.message
+      @event_search = nil
+      render :index, status: :unprocessable_entity
+    rescue Core::BusinessDate::Errors::NotSet => e
+      @error_message = e.message
+      @event_search = nil
+      render :index, status: :unprocessable_entity
+    end
+
+    def show
+      @event = Core::OperationalEvents::Models::OperationalEvent.includes(
+        :source_account,
+        :destination_account,
+        :teller_session,
+        :actor,
+        :reversal_of_event,
+        { posting_batches: :journal_entries }
+      ).find(params[:id])
+    end
+
+    private
+
+    def permitted_query_params
+      p = params.permit(
+        :business_date, :business_date_from, :business_date_to,
+        :source_account_id, :destination_account_id, :status, :event_type, :channel, :actor_id,
+        :after_id, :limit
+      ).to_h.symbolize_keys
+      p[:source_account_id] = p[:source_account_id].to_i if p[:source_account_id].present?
+      p[:destination_account_id] = p[:destination_account_id].to_i if p[:destination_account_id].present?
+      p[:actor_id] = p[:actor_id].to_i if p[:actor_id].present?
+      p
+    end
+  end
+end

--- a/app/controllers/branch/overrides_controller.rb
+++ b/app/controllers/branch/overrides_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Branch
+  class OverridesController < ApplicationController
+    before_action :require_branch_supervisor_for_approval!
+
+    def new
+      @override = default_form_params("branch-override")
+    end
+
+    def create
+      @override = override_params
+      result = Core::OperationalEvents::Commands::RecordControlEvent.call(
+        event_type: @override[:event_type],
+        channel: "teller",
+        idempotency_key: @override[:idempotency_key],
+        reference_id: @override[:reference_id],
+        actor_id: current_operator.id
+      )
+      @event = result[:event]
+      @outcome = result[:outcome]
+      render :result, status: @outcome == :created ? :created : :ok
+    rescue Core::OperationalEvents::Commands::RecordControlEvent::InvalidRequest,
+      Core::OperationalEvents::Commands::RecordControlEvent::MismatchedIdempotency => e
+      @error_message = e.message
+      render :new, status: :unprocessable_entity
+    end
+
+    private
+
+    def require_branch_supervisor_for_approval!
+      return unless params.dig(:override, :event_type).to_s == "override.approved"
+
+      require_branch_supervisor!
+    end
+
+    def default_form_params(prefix)
+      {
+        "event_type" => params[:event_type] || "override.requested",
+        "reference_id" => params[:reference_id],
+        "idempotency_key" => default_idempotency_key(prefix)
+      }
+    end
+
+    def override_params
+      params.require(:override).permit(:event_type, :reference_id, :idempotency_key).to_h.symbolize_keys
+    end
+  end
+end

--- a/app/controllers/branch/reversals_controller.rb
+++ b/app/controllers/branch/reversals_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Branch
+  class ReversalsController < ApplicationController
+    before_action :require_branch_supervisor!
+
+    def new
+      @reversal = default_form_params("branch-reversal")
+    end
+
+    def create
+      @reversal = reversal_params
+      result = Core::OperationalEvents::Commands::RecordReversal.call(
+        original_operational_event_id: @reversal[:original_operational_event_id].to_i,
+        channel: "teller",
+        idempotency_key: @reversal[:idempotency_key],
+        actor_id: current_operator.id
+      )
+      @event = result[:event]
+      @outcome = result[:outcome]
+      @post_result = post_event_if_requested(@event, @reversal[:record_and_post])
+      render :result, status: @outcome == :created ? :created : :ok
+    rescue Core::OperationalEvents::Commands::RecordReversal::InvalidRequest,
+      Core::OperationalEvents::Commands::RecordReversal::MismatchedIdempotency,
+      Core::OperationalEvents::Commands::RecordReversal::PostedReplay,
+      Core::Posting::Commands::PostEvent::InvalidState => e
+      @error_message = e.message
+      render :new, status: :unprocessable_entity
+    rescue Core::OperationalEvents::Commands::RecordReversal::NotFound => e
+      @error_message = e.message
+      render :new, status: :not_found
+    end
+
+    private
+
+    def default_form_params(prefix)
+      {
+        "original_operational_event_id" => params[:original_operational_event_id],
+        "idempotency_key" => default_idempotency_key(prefix),
+        "record_and_post" => "0"
+      }
+    end
+
+    def reversal_params
+      params.require(:reversal).permit(:original_operational_event_id, :idempotency_key, :record_and_post).to_h.symbolize_keys
+    end
+  end
+end

--- a/app/controllers/branch/teller_sessions_controller.rb
+++ b/app/controllers/branch/teller_sessions_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Branch
+  class TellerSessionsController < ApplicationController
+    def new
+      @teller_session = { "drawer_code" => params[:drawer_code] }
+    end
+
+    def create
+      @teller_session = teller_session_params
+      session = Teller::Commands::OpenSession.call(drawer_code: @teller_session[:drawer_code].presence)
+      redirect_to branch_path, notice: "Opened teller session ##{session.id}."
+    rescue Teller::Commands::OpenSession::SessionAlreadyOpen => e
+      @error_message = e.message
+      render :new, status: :unprocessable_entity
+    end
+
+    def close
+      session = Teller::Commands::CloseSession.call(
+        teller_session_id: params[:id].to_i,
+        expected_cash_minor_units: close_params[:expected_cash_minor_units].to_i,
+        actual_cash_minor_units: close_params[:actual_cash_minor_units].to_i
+      )
+      message = if session.status == Teller::Models::TellerSession::STATUS_PENDING_SUPERVISOR
+        "Session ##{session.id} is pending supervisor approval for variance."
+      else
+        "Closed teller session ##{session.id}."
+      end
+      redirect_to branch_path, notice: message
+    rescue Teller::Commands::CloseSession::NotFound => e
+      redirect_to branch_path, alert: e.message
+    rescue Teller::Commands::CloseSession::InvalidState => e
+      redirect_to branch_path, alert: e.message
+    end
+
+    private
+
+    def teller_session_params
+      params.require(:teller_session).permit(:drawer_code).to_h.symbolize_keys
+    end
+
+    def close_params
+      params.require(:teller_session_close).permit(:expected_cash_minor_units, :actual_cash_minor_units)
+    end
+  end
+end

--- a/app/controllers/branch/transfers_controller.rb
+++ b/app/controllers/branch/transfers_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Branch
+  class TransfersController < ApplicationController
+    def new
+      @transfer = default_form_params("branch-transfer")
+    end
+
+    def create
+      @transfer = transfer_params
+      result = Accounts::Commands::AuthorizeDebit.call(
+        event_type: "transfer.completed",
+        channel: "teller",
+        idempotency_key: @transfer[:idempotency_key],
+        amount_minor_units: @transfer[:amount_minor_units].to_i,
+        currency: @transfer[:currency],
+        source_account_id: @transfer[:source_account_id].to_i,
+        destination_account_id: @transfer[:destination_account_id].to_i,
+        actor_id: current_operator.id
+      )
+      if result[:outcome].in?([ Accounts::Commands::AuthorizeDebit::OUTCOME_DENIED, Accounts::Commands::AuthorizeDebit::OUTCOME_DENIED_REPLAY ])
+        @outcome = result[:outcome]
+        @denial_event = result[:denial_event]
+        @fee_event = result[:fee_event]
+        render :result, status: :unprocessable_entity
+        return
+      end
+
+      @event = result[:event]
+      @outcome = result[:outcome]
+      @post_result = post_event_if_requested(@event, @transfer[:record_and_post])
+      render :result, status: @outcome == :created ? :created : :ok
+    rescue Accounts::Commands::AuthorizeDebit::InvalidRequest,
+      Core::OperationalEvents::Commands::RecordEvent::InvalidRequest,
+      Core::OperationalEvents::Commands::RecordEvent::MismatchedIdempotency,
+      Core::OperationalEvents::Commands::RecordEvent::PostedReplay,
+      Core::Posting::Commands::PostEvent::InvalidState => e
+      @error_message = e.message
+      render :new, status: :unprocessable_entity
+    rescue Core::Posting::Commands::PostEvent::NotFound
+      @error_message = "Operational event not found for posting"
+      render :new, status: :not_found
+    end
+
+    private
+
+    def default_form_params(prefix)
+      {
+        "source_account_id" => params[:source_account_id],
+        "destination_account_id" => params[:destination_account_id],
+        "amount_minor_units" => nil,
+        "currency" => "USD",
+        "idempotency_key" => default_idempotency_key(prefix),
+        "record_and_post" => "0"
+      }
+    end
+
+    def transfer_params
+      params.require(:transfer).permit(
+        :source_account_id, :destination_account_id, :amount_minor_units, :currency, :idempotency_key, :record_and_post
+      ).to_h.symbolize_keys
+    end
+  end
+end

--- a/app/controllers/ops/close_packages_controller.rb
+++ b/app/controllers/ops/close_packages_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Ops
+  class ClosePackagesController < ApplicationController
+    def show
+      @business_date = resolve_business_date
+      return if @business_date.nil?
+
+      @readiness = Teller::Queries::EodReadiness.call(business_date: @business_date)
+      @trial_balance_rows = Core::Ledger::Queries::TrialBalanceForBusinessDate.call(business_date: @business_date)
+      @pending_events = Core::OperationalEvents::Models::OperationalEvent
+        .where(business_date: @business_date, status: Core::OperationalEvents::Models::OperationalEvent::STATUS_PENDING)
+        .order(:id)
+      @open_or_pending_sessions = Teller::Models::TellerSession
+        .where(status: [ Teller::Models::TellerSession::STATUS_OPEN, Teller::Models::TellerSession::STATUS_PENDING_SUPERVISOR ])
+        .order(:opened_at, :id)
+      @recent_closes = Core::BusinessDate::Models::BusinessDateCloseEvent
+        .includes(:closed_by_operator)
+        .order(closed_at: :desc, id: :desc)
+        .limit(10)
+    rescue Core::BusinessDate::Errors::NotSet => e
+      @error_message = e.message
+      render :show, status: :unprocessable_entity
+    end
+
+    private
+
+    def resolve_business_date
+      raw = params[:business_date].presence
+      raw.present? ? Date.iso8601(raw.to_s) : Core::BusinessDate::Services::CurrentBusinessDate.call
+    rescue ArgumentError, TypeError
+      @error_message = "business_date must be a valid ISO 8601 date (YYYY-MM-DD)"
+      render :show, status: :unprocessable_entity
+      nil
+    rescue Core::BusinessDate::Errors::NotSet => e
+      @error_message = e.message
+      render :show, status: :unprocessable_entity
+      nil
+    end
+  end
+end

--- a/app/controllers/ops/exceptions_controller.rb
+++ b/app/controllers/ops/exceptions_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Ops
+  class ExceptionsController < ApplicationController
+    def index
+      @pending_events = Core::OperationalEvents::Models::OperationalEvent
+        .where(status: Core::OperationalEvents::Models::OperationalEvent::STATUS_PENDING)
+        .order(:business_date, :id)
+        .limit(50)
+      @pending_sessions = Teller::Models::TellerSession
+        .where(status: Teller::Models::TellerSession::STATUS_PENDING_SUPERVISOR)
+        .order(:opened_at, :id)
+      @nsf_denials = Core::OperationalEvents::Models::OperationalEvent
+        .where(event_type: "overdraft.nsf_denied")
+        .order(id: :desc)
+        .limit(25)
+    end
+  end
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -13,6 +13,11 @@
     <p class="mt-2 text-sm text-slate-600">Browse products and related fee, overdraft, and statement configuration.</p>
   <% end %>
 
+  <%= link_to admin_deposit_products_path, class: "rounded border border-slate-200 bg-white p-5 shadow-sm hover:border-slate-400" do %>
+    <h2 class="font-semibold">Product readiness</h2>
+    <p class="mt-2 text-sm text-slate-600">Open a product and review active profiles needed by shipped engines.</p>
+  <% end %>
+
   <%= link_to admin_deposit_product_fee_rules_path, class: "rounded border border-slate-200 bg-white p-5 shadow-sm hover:border-slate-400" do %>
     <h2 class="font-semibold">Fee rules</h2>
     <p class="mt-2 text-sm text-slate-600">Review monthly maintenance fee rules and active-as-of results.</p>

--- a/app/views/admin/deposit_products/readiness.html.erb
+++ b/app/views/admin/deposit_products/readiness.html.erb
@@ -1,0 +1,32 @@
+<% content_for :title, "#{@deposit_product.product_code} Readiness - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">Product readiness</h1>
+    <p class="mt-2 text-slate-600"><%= admin_product_label(@deposit_product) %></p>
+  </div>
+  <%= link_to "Product detail", admin_deposit_product_path(@deposit_product), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+</section>
+
+<section class="mt-6 rounded border border-slate-200 bg-white p-5 shadow-sm">
+  <%= form_with url: admin_deposit_product_readiness_path(@deposit_product), method: :get, class: "flex items-end gap-3" do |form| %>
+    <div>
+      <%= form.label :as_of, "As of", class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :as_of, value: @as_of&.iso8601 || params[:as_of], placeholder: "YYYY-MM-DD", class: "mt-1 rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <%= form.submit "Review", class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+  <% end %>
+</section>
+
+<% if @error_message.present? %>
+  <section class="mt-6 rounded border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"><%= @error_message %></section>
+<% else %>
+  <section class="mt-8 grid gap-4 md:grid-cols-2">
+    <% @checks.each do |check| %>
+      <div class="rounded border <%= check[:ready] ? "border-emerald-200 bg-emerald-50" : "border-amber-200 bg-amber-50" %> p-5 shadow-sm">
+        <p class="text-sm font-medium <%= check[:ready] ? "text-emerald-800" : "text-amber-900" %>"><%= check[:label] %></p>
+        <p class="mt-2 text-2xl font-semibold"><%= check[:ready] ? "Ready" : "Needs configuration" %></p>
+      </div>
+    <% end %>
+  </section>
+<% end %>

--- a/app/views/admin/deposit_products/show.html.erb
+++ b/app/views/admin/deposit_products/show.html.erb
@@ -6,6 +6,7 @@
     <p class="mt-2 text-slate-600"><%= @deposit_product.name %></p>
   </div>
   <%= link_to "All products", admin_deposit_products_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+  <%= link_to "Readiness", admin_deposit_product_readiness_path(@deposit_product), class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
 </section>
 
 <section class="mt-8 grid gap-4 md:grid-cols-3">
@@ -20,6 +21,21 @@
   <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
     <p class="text-sm font-medium text-slate-500">Created</p>
     <p class="mt-2 text-2xl font-semibold"><%= admin_date(@deposit_product.created_at.to_date) %></p>
+  </div>
+</section>
+
+<section class="mt-8 grid gap-4 md:grid-cols-3">
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Open accounts</p>
+    <p class="mt-2 text-2xl font-semibold"><%= @account_counts.fetch(Accounts::Models::DepositAccount::STATUS_OPEN, 0) %></p>
+  </div>
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Closed accounts</p>
+    <p class="mt-2 text-2xl font-semibold"><%= @account_counts.fetch(Accounts::Models::DepositAccount::STATUS_CLOSED, 0) %></p>
+  </div>
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Configured rule families</p>
+    <p class="mt-2 text-2xl font-semibold"><%= [@deposit_product.deposit_product_fee_rules.any?, @deposit_product.deposit_product_overdraft_policies.any?, @deposit_product.deposit_product_statement_profiles.any?].count(true) %> / 3</p>
   </div>
 </section>
 
@@ -40,3 +56,38 @@
   rows: @deposit_product.deposit_product_statement_profiles.order(:effective_on, :id),
   empty_message: "No statement profiles configured for this product.",
   index_path: admin_deposit_product_statement_profiles_path(deposit_product_id: @deposit_product.id) %>
+
+<section class="mt-8 rounded border border-slate-200 bg-white shadow-sm">
+  <div class="border-b border-slate-200 px-5 py-4">
+    <h2 class="text-xl font-semibold">Recent accounts using this product</h2>
+  </div>
+  <% if @recent_accounts.any? %>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-slate-200 text-sm">
+        <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+          <tr>
+            <th class="px-5 py-3">Account</th>
+            <th class="px-5 py-3">Status</th>
+            <th class="px-5 py-3">Currency</th>
+              <th class="px-5 py-3">Created</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100">
+          <% @recent_accounts.each do |account| %>
+            <tr>
+              <td class="px-5 py-4">
+                <div class="font-medium text-slate-950"><%= account.account_number %></div>
+                <div class="text-xs text-slate-500">#<%= account.id %></div>
+              </td>
+              <td class="px-5 py-4"><%= admin_status_badge(account.status) %></td>
+              <td class="px-5 py-4"><%= account.currency %></td>
+              <td class="px-5 py-4"><%= admin_date(account.created_at.to_date) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <div class="px-5 py-8 text-sm text-slate-600">No accounts currently use this product.</div>
+  <% end %>
+</section>

--- a/app/views/branch/dashboard/_session_group.html.erb
+++ b/app/views/branch/dashboard/_session_group.html.erb
@@ -18,6 +18,8 @@
               <th class="px-5 py-3 text-right">Actual</th>
               <th class="px-5 py-3 text-right">Variance</th>
               <th class="px-5 py-3">Supervisor</th>
+            <% else %>
+              <th class="px-5 py-3">Close session</th>
             <% end %>
           </tr>
         </thead>
@@ -41,6 +43,14 @@
                     <div class="text-xs text-slate-500"><%= branch_session_time(session.supervisor_approved_at) %></div>
                   <% else %>
                     <span class="text-slate-500">Not approved</span>
+                  <% end %>
+                </td>
+              <% else %>
+                <td class="px-5 py-4">
+                  <%= form_with url: close_branch_teller_session_path(session), scope: :teller_session_close, method: :post, class: "grid gap-2 md:grid-cols-3" do |form| %>
+                    <%= form.text_field :expected_cash_minor_units, placeholder: "Expected", class: "rounded border border-slate-300 px-2 py-1" %>
+                    <%= form.text_field :actual_cash_minor_units, placeholder: "Actual", class: "rounded border border-slate-300 px-2 py-1" %>
+                    <%= form.submit "Close", class: "rounded bg-slate-900 px-3 py-1 font-medium text-white" %>
                   <% end %>
                 </td>
               <% end %>

--- a/app/views/branch/dashboard/index.html.erb
+++ b/app/views/branch/dashboard/index.html.erb
@@ -11,8 +11,12 @@
   <nav class="flex flex-wrap gap-2 text-sm">
     <%= link_to "Create party", new_branch_party_path, class: "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 shadow-sm" %>
     <%= link_to "Open account", new_branch_deposit_account_path, class: "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 shadow-sm" %>
+    <%= link_to "Open session", new_branch_teller_session_path, class: "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 shadow-sm" %>
     <%= link_to "Record deposit", new_branch_deposit_path, class: "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 shadow-sm" %>
     <%= link_to "Record withdrawal", new_branch_withdrawal_path, class: "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 shadow-sm" %>
+    <%= link_to "Transfer", new_branch_transfer_path, class: "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 shadow-sm" %>
+    <%= link_to "Place hold", new_branch_hold_path, class: "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 shadow-sm" %>
+    <%= link_to "Events", branch_operational_events_path, class: "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 shadow-sm" %>
   </nav>
 </section>
 

--- a/app/views/branch/holds/new.html.erb
+++ b/app/views/branch/holds/new.html.erb
@@ -1,0 +1,37 @@
+<% content_for :title, "Place Hold - BankCORE" %>
+
+<section>
+  <h1 class="text-3xl font-semibold">Place hold</h1>
+  <p class="mt-2 text-slate-600">Create a no-GL hold event against a deposit account.</p>
+</section>
+
+<%= render "branch/shared/form_error", error_message: @error_message %>
+
+<section class="mt-6 rounded border border-slate-200 bg-white p-6 shadow-sm">
+  <%= form_with url: branch_holds_path, scope: :hold, method: :post, class: "grid gap-4 md:grid-cols-2" do |form| %>
+    <div>
+      <%= form.label :deposit_account_id, "Deposit account id", class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :deposit_account_id, value: @hold["deposit_account_id"] || @hold[:deposit_account_id], class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :placed_for_operational_event_id, "Deposit event id (optional)", class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :placed_for_operational_event_id, value: @hold["placed_for_operational_event_id"] || @hold[:placed_for_operational_event_id], class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :amount_minor_units, "Amount minor units", class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :amount_minor_units, value: @hold["amount_minor_units"] || @hold[:amount_minor_units], class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :currency, class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :currency, value: @hold["currency"] || @hold[:currency] || "USD", class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div class="md:col-span-2">
+      <%= form.label :idempotency_key, class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :idempotency_key, value: @hold["idempotency_key"] || @hold[:idempotency_key], class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div class="md:col-span-2">
+      <%= form.submit "Place hold", class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+      <%= link_to "Release hold", release_branch_holds_path, class: "ml-3 text-sm font-medium text-slate-700" %>
+    </div>
+  <% end %>
+</section>

--- a/app/views/branch/holds/release.html.erb
+++ b/app/views/branch/holds/release.html.erb
@@ -1,0 +1,25 @@
+<% content_for :title, "Release Hold - BankCORE" %>
+
+<section>
+  <h1 class="text-3xl font-semibold">Release hold</h1>
+  <p class="mt-2 text-slate-600">Release an active hold and record a no-GL hold release event.</p>
+</section>
+
+<%= render "branch/shared/form_error", error_message: @error_message %>
+
+<section class="mt-6 rounded border border-slate-200 bg-white p-6 shadow-sm">
+  <%= form_with url: release_branch_holds_path, scope: :hold_release, method: :post, class: "grid gap-4 md:grid-cols-2" do |form| %>
+    <div>
+      <%= form.label :hold_id, "Hold id", class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :hold_id, value: @hold_release["hold_id"] || @hold_release[:hold_id], class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :idempotency_key, class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :idempotency_key, value: @hold_release["idempotency_key"] || @hold_release[:idempotency_key], class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div class="md:col-span-2">
+      <%= form.submit "Release hold", class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+      <%= link_to "Place hold", new_branch_hold_path, class: "ml-3 text-sm font-medium text-slate-700" %>
+    </div>
+  <% end %>
+</section>

--- a/app/views/branch/holds/result.html.erb
+++ b/app/views/branch/holds/result.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, "Hold Result - BankCORE" %>
+
+<section>
+  <h1 class="text-3xl font-semibold">Hold result</h1>
+  <p class="mt-2 text-slate-600">Review the hold event and hold row.</p>
+</section>
+
+<section class="mt-6 rounded border border-slate-200 bg-white p-6 shadow-sm">
+  <h2 class="text-xl font-semibold"><%= @event.event_type %></h2>
+  <dl class="mt-4 grid gap-4 text-sm md:grid-cols-2">
+    <div><dt class="font-medium text-slate-500">Hold</dt><dd>#<%= @hold_record.id %> (<%= @hold_record.status %>)</dd></div>
+    <div><dt class="font-medium text-slate-500">Operational event</dt><dd>#<%= @event.id %></dd></div>
+    <div><dt class="font-medium text-slate-500">Outcome</dt><dd><%= @outcome %></dd></div>
+    <div><dt class="font-medium text-slate-500">Account</dt><dd>#<%= @event.source_account_id %></dd></div>
+    <div><dt class="font-medium text-slate-500">Amount</dt><dd><%= branch_money(@event.amount_minor_units) %> <%= @event.currency %></dd></div>
+  </dl>
+</section>

--- a/app/views/branch/operational_events/index.html.erb
+++ b/app/views/branch/operational_events/index.html.erb
@@ -1,0 +1,76 @@
+<% content_for :title, "Branch Events - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">Branch operational events</h1>
+    <p class="mt-2 text-slate-600">Search recent teller-facing events and post pending events.</p>
+  </div>
+  <nav class="flex flex-wrap gap-2 text-sm">
+    <%= link_to "Place hold", new_branch_hold_path, class: "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 shadow-sm" %>
+    <%= link_to "Release hold", release_branch_holds_path, class: "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 shadow-sm" %>
+    <% if current_operator.supervisor? %>
+      <%= link_to "Record reversal", new_branch_reversal_path, class: "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 shadow-sm" %>
+    <% end %>
+    <%= link_to "Override", new_branch_override_path, class: "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 shadow-sm" %>
+  </nav>
+</section>
+
+<%= render "branch/shared/form_error", error_message: @error_message %>
+
+<section class="mt-6 rounded border border-slate-200 bg-white p-5 shadow-sm">
+  <%= form_with url: branch_operational_events_path, method: :get, class: "grid gap-4 md:grid-cols-4" do |form| %>
+    <div>
+      <%= form.label :business_date, class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :business_date, value: @query_params&.fetch(:business_date, nil), placeholder: "YYYY-MM-DD", class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :event_type, class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :event_type, value: @query_params&.fetch(:event_type, nil), class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :source_account_id, "Account id", class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :source_account_id, value: @query_params&.fetch(:source_account_id, nil), class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div class="self-end">
+      <%= form.submit "Search", class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+    </div>
+  <% end %>
+</section>
+
+<section class="mt-6 overflow-hidden rounded border border-slate-200 bg-white shadow-sm">
+  <% if @event_search&.fetch(:rows)&.any? %>
+    <table class="min-w-full divide-y divide-slate-200 text-sm">
+      <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+        <tr>
+          <th class="px-5 py-3">Event</th>
+          <th class="px-5 py-3">Status</th>
+          <th class="px-5 py-3">Account</th>
+          <th class="px-5 py-3 text-right">Amount</th>
+          <th class="px-5 py-3">Actions</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-slate-100">
+        <% @event_search[:rows].each do |event| %>
+          <tr>
+            <td class="px-5 py-4">
+              <%= link_to "##{event.id}", branch_operational_event_path(event), class: "font-medium text-slate-950" %>
+              <div class="text-xs text-slate-500"><%= event.event_type %></div>
+            </td>
+            <td class="px-5 py-4"><%= event.status %></td>
+            <td class="px-5 py-4">#<%= event.source_account_id || event.destination_account_id || "none" %></td>
+            <td class="px-5 py-4 text-right"><%= branch_money(event.amount_minor_units) %> <%= event.currency %></td>
+            <td class="px-5 py-4">
+              <% if event.status == Core::OperationalEvents::Models::OperationalEvent::STATUS_PENDING %>
+                <%= button_to "Post", branch_operational_event_post_path(event), method: :post, class: "rounded bg-slate-900 px-3 py-1 text-white" %>
+              <% else %>
+                <span class="text-slate-500">No action</span>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <div class="p-6 text-sm text-slate-600">No operational events found.</div>
+  <% end %>
+</section>

--- a/app/views/branch/operational_events/show.html.erb
+++ b/app/views/branch/operational_events/show.html.erb
@@ -1,0 +1,33 @@
+<% content_for :title, "Event ##{@event.id} - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">Operational event #<%= @event.id %></h1>
+    <p class="mt-2 text-slate-600"><%= @event.event_type %></p>
+  </div>
+  <%= link_to "Back to events", branch_operational_events_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+</section>
+
+<section class="mt-6 rounded border border-slate-200 bg-white p-6 shadow-sm">
+  <dl class="grid gap-4 text-sm md:grid-cols-2">
+    <div><dt class="font-medium text-slate-500">Status</dt><dd><%= @event.status %></dd></div>
+    <div><dt class="font-medium text-slate-500">Business date</dt><dd><%= @event.business_date %></dd></div>
+    <div><dt class="font-medium text-slate-500">Channel</dt><dd><%= @event.channel %></dd></div>
+    <div><dt class="font-medium text-slate-500">Idempotency key</dt><dd><%= @event.idempotency_key %></dd></div>
+    <div><dt class="font-medium text-slate-500">Source account</dt><dd><%= @event.source_account_id || "None" %></dd></div>
+    <div><dt class="font-medium text-slate-500">Destination account</dt><dd><%= @event.destination_account_id || "None" %></dd></div>
+    <div><dt class="font-medium text-slate-500">Amount</dt><dd><%= branch_money(@event.amount_minor_units) %> <%= @event.currency %></dd></div>
+    <div><dt class="font-medium text-slate-500">Reference</dt><dd><%= @event.reference_id.presence || "None" %></dd></div>
+    <div><dt class="font-medium text-slate-500">Teller session</dt><dd><%= @event.teller_session_id || "None" %></dd></div>
+    <div><dt class="font-medium text-slate-500">Actor</dt><dd><%= @event.actor&.display_name || @event.actor_id || "None" %></dd></div>
+  </dl>
+
+  <div class="mt-6 flex flex-wrap gap-3">
+    <% if @event.status == Core::OperationalEvents::Models::OperationalEvent::STATUS_PENDING %>
+      <%= button_to "Post event", branch_operational_event_post_path(@event), method: :post, class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+    <% end %>
+    <% if current_operator.supervisor? && @event.status == Core::OperationalEvents::Models::OperationalEvent::STATUS_POSTED %>
+      <%= link_to "Reverse event", new_branch_reversal_path(original_operational_event_id: @event.id), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+    <% end %>
+  </div>
+</section>

--- a/app/views/branch/overrides/new.html.erb
+++ b/app/views/branch/overrides/new.html.erb
@@ -1,0 +1,28 @@
+<% content_for :title, "Record Override - BankCORE" %>
+
+<section>
+  <h1 class="text-3xl font-semibold">Record override</h1>
+  <p class="mt-2 text-slate-600">Record an override request or supervisor approval control event.</p>
+</section>
+
+<%= render "branch/shared/form_error", error_message: @error_message %>
+
+<section class="mt-6 rounded border border-slate-200 bg-white p-6 shadow-sm">
+  <%= form_with url: branch_overrides_path, scope: :override, method: :post, class: "grid gap-4 md:grid-cols-2" do |form| %>
+    <div>
+      <%= form.label :event_type, class: "block text-sm font-medium text-slate-700" %>
+      <%= form.select :event_type, options_for_select([["Override requested", "override.requested"], ["Override approved", "override.approved"]], @override["event_type"] || @override[:event_type]), {}, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :reference_id, class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :reference_id, value: @override["reference_id"] || @override[:reference_id], class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div class="md:col-span-2">
+      <%= form.label :idempotency_key, class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :idempotency_key, value: @override["idempotency_key"] || @override[:idempotency_key], class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div class="md:col-span-2">
+      <%= form.submit "Record override", class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+    </div>
+  <% end %>
+</section>

--- a/app/views/branch/overrides/result.html.erb
+++ b/app/views/branch/overrides/result.html.erb
@@ -1,0 +1,16 @@
+<% content_for :title, "Override Result - BankCORE" %>
+
+<section>
+  <h1 class="text-3xl font-semibold">Override result</h1>
+  <p class="mt-2 text-slate-600">Review the posted control event.</p>
+</section>
+
+<section class="mt-6 rounded border border-slate-200 bg-white p-6 shadow-sm">
+  <h2 class="text-xl font-semibold"><%= @event.event_type %></h2>
+  <dl class="mt-4 grid gap-4 text-sm md:grid-cols-2">
+    <div><dt class="font-medium text-slate-500">Operational event</dt><dd>#<%= @event.id %></dd></div>
+    <div><dt class="font-medium text-slate-500">Outcome</dt><dd><%= @outcome %></dd></div>
+    <div><dt class="font-medium text-slate-500">Reference</dt><dd><%= @event.reference_id %></dd></div>
+    <div><dt class="font-medium text-slate-500">Actor</dt><dd>#<%= @event.actor_id %></dd></div>
+  </dl>
+</section>

--- a/app/views/branch/reversals/new.html.erb
+++ b/app/views/branch/reversals/new.html.erb
@@ -1,0 +1,30 @@
+<% content_for :title, "Record Reversal - BankCORE" %>
+
+<section>
+  <h1 class="text-3xl font-semibold">Record reversal</h1>
+  <p class="mt-2 text-slate-600">Supervisor-only compensating reversal for a posted financial event.</p>
+</section>
+
+<%= render "branch/shared/form_error", error_message: @error_message %>
+
+<section class="mt-6 rounded border border-slate-200 bg-white p-6 shadow-sm">
+  <%= form_with url: branch_reversals_path, scope: :reversal, method: :post, class: "grid gap-4 md:grid-cols-2" do |form| %>
+    <div>
+      <%= form.label :original_operational_event_id, "Original event id", class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :original_operational_event_id, value: @reversal["original_operational_event_id"] || @reversal[:original_operational_event_id], class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :idempotency_key, class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :idempotency_key, value: @reversal["idempotency_key"] || @reversal[:idempotency_key], class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div class="md:col-span-2">
+      <label class="flex items-center gap-2 text-sm text-slate-700">
+        <%= form.check_box :record_and_post, { checked: ActiveModel::Type::Boolean.new.cast(@reversal["record_and_post"] || @reversal[:record_and_post]) }, "1", "0" %>
+        Record and post immediately
+      </label>
+    </div>
+    <div class="md:col-span-2">
+      <%= form.submit "Record reversal", class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+    </div>
+  <% end %>
+</section>

--- a/app/views/branch/reversals/result.html.erb
+++ b/app/views/branch/reversals/result.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, "Reversal Result - BankCORE" %>
+
+<section>
+  <h1 class="text-3xl font-semibold">Reversal result</h1>
+  <p class="mt-2 text-slate-600">Review the compensating reversal event and posting outcome.</p>
+</section>
+
+<%= render "branch/shared/transaction_result",
+  title: "Reversal recorded",
+  event: @event,
+  outcome: @outcome,
+  post_result: @post_result %>

--- a/app/views/branch/teller_sessions/new.html.erb
+++ b/app/views/branch/teller_sessions/new.html.erb
@@ -1,0 +1,21 @@
+<% content_for :title, "Open Teller Session - BankCORE" %>
+
+<section>
+  <h1 class="text-3xl font-semibold">Open teller session</h1>
+  <p class="mt-2 text-slate-600">Start a drawer session for branch cash activity.</p>
+</section>
+
+<%= render "branch/shared/form_error", error_message: @error_message %>
+
+<section class="mt-6 rounded border border-slate-200 bg-white p-6 shadow-sm">
+  <%= form_with url: branch_teller_sessions_path, scope: :teller_session, method: :post, class: "grid gap-4 md:grid-cols-2" do |form| %>
+    <div>
+      <%= form.label :drawer_code, "Drawer code", class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :drawer_code, value: @teller_session["drawer_code"] || @teller_session[:drawer_code], class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+      <p class="mt-1 text-xs text-slate-500">Leave blank for the default MVP drawer.</p>
+    </div>
+    <div class="self-end">
+      <%= form.submit "Open session", class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+    </div>
+  <% end %>
+</section>

--- a/app/views/branch/transfers/new.html.erb
+++ b/app/views/branch/transfers/new.html.erb
@@ -1,0 +1,43 @@
+<% content_for :title, "Record Transfer - BankCORE" %>
+
+<section>
+  <h1 class="text-3xl font-semibold">Record transfer</h1>
+  <p class="mt-2 text-slate-600">Create a teller-channel transfer event, with optional immediate posting.</p>
+</section>
+
+<%= render "branch/shared/form_error", error_message: @error_message %>
+
+<section class="mt-6 rounded border border-slate-200 bg-white p-6 shadow-sm">
+  <%= form_with url: branch_transfers_path, scope: :transfer, method: :post, class: "grid gap-4 md:grid-cols-2" do |form| %>
+    <div>
+      <%= form.label :source_account_id, "Source account id", class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :source_account_id, value: @transfer["source_account_id"] || @transfer[:source_account_id], class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :destination_account_id, "Destination account id", class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :destination_account_id, value: @transfer["destination_account_id"] || @transfer[:destination_account_id], class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :amount_minor_units, "Amount minor units", class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :amount_minor_units, value: @transfer["amount_minor_units"] || @transfer[:amount_minor_units], class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :currency, class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :currency, value: @transfer["currency"] || @transfer[:currency] || "USD", class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div class="md:col-span-2">
+      <%= form.label :idempotency_key, class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :idempotency_key, value: @transfer["idempotency_key"] || @transfer[:idempotency_key], class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+      <p class="mt-1 text-xs text-slate-500">Keep this value stable when retrying the same request.</p>
+    </div>
+    <div class="md:col-span-2">
+      <label class="flex items-center gap-2 text-sm text-slate-700">
+        <%= form.check_box :record_and_post, { checked: ActiveModel::Type::Boolean.new.cast(@transfer["record_and_post"] || @transfer[:record_and_post]) }, "1", "0" %>
+        Record and post immediately
+      </label>
+    </div>
+    <div class="md:col-span-2">
+      <%= form.submit "Record transfer", class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+    </div>
+  <% end %>
+</section>

--- a/app/views/branch/transfers/result.html.erb
+++ b/app/views/branch/transfers/result.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, "Transfer Result - BankCORE" %>
+
+<section>
+  <h1 class="text-3xl font-semibold">Transfer result</h1>
+  <p class="mt-2 text-slate-600">Review the transfer event, posting outcome, or NSF denial.</p>
+</section>
+
+<% if @denial_event.present? %>
+  <section class="mt-6 rounded border border-amber-200 bg-amber-50 p-6 text-amber-950 shadow-sm">
+    <h2 class="text-xl font-semibold">Transfer denied for NSF</h2>
+    <dl class="mt-4 grid gap-4 text-sm md:grid-cols-2">
+      <div><dt class="font-medium">Denial event</dt><dd>#<%= @denial_event.id %></dd></div>
+      <div><dt class="font-medium">Fee event</dt><dd>#<%= @fee_event.id %></dd></div>
+      <div><dt class="font-medium">Outcome</dt><dd><%= @outcome %></dd></div>
+      <div><dt class="font-medium">Attempt amount</dt><dd><%= branch_money(@denial_event.amount_minor_units) %> <%= @denial_event.currency %></dd></div>
+    </dl>
+  </section>
+<% else %>
+  <%= render "branch/shared/transaction_result",
+    title: "Transfer recorded",
+    event: @event,
+    outcome: @outcome,
+    post_result: @post_result %>
+<% end %>

--- a/app/views/ops/close_packages/show.html.erb
+++ b/app/views/ops/close_packages/show.html.erb
@@ -1,0 +1,88 @@
+<% content_for :title, "Close Package - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">Close package</h1>
+    <p class="mt-2 text-slate-600">Control summary for EOD close, exceptions, trial balance, and close history.</p>
+  </div>
+  <%= form_with url: ops_close_package_path, method: :get, class: "flex items-end gap-3" do |form| %>
+    <div>
+      <%= form.label :business_date, class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :business_date, value: @business_date&.iso8601 || params[:business_date], placeholder: "YYYY-MM-DD", class: "mt-1 rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <%= form.submit "Review", class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+  <% end %>
+</section>
+
+<% if @error_message.present? %>
+  <section class="mt-6 rounded border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"><%= @error_message %></section>
+<% elsif @readiness.present? %>
+  <section class="mt-8 grid gap-4 md:grid-cols-4">
+    <%= render "ops/eod/readiness_card", label: "EOD ready", value: @readiness[:eod_ready] ? "Yes" : "No", state: @readiness[:eod_ready] %>
+    <%= render "ops/eod/readiness_card", label: "Balanced", value: @readiness[:journal_totals_balanced] ? "Yes" : "No", state: @readiness[:journal_totals_balanced] %>
+    <%= render "ops/eod/readiness_card", label: "Open/pending sessions", value: @readiness[:open_teller_sessions_count], state: @readiness[:all_sessions_closed] %>
+    <%= render "ops/eod/readiness_card", label: "Pending events", value: @readiness[:pending_operational_events_count], state: @readiness[:pending_operational_events_count].to_i.zero? %>
+  </section>
+
+  <section class="mt-8 grid gap-6 lg:grid-cols-2">
+    <div class="rounded border border-slate-200 bg-white shadow-sm">
+      <div class="border-b border-slate-200 px-5 py-4">
+        <h2 class="text-xl font-semibold">Pending operational events</h2>
+      </div>
+      <% if @pending_events.any? %>
+        <ul class="divide-y divide-slate-100">
+          <% @pending_events.each do |event| %>
+            <li class="px-5 py-4 text-sm">
+              <%= link_to "##{event.id}", ops_operational_event_path(event), class: "font-medium text-slate-950" %>
+              <span class="text-slate-600"><%= event.event_type %> · <%= ops_event_amount(event) %></span>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <div class="px-5 py-8 text-sm text-slate-600">No pending events for this date.</div>
+      <% end %>
+    </div>
+
+    <div class="rounded border border-slate-200 bg-white shadow-sm">
+      <div class="border-b border-slate-200 px-5 py-4">
+        <h2 class="text-xl font-semibold">Open or pending sessions</h2>
+      </div>
+      <% if @open_or_pending_sessions.any? %>
+        <ul class="divide-y divide-slate-100">
+          <% @open_or_pending_sessions.each do |session| %>
+            <li class="px-5 py-4 text-sm">
+              <span class="font-medium">#<%= session.id %></span>
+              <span class="text-slate-600"><%= session.status.humanize %> · <%= session.drawer_code.presence || "Default drawer" %></span>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <div class="px-5 py-8 text-sm text-slate-600">No open or pending-supervisor sessions.</div>
+      <% end %>
+    </div>
+  </section>
+
+  <section class="mt-8 rounded border border-slate-200 bg-white shadow-sm">
+    <div class="border-b border-slate-200 px-5 py-4">
+      <h2 class="text-xl font-semibold">Recent close history</h2>
+    </div>
+    <% if @recent_closes.any? %>
+      <ul class="divide-y divide-slate-100">
+        <% @recent_closes.each do |close| %>
+          <li class="px-5 py-4 text-sm">
+            <span class="font-medium"><%= close.closed_on.iso8601 %></span>
+            <span class="text-slate-600">closed at <%= ops_time(close.closed_at) %> by <%= close.closed_by_operator&.display_name || "Unknown" %></span>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <div class="px-5 py-8 text-sm text-slate-600">No business dates closed yet.</div>
+    <% end %>
+  </section>
+
+  <section class="mt-8 rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <h2 class="text-xl font-semibold">Close action</h2>
+    <p class="mt-2 text-sm text-slate-600">Close is still performed through the guarded business-date close screen.</p>
+    <%= link_to "Preview close", ops_business_date_close_path(business_date: @business_date.iso8601), class: "mt-4 inline-block rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+  </section>
+<% end %>

--- a/app/views/ops/dashboard/index.html.erb
+++ b/app/views/ops/dashboard/index.html.erb
@@ -23,6 +23,16 @@
     <p class="mt-2 text-sm text-slate-600">Preview EOD readiness and close the current business date.</p>
   <% end %>
 
+  <%= link_to ops_close_package_path, class: "rounded border border-slate-200 bg-white p-5 shadow-sm hover:border-slate-400" do %>
+    <h2 class="font-semibold">Close package</h2>
+    <p class="mt-2 text-sm text-slate-600">Review close evidence, exceptions, trial balance, and close history.</p>
+  <% end %>
+
+  <%= link_to ops_exceptions_path, class: "rounded border border-slate-200 bg-white p-5 shadow-sm hover:border-slate-400" do %>
+    <h2 class="font-semibold">Exception queues</h2>
+    <p class="mt-2 text-sm text-slate-600">Review pending events, variance approvals, and NSF denials.</p>
+  <% end %>
+
   <%= link_to ops_engine_runs_path, class: "rounded border border-slate-200 bg-white p-5 shadow-sm hover:border-slate-400" do %>
     <h2 class="font-semibold">Engine runs</h2>
     <p class="mt-2 text-sm text-slate-600">Preview and run monthly fees or statement generation.</p>

--- a/app/views/ops/exceptions/index.html.erb
+++ b/app/views/ops/exceptions/index.html.erb
@@ -1,0 +1,63 @@
+<% content_for :title, "Ops Exceptions - BankCORE" %>
+
+<section>
+  <h1 class="text-3xl font-semibold">Exception queues</h1>
+  <p class="mt-2 text-slate-600">Review pending events, variance approvals, and recent NSF denials.</p>
+</section>
+
+<section class="mt-8 grid gap-6 lg:grid-cols-3">
+  <div class="rounded border border-slate-200 bg-white shadow-sm">
+    <div class="border-b border-slate-200 px-5 py-4">
+      <h2 class="text-xl font-semibold">Pending events</h2>
+    </div>
+    <% if @pending_events.any? %>
+      <ul class="divide-y divide-slate-100">
+        <% @pending_events.each do |event| %>
+          <li class="px-5 py-4 text-sm">
+            <%= link_to "##{event.id}", ops_operational_event_path(event), class: "font-medium text-slate-950" %>
+            <div class="text-slate-600"><%= event.event_type %> · <%= event.business_date.iso8601 %></div>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <div class="px-5 py-8 text-sm text-slate-600">No pending events.</div>
+    <% end %>
+  </div>
+
+  <div class="rounded border border-slate-200 bg-white shadow-sm">
+    <div class="border-b border-slate-200 px-5 py-4">
+      <h2 class="text-xl font-semibold">Variance approvals</h2>
+    </div>
+    <% if @pending_sessions.any? %>
+      <ul class="divide-y divide-slate-100">
+        <% @pending_sessions.each do |session| %>
+          <li class="px-5 py-4 text-sm">
+            <span class="font-medium">Session #<%= session.id %></span>
+            <div class="text-slate-600">Variance <%= ops_money(session.variance_minor_units, signed: true) %></div>
+            <%= button_to "Approve", approve_ops_teller_variance_path(session), method: :post, class: "mt-2 rounded bg-slate-900 px-3 py-1 text-white" %>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <div class="px-5 py-8 text-sm text-slate-600">No pending variances.</div>
+    <% end %>
+  </div>
+
+  <div class="rounded border border-slate-200 bg-white shadow-sm">
+    <div class="border-b border-slate-200 px-5 py-4">
+      <h2 class="text-xl font-semibold">Recent NSF denials</h2>
+    </div>
+    <% if @nsf_denials.any? %>
+      <ul class="divide-y divide-slate-100">
+        <% @nsf_denials.each do |event| %>
+          <li class="px-5 py-4 text-sm">
+            <%= link_to "##{event.id}", ops_operational_event_path(event), class: "font-medium text-slate-950" %>
+            <div class="text-slate-600">Account #<%= event.source_account_id %> · <%= ops_event_amount(event) %></div>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <div class="px-5 py-8 text-sm text-slate-600">No NSF denials found.</div>
+    <% end %>
+  </div>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,21 @@ Rails.application.routes.draw do
   scope path: "branch", module: :branch, as: :branch do
     resources :parties, only: [ :new, :create ]
     resources :deposit_accounts, only: [ :new, :create ]
+    resources :teller_sessions, only: [ :new, :create ] do
+      post :close, on: :member
+    end
     resources :deposits, only: [ :new, :create ]
     resources :withdrawals, only: [ :new, :create ]
+    resources :transfers, only: [ :new, :create ]
+    resources :holds, only: [ :new, :create ] do
+      collection do
+        get :release
+        post :release, action: :create_release
+      end
+    end
+    resources :reversals, only: [ :new, :create ]
+    resources :overrides, only: [ :new, :create ]
+    resources :operational_events, only: [ :index, :show ]
     post "operational_events/:id/post", to: "operational_event_posts#create", as: :operational_event_post
   end
   get "ops", to: "ops/dashboard#index", as: :ops
@@ -17,6 +30,8 @@ Rails.application.routes.draw do
     get "eod", to: "eod#index", as: :eod
     get "business_date_close", to: "business_date_closes#new", as: :business_date_close
     post "business_date_close", to: "business_date_closes#create"
+    get "close_package", to: "close_packages#show", as: :close_package
+    get "exceptions", to: "exceptions#index", as: :exceptions
     get "engine_runs", to: "engine_runs#index", as: :engine_runs
     get "engine_runs/:engine/new", to: "engine_runs#new", as: :new_engine_run
     post "engine_runs/:engine", to: "engine_runs#create", as: :engine_run
@@ -28,6 +43,7 @@ Rails.application.routes.draw do
   get "admin", to: "admin/dashboard#index", as: :admin
   scope path: "admin", module: :admin, as: :admin do
     resources :deposit_products, only: [ :index, :show ]
+    get "deposit_products/:id/readiness", to: "deposit_products#readiness", as: :deposit_product_readiness
     resources :deposit_product_fee_rules, only: [ :index ]
     resources :deposit_product_overdraft_policies, only: [ :index ]
     resources :deposit_product_statement_profiles, only: [ :index ]

--- a/docs/operational_events/README.md
+++ b/docs/operational_events/README.md
@@ -28,6 +28,15 @@ Each spec uses the same headings so scans and diffs stay predictable:
 
 Copy the structure from any existing file in this folder when adding a new `event_type`, or start from [_template.md](_template.md).
 
+## Drift-check convention
+
+Every new **shipped** `event_type` must update these surfaces together before tests pass:
+
+- Add an entry to `Core::OperationalEvents::EventCatalog`.
+- Add a `PostingRules::Registry` handler when the event posts to GL.
+- Add or update the per-type spec in this directory, including the `## Registry` table.
+- Add or update the index row below so its `event_type` and GL posting columns match the catalog.
+
 ## Index
 
 | Spec | `event_type` | GL posting | Record command |

--- a/docs/roadmap-deferred-completion.md
+++ b/docs/roadmap-deferred-completion.md
@@ -302,19 +302,21 @@ Phase 3.5 is internal UI enablement over shipped Phase 0–3 domain capabilities
 
 Shipped narrow slice: session-backed internal operator authentication, shared internal shell, `branch`, `ops`, and `admin` namespaces, branch transaction forms for core teller flows, ops EOD/event/variance/engine surfaces, and admin product/rule inspection plus guarded rule changes.
 
+Phase 3.5b refinement adds broader internal coverage for shipped operations: branch session open/close, transfers, holds, reversals, overrides, branch event search/detail, ops close packages and exception queues, and admin product readiness/detail views.
+
 To complete:
 
 - Add request/system coverage for critical internal screens before they become required support paths for Phase 4.
-- Add close packages and exception review workflows beyond the current EOD/event/variance views.
-- Expand branch workspace coverage for holds, reversals, transfers, receipts, and richer session workflows as needed.
+- Add close package export/attestation artifacts and exception review workflows beyond the current close package and queue views.
+- Expand branch workspace coverage for receipts and richer session workflows as needed.
 - Refine admin/ops role taxonomy once distinct operations/admin roles are required by mutating screens.
 - Keep existing JSON `/teller` APIs stable for curl/tests/future clients.
 
 Likely slices:
 
 - Internal workspace request/system test pass.
-- Ops close package and exception review UI.
-- Branch workflow completion for holds, transfers, reversals, and receipts.
+- Ops close package export and exception review workflow.
+- Branch receipt and richer workflow completion.
 - Admin/ops role policy refinement.
 - Guarded admin/ops control surfaces where product requires mutation.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -158,6 +158,8 @@ Phase 3.5 is an internal Rails HTML workspace phase over the Phase 0-3 domain su
 - **Ops workspace:** EOD readiness, trial balance, operational event search/detail, close packages, and exception review.
 - **Admin/Product workspace:** product configuration inspection first, then guarded config edits in later slices.
 
+**Phase 3.5b refinement:** extend those workspaces toward parity with shipped Phase 0-3 operations: branch session lifecycle, transfer/hold/reversal/override/event screens; ops close package and exception queues; admin product readiness and richer product detail. This remains an internal staff UI pass and does **not** introduce new event types, posting semantics, GL mappings, or external channels.
+
 ---
 
 ## 10. Phase 4 — Channels and ecosystem

--- a/test/domains/core/operational_events/event_catalog_test.rb
+++ b/test/domains/core/operational_events/event_catalog_test.rb
@@ -3,6 +3,12 @@
 require "test_helper"
 
 class CoreOperationalEventsEventCatalogTest < ActiveSupport::TestCase
+  DOCS_DIR = Rails.root.join("docs/operational_events")
+  NON_CATALOG_SPEC_FILES = %w[
+    teller-session-opened.md
+    teller-session-closed.md
+  ].freeze
+
   test "every posting registry handler has catalog entry with posts_to_gl" do
     Core::Posting::PostingRules::Registry::HANDLERS.each_key do |event_type|
       entry = Core::OperationalEvents::EventCatalog.entry_for(event_type)
@@ -33,5 +39,127 @@ class CoreOperationalEventsEventCatalogTest < ActiveSupport::TestCase
     assert entry
     assert_not entry.posts_to_gl
     assert_equal "RecordControlEvent", entry.record_command
+  end
+
+  test "catalog event types are unique" do
+    event_types = catalog_event_types
+    assert_equal event_types.uniq, event_types, "EventCatalog contains duplicate event_type values"
+  end
+
+  test "every GL-backed catalog entry has posting registry handler" do
+    Core::OperationalEvents::EventCatalog.all_entries.each do |entry|
+      next unless entry.posts_to_gl
+
+      assert Core::Posting::PostingRules::Registry::HANDLERS.key?(entry.event_type),
+        "missing PostingRules handler for GL-backed catalog entry #{entry.event_type}"
+    end
+  end
+
+  test "catalog entries are covered by operational event docs index and specs" do
+    rows_by_type = readme_index_rows_by_event_type
+
+    Core::OperationalEvents::EventCatalog.all_entries.each do |entry|
+      row = rows_by_type[entry.event_type]
+
+      assert row, "missing docs/operational_events/README.md index row for #{entry.event_type}"
+      assert row.fetch(:path).present?, "missing spec link for #{entry.event_type}"
+      assert spec_path(row.fetch(:path)).exist?, "missing docs/operational_events/#{row.fetch(:path)} for #{entry.event_type}"
+    end
+  end
+
+  test "operational event docs index links point to existing spec files" do
+    readme_index_rows.each do |row|
+      assert spec_path(row.fetch(:path)).exist?,
+        "docs/operational_events/README.md links to missing file #{row.fetch(:path)}"
+    end
+  end
+
+  test "catalog spec registry event_type matches catalog entry" do
+    rows_by_type = readme_index_rows_by_event_type
+
+    Core::OperationalEvents::EventCatalog.all_entries.each do |entry|
+      row = rows_by_type.fetch(entry.event_type)
+      declared = spec_registry_event_type(row.fetch(:path))
+
+      assert_equal entry.event_type, declared,
+        "docs/operational_events/#{row.fetch(:path)} declares #{declared.inspect}, expected #{entry.event_type.inspect}"
+    end
+  end
+
+  test "docs index GL posting column matches EventCatalog posts_to_gl" do
+    rows_by_type = readme_index_rows_by_event_type
+
+    Core::OperationalEvents::EventCatalog.all_entries.each do |entry|
+      row = rows_by_type.fetch(entry.event_type)
+      gl_posting = row.fetch(:gl_posting)
+
+      if entry.posts_to_gl
+        assert gl_posting.start_with?("Yes"),
+          "README GL posting column for #{entry.event_type} should start with Yes, was #{gl_posting.inspect}"
+      else
+        assert gl_posting.start_with?("No"),
+          "README GL posting column for #{entry.event_type} should start with No, was #{gl_posting.inspect}"
+      end
+    end
+  end
+
+  test "non-catalog operational event docs are explicitly allowed" do
+    catalog_spec_files = readme_index_rows_by_event_type.values.map { |row| row.fetch(:path) }
+    indexed_spec_files = readme_index_rows.map { |row| row.fetch(:path) }
+    extra_spec_files = indexed_spec_files - catalog_spec_files
+
+    assert_empty extra_spec_files - NON_CATALOG_SPEC_FILES,
+      "README indexes non-catalog operational event docs without allowlist entry"
+  end
+
+  private
+
+  def catalog_event_types
+    Core::OperationalEvents::EventCatalog.all_entries.map(&:event_type)
+  end
+
+  def readme_index_rows_by_event_type
+    readme_index_rows.each_with_object({}) do |row, memo|
+      memo[row.fetch(:event_type)] = row if row.fetch(:event_type).present?
+    end
+  end
+
+  def readme_index_rows
+    @readme_index_rows ||= begin
+      readme_path = DOCS_DIR.join("README.md")
+
+      File.readlines(readme_path).filter_map do |line|
+        parse_readme_index_row(line)
+      end
+    end
+  end
+
+  def parse_readme_index_row(line)
+    match = line.match(/\|\s*\[[^\]]+\]\(([^)]+)\)\s*\|\s*(.*?)\s*\|\s*(.*?)\s*\|\s*(.*?)\s*\|/)
+    return unless match
+
+    {
+      path: match[1],
+      event_type: extract_backticked_value(match[2]),
+      gl_posting: match[3].strip,
+      record_command: match[4].strip
+    }
+  end
+
+  def spec_registry_event_type(relative_path)
+    content = File.read(spec_path(relative_path))
+    registry_section = content.split("## Registry", 2).fetch(1, "")
+    row = registry_section.lines.find { |line| line.include?("**`event_type`**") }
+    value_cell = row&.split("|")&.[](2)
+
+    extract_backticked_value(value_cell.to_s)
+  end
+
+  def spec_path(relative_path)
+    DOCS_DIR.join(relative_path)
+  end
+
+  def extract_backticked_value(value)
+    value.match(/`([^`]+)`/)&.[](1)
   end
 end

--- a/test/integration/internal_workspace_phase35b_test.rb
+++ b/test/integration/internal_workspace_phase35b_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InternalWorkspacePhase35bTest < ActionDispatch::IntegrationTest
+  setup do
+    BankCore::Seeds::GlCoa.seed!
+    Core::BusinessDate::Models::BusinessDateSetting.delete_all
+    Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.new(2026, 4, 22))
+
+    @teller = create_operator_with_credential!(role: "teller", username: "branch-teller")
+    @operations = create_operator_with_credential!(role: "operations", username: "ops-user")
+    @admin = create_operator_with_credential!(role: "admin", username: "admin-user")
+  end
+
+  test "branch workspace exposes session and transaction parity routes" do
+    internal_login!(username: "branch-teller")
+
+    get branch_path
+    assert_response :success
+    assert_includes response.body, "Open session"
+    assert_includes response.body, "Transfer"
+    assert_includes response.body, "Place hold"
+
+    get new_branch_teller_session_path
+    assert_response :success
+    assert_includes response.body, "Open teller session"
+
+    get new_branch_transfer_path
+    assert_response :success
+    assert_includes response.body, "Record transfer"
+
+    get new_branch_hold_path
+    assert_response :success
+    assert_includes response.body, "Place hold"
+
+    get branch_operational_events_path
+    assert_response :success
+    assert_includes response.body, "Branch operational events"
+  end
+
+  test "ops workspace exposes close package and exception queues" do
+    internal_login!(username: "ops-user")
+
+    get ops_path
+    assert_response :success
+    assert_includes response.body, "Close package"
+    assert_includes response.body, "Exception queues"
+
+    get ops_close_package_path
+    assert_response :success
+    assert_includes response.body, "Close package"
+
+    get ops_exceptions_path
+    assert_response :success
+    assert_includes response.body, "Exception queues"
+  end
+
+  test "admin product workspace exposes readiness review" do
+    internal_login!(username: "admin-user")
+    product = Products::Queries::FindDepositProduct.default_slice1!
+
+    get admin_deposit_product_path(product)
+    assert_response :success
+    assert_includes response.body, "Readiness"
+
+    get admin_deposit_product_readiness_path(product)
+    assert_response :success
+    assert_includes response.body, "Product readiness"
+  end
+end


### PR DESCRIPTION
## Summary
- Adds branch workspace parity for teller session lifecycle, transfers, holds, reversals, overrides, and operational event search/detail.
- Adds ops close package and exception queue screens for close support and investigation.
- Expands admin product detail/readiness views and strengthens EventCatalog/docs drift checks.

## Test plan
- ReadLints for edited controllers, views, routes, docs, and tests: passed.
- `bin/rails test test/integration/internal_workspace_phase35b_test.rb`: not run locally because active Ruby is 2.6.10 while Gemfile requires 3.4.9.

Made with [Cursor](https://cursor.com)