### PR TITLE
Show expected cash on session close

### DIFF
--- a/app/controllers/branch/operational_event_posts_controller.rb
+++ b/app/controllers/branch/operational_event_posts_controller.rb
@@ -4,11 +4,12 @@ module Branch
   class OperationalEventPostsController < ApplicationController
     def create
       result = Core::Posting::Commands::PostEvent.call(operational_event_id: params[:id].to_i)
-      redirect_back fallback_location: branch_path, notice: "Posted operational event ##{result[:event].id} (#{result[:outcome]})."
+      redirect_to branch_operational_event_path(result[:event]),
+        notice: "Posted operational event ##{result[:event].id} (#{result[:outcome]})."
     rescue Core::Posting::Commands::PostEvent::NotFound
-      redirect_back fallback_location: branch_path, alert: "Operational event not found."
+      redirect_to branch_path, alert: "Operational event not found."
     rescue Core::Posting::Commands::PostEvent::InvalidState => e
-      redirect_back fallback_location: branch_path, alert: e.message
+      redirect_to branch_operational_event_path(params[:id]), alert: e.message
     end
   end
 end

--- a/app/controllers/branch/teller_sessions_controller.rb
+++ b/app/controllers/branch/teller_sessions_controller.rb
@@ -16,9 +16,10 @@ module Branch
     end
 
     def close
+      teller_session_id = params[:id].to_i
       session = Teller::Commands::CloseSession.call(
-        teller_session_id: params[:id].to_i,
-        expected_cash_minor_units: close_params[:expected_cash_minor_units].to_i,
+        teller_session_id: teller_session_id,
+        expected_cash_minor_units: Teller::Queries::ExpectedCashForSession.call(teller_session_id: teller_session_id),
         actual_cash_minor_units: close_params[:actual_cash_minor_units].to_i
       )
       message = if session.status == Teller::Models::TellerSession::STATUS_PENDING_SUPERVISOR
@@ -40,7 +41,7 @@ module Branch
     end
 
     def close_params
-      params.require(:teller_session_close).permit(:expected_cash_minor_units, :actual_cash_minor_units)
+      params.require(:teller_session_close).permit(:actual_cash_minor_units)
     end
   end
 end

--- a/app/domains/teller/queries/expected_cash_for_session.rb
+++ b/app/domains/teller/queries/expected_cash_for_session.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Teller
+  module Queries
+    class ExpectedCashForSession
+      CASH_EVENT_DELTAS = {
+        "deposit.accepted" => 1,
+        "withdrawal.posted" => -1
+      }.freeze
+
+      def self.call(teller_session_id:)
+        new(teller_session_id: teller_session_id).call
+      end
+
+      def initialize(teller_session_id:)
+        @teller_session_id = teller_session_id
+      end
+
+      def call
+        Core::OperationalEvents::Models::OperationalEvent
+          .where(teller_session_id: teller_session_id, event_type: CASH_EVENT_DELTAS.keys)
+          .where(reversed_by_event_id: nil)
+          .sum { |event| event.amount_minor_units.to_i * CASH_EVENT_DELTAS.fetch(event.event_type) }
+      end
+
+      private
+
+      attr_reader :teller_session_id
+    end
+  end
+end

--- a/app/helpers/branch/dashboard_helper.rb
+++ b/app/helpers/branch/dashboard_helper.rb
@@ -7,5 +7,9 @@ module Branch
 
       value.in_time_zone.strftime("%Y-%m-%d %H:%M")
     end
+
+    def branch_expected_cash_for(session)
+      Teller::Queries::ExpectedCashForSession.call(teller_session_id: session.id)
+    end
   end
 end

--- a/app/views/branch/dashboard/_session_group.html.erb
+++ b/app/views/branch/dashboard/_session_group.html.erb
@@ -47,9 +47,12 @@
                 </td>
               <% else %>
                 <td class="px-5 py-4">
-                  <%= form_with url: close_branch_teller_session_path(session), scope: :teller_session_close, method: :post, class: "grid gap-2 md:grid-cols-3" do |form| %>
-                    <%= form.text_field :expected_cash_minor_units, placeholder: "Expected", class: "rounded border border-slate-300 px-2 py-1" %>
-                    <%= form.text_field :actual_cash_minor_units, placeholder: "Actual", class: "rounded border border-slate-300 px-2 py-1" %>
+                  <% expected_cash_minor_units = branch_expected_cash_for(session) %>
+                  <div class="mb-2 text-xs text-slate-600">
+                    Expected cash: <span class="font-medium text-slate-950"><%= branch_money(expected_cash_minor_units) %></span>
+                  </div>
+                  <%= form_with url: close_branch_teller_session_path(session), scope: :teller_session_close, method: :post, class: "grid gap-2 md:grid-cols-2" do |form| %>
+                    <%= form.text_field :actual_cash_minor_units, placeholder: "Actual cash", class: "rounded border border-slate-300 px-2 py-1" %>
                     <%= form.submit "Close", class: "rounded bg-slate-900 px-3 py-1 font-medium text-white" %>
                   <% end %>
                 </td>

--- a/docs/roadmap-deferred-completion.md
+++ b/docs/roadmap-deferred-completion.md
@@ -175,7 +175,7 @@ Likely slices:
 
 ### 3.6 Drawer Variance and Cash Operations
 
-Shipped narrow slice: teller sessions, open/close lifecycle, variance thresholding, supervisor variance approval, and optional GL posting via `teller.drawer.variance.posted` are shipped. Deeper cash operations such as vaults, drawers as explicit cash locations, transfers, denominations, and in-transit cash remain deferred.
+Shipped narrow slice: teller sessions, open/close lifecycle, expected cash display on branch session close, variance thresholding, supervisor variance approval, and optional GL posting via `teller.drawer.variance.posted` are shipped. Deeper cash operations such as vaults, drawers as explicit cash locations, transfers, denominations, and in-transit cash remain deferred.
 
 To complete:
 
@@ -302,13 +302,13 @@ Phase 3.5 is internal UI enablement over shipped Phase 0–3 domain capabilities
 
 Shipped narrow slice: session-backed internal operator authentication, shared internal shell, `branch`, `ops`, and `admin` namespaces, branch transaction forms for core teller flows, ops EOD/event/variance/engine surfaces, and admin product/rule inspection plus guarded rule changes.
 
-Phase 3.5b refinement adds broader internal coverage for shipped operations: branch session open/close, transfers, holds, reversals, overrides, branch event search/detail, ops close packages and exception queues, and admin product readiness/detail views.
+Phase 3.5b refinement adds broader internal coverage for shipped operations: branch session open/close with expected cash shown at close, transfers, holds, reversals, overrides, branch event search/detail, ops close packages and exception queues, and admin product readiness/detail views.
 
 To complete:
 
 - Add request/system coverage for critical internal screens before they become required support paths for Phase 4.
 - Add close package export/attestation artifacts and exception review workflows beyond the current close package and queue views.
-- Expand branch workspace coverage for receipts and richer session workflows as needed.
+- Expand branch workspace coverage for receipts, close confirmation/variance preview polish, and richer session workflows as needed.
 - Refine admin/ops role taxonomy once distinct operations/admin roles are required by mutating screens.
 - Keep existing JSON `/teller` APIs stable for curl/tests/future clients.
 
@@ -316,7 +316,7 @@ Likely slices:
 
 - Internal workspace request/system test pass.
 - Ops close package export and exception review workflow.
-- Branch receipt and richer workflow completion.
+- Branch receipt, close confirmation, and richer workflow completion.
 - Admin/ops role policy refinement.
 - Guarded admin/ops control surfaces where product requires mutation.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -158,7 +158,7 @@ Phase 3.5 is an internal Rails HTML workspace phase over the Phase 0-3 domain su
 - **Ops workspace:** EOD readiness, trial balance, operational event search/detail, close packages, and exception review.
 - **Admin/Product workspace:** product configuration inspection first, then guarded config edits in later slices.
 
-**Phase 3.5b refinement:** extend those workspaces toward parity with shipped Phase 0-3 operations: branch session lifecycle, transfer/hold/reversal/override/event screens; ops close package and exception queues; admin product readiness and richer product detail. This remains an internal staff UI pass and does **not** introduce new event types, posting semantics, GL mappings, or external channels.
+**Phase 3.5b refinement:** extend those workspaces toward parity with shipped Phase 0-3 operations: branch session lifecycle with expected-cash close display, transfer/hold/reversal/override/event screens; ops close package and exception queues; admin product readiness and richer product detail. This remains an internal staff UI pass and does **not** introduce new event types, posting semantics, GL mappings, cash-location depth, or external channels.
 
 ---
 

--- a/test/domains/teller/expected_cash_for_session_test.rb
+++ b/test/domains/teller/expected_cash_for_session_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Teller
+  module Queries
+    class ExpectedCashForSessionTest < ActiveSupport::TestCase
+      test "sums non-reversed teller cash activity for a session" do
+        session = Teller::Models::TellerSession.create!(
+          status: Teller::Models::TellerSession::STATUS_OPEN,
+          opened_at: Time.current,
+          drawer_code: "expected-cash-#{SecureRandom.hex(4)}"
+        )
+        other_session = Teller::Models::TellerSession.create!(
+          status: Teller::Models::TellerSession::STATUS_OPEN,
+          opened_at: Time.current,
+          drawer_code: "other-cash-#{SecureRandom.hex(4)}"
+        )
+        reversal = create_event!("posting.reversal", session.id, 200)
+
+        create_event!("deposit.accepted", session.id, 1_000)
+        create_event!("withdrawal.posted", session.id, 300)
+        create_event!("transfer.completed", session.id, 500)
+        create_event!("deposit.accepted", other_session.id, 9_999)
+        create_event!("deposit.accepted", session.id, 200, reversed_by_event_id: reversal.id)
+
+        assert_equal 700, ExpectedCashForSession.call(teller_session_id: session.id)
+      end
+
+      private
+
+      def create_event!(event_type, teller_session_id, amount_minor_units, reversed_by_event_id: nil)
+        Core::OperationalEvents::Models::OperationalEvent.create!(
+          event_type: event_type,
+          status: Core::OperationalEvents::Models::OperationalEvent::STATUS_POSTED,
+          business_date: Date.new(2026, 4, 22),
+          channel: "teller",
+          idempotency_key: "#{event_type}-#{SecureRandom.hex(8)}",
+          amount_minor_units: amount_minor_units,
+          currency: "USD",
+          teller_session_id: teller_session_id,
+          reversed_by_event_id: reversed_by_event_id
+        )
+      end
+    end
+  end
+end

--- a/test/integration/branch_transaction_forms_test.rb
+++ b/test/integration/branch_transaction_forms_test.rb
@@ -103,7 +103,7 @@ class BranchTransactionFormsTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "Post event"
 
     post "/branch/operational_events/#{event.id}/post"
-    assert_redirected_to "/branch"
+    assert_redirected_to "/branch/operational_events/#{event.id}"
     assert_equal "posted", event.reload.status
   end
 


### PR DESCRIPTION
## Summary
- Shows calculated expected cash on the branch teller-session close form and recomputes it server-side on close.
- Adds a Teller query and test for session expected cash based on non-reversed deposit/withdrawal activity.
- Redirects branch post-pending actions to durable operational-event detail pages and updates roadmap docs.

## Test plan
- ReadLints for edited controllers, views, query, test, and roadmap docs: passed.
- `bin/rails test test/domains/teller/expected_cash_for_session_test.rb`: not run locally because active Ruby is 2.6.10 while Gemfile requires 3.4.9.

Made with [Cursor](https://cursor.com)