### PR TITLE
Add Phase 4.2 and 4.3 channel foundations

### DIFF
--- a/app/domains/accounts/commands/authorize_debit.rb
+++ b/app/domains/accounts/commands/authorize_debit.rb
@@ -78,10 +78,10 @@ module Accounts
         source = Accounts::Models::DepositAccount.find_by(id: source_account_id)
         raise original_error if source.nil?
 
-        policy = Products::Queries::ActiveOverdraftPolicies.deny_nsf_for_product(
-          business_date: business_date,
-          deposit_product_id: source.deposit_product_id
-        )
+        policy = Products::Services::DepositProductResolver.call(
+          deposit_account: source,
+          as_of: business_date
+        ).deny_nsf_policy
         raise original_error if policy.nil?
 
         denial_result = Core::OperationalEvents::Commands::RecordControlEvent.call(
@@ -111,10 +111,10 @@ module Accounts
           idempotency_key: nsf_fee_idempotency_key(denial_event)
         )
         unless fee_event
-          policy = Products::Queries::ActiveOverdraftPolicies.deny_nsf_for_product(
-            business_date: business_date,
-            deposit_product_id: denial_event.source_account.deposit_product_id
-          )
+          policy = Products::Services::DepositProductResolver.call(
+            deposit_account: denial_event.source_account,
+            as_of: business_date
+          ).deny_nsf_policy
           fee_event = record_and_post_nsf_fee!(policy, denial_event, business_date)
         end
 

--- a/app/domains/core/operational_events/event_catalog.rb
+++ b/app/domains/core/operational_events/event_catalog.rb
@@ -11,38 +11,241 @@ module Core
         :record_command,
         :reversible_via_posting_reversal,
         :compensating_event_type,
-        :description
+        :description,
+        :lifecycle,
+        :allowed_channels,
+        :financial_impact,
+        :customer_visible,
+        :statement_visible,
+        :payload_schema,
+        :support_search_keys
       )
 
       ENTRIES = [
-        Entry.new("deposit.accepted", "financial", true, "RecordEvent", true, "posting.reversal",
-          "Cash or equivalent in to DDA"),
-        Entry.new("withdrawal.posted", "financial", true, "RecordEvent", true, "posting.reversal",
-          "Cash or equivalent out from DDA"),
-        Entry.new("transfer.completed", "financial", true, "RecordEvent", true, "posting.reversal",
-          "Transfer between DDAs"),
-        Entry.new("posting.reversal", "financial", true, "RecordReversal", false, nil,
-          "Compensating reversal journal for a reversible financial event"),
-        Entry.new("fee.assessed", "financial", true, "RecordEvent", false, "fee.waived",
-          "Deposit service charge assessed to DDA"),
-        Entry.new("fee.waived", "financial", true, "RecordEvent", false, nil,
-          "Waives a prior posted fee.assessed (reference_id = original event id)"),
-        Entry.new("interest.accrued", "financial", true, "RecordEvent", true, "posting.reversal",
-          "Accrues deposit interest expense and payable (system channel only; ADR-0021)"),
-        Entry.new("interest.posted", "financial", true, "RecordEvent", true, "posting.reversal",
-          "Pays a posted interest.accrued into DDA (reference_id = accrual event id; ADR-0021)"),
-        Entry.new("teller.drawer.variance.posted", "financial", true, "RecordEvent", false, nil,
-          "GL adjustment for non-zero teller drawer cash variance (system channel only; ADR-0020)"),
-        Entry.new("hold.placed", "servicing", false, "PlaceHold", false, nil,
-          "Posted hold on DDA (no GL posting)"),
-        Entry.new("hold.released", "servicing", false, "ReleaseHold", false, nil,
-          "Posted hold release (no GL posting)"),
-        Entry.new("override.requested", "operational", false, "RecordControlEvent", false, nil,
-          "Supervisor override requested"),
-        Entry.new("override.approved", "operational", false, "RecordControlEvent", false, nil,
-          "Supervisor override approved"),
-        Entry.new("overdraft.nsf_denied", "operational", false, "RecordControlEvent", false, "fee.assessed",
-          "Denied overdraft/NSF debit attempt; may trigger linked NSF fee")
+        Entry.new(
+          event_type: "deposit.accepted",
+          category: "financial",
+          posts_to_gl: true,
+          record_command: "RecordEvent",
+          reversible_via_posting_reversal: true,
+          compensating_event_type: "posting.reversal",
+          description: "Cash or equivalent in to DDA",
+          lifecycle: "pending_to_posted",
+          allowed_channels: %w[teller api batch],
+          financial_impact: "gl_posting",
+          customer_visible: true,
+          statement_visible: true,
+          payload_schema: "docs/operational_events/deposit-accepted.md",
+          support_search_keys: %w[source_account_id actor_id teller_session_id]
+        ),
+        Entry.new(
+          event_type: "withdrawal.posted",
+          category: "financial",
+          posts_to_gl: true,
+          record_command: "RecordEvent",
+          reversible_via_posting_reversal: true,
+          compensating_event_type: "posting.reversal",
+          description: "Cash or equivalent out from DDA",
+          lifecycle: "pending_to_posted",
+          allowed_channels: %w[teller api batch],
+          financial_impact: "gl_posting",
+          customer_visible: true,
+          statement_visible: true,
+          payload_schema: "docs/operational_events/withdrawal-posted.md",
+          support_search_keys: %w[source_account_id actor_id teller_session_id]
+        ),
+        Entry.new(
+          event_type: "transfer.completed",
+          category: "financial",
+          posts_to_gl: true,
+          record_command: "RecordEvent",
+          reversible_via_posting_reversal: true,
+          compensating_event_type: "posting.reversal",
+          description: "Transfer between DDAs",
+          lifecycle: "pending_to_posted",
+          allowed_channels: %w[teller api batch],
+          financial_impact: "gl_posting",
+          customer_visible: true,
+          statement_visible: true,
+          payload_schema: "docs/operational_events/transfer-completed.md",
+          support_search_keys: %w[source_account_id destination_account_id actor_id]
+        ),
+        Entry.new(
+          event_type: "posting.reversal",
+          category: "financial",
+          posts_to_gl: true,
+          record_command: "RecordReversal",
+          reversible_via_posting_reversal: false,
+          compensating_event_type: nil,
+          description: "Compensating reversal journal for a reversible financial event",
+          lifecycle: "pending_to_posted",
+          allowed_channels: %w[teller branch api batch],
+          financial_impact: "gl_posting",
+          customer_visible: true,
+          statement_visible: true,
+          payload_schema: "docs/operational_events/compensating-reversal.md",
+          support_search_keys: %w[source_account_id destination_account_id reversal_of_event_id actor_id]
+        ),
+        Entry.new(
+          event_type: "fee.assessed",
+          category: "financial",
+          posts_to_gl: true,
+          record_command: "RecordEvent",
+          reversible_via_posting_reversal: false,
+          compensating_event_type: "fee.waived",
+          description: "Deposit service charge assessed to DDA",
+          lifecycle: "pending_to_posted",
+          allowed_channels: %w[teller api batch system],
+          financial_impact: "gl_posting",
+          customer_visible: true,
+          statement_visible: true,
+          payload_schema: "docs/operational_events/fee-assessed.md",
+          support_search_keys: %w[source_account_id reference_id actor_id]
+        ),
+        Entry.new(
+          event_type: "fee.waived",
+          category: "financial",
+          posts_to_gl: true,
+          record_command: "RecordEvent",
+          reversible_via_posting_reversal: false,
+          compensating_event_type: nil,
+          description: "Waives a prior posted fee.assessed (reference_id = original event id)",
+          lifecycle: "pending_to_posted",
+          allowed_channels: %w[teller branch api batch],
+          financial_impact: "gl_posting",
+          customer_visible: true,
+          statement_visible: true,
+          payload_schema: "docs/operational_events/fee-waived.md",
+          support_search_keys: %w[source_account_id reference_id actor_id]
+        ),
+        Entry.new(
+          event_type: "interest.accrued",
+          category: "financial",
+          posts_to_gl: true,
+          record_command: "RecordEvent",
+          reversible_via_posting_reversal: true,
+          compensating_event_type: "posting.reversal",
+          description: "Accrues deposit interest expense and payable (system channel only; ADR-0021)",
+          lifecycle: "pending_to_posted",
+          allowed_channels: %w[system],
+          financial_impact: "gl_posting",
+          customer_visible: false,
+          statement_visible: false,
+          payload_schema: "docs/operational_events/interest-accrued.md",
+          support_search_keys: %w[source_account_id reference_id]
+        ),
+        Entry.new(
+          event_type: "interest.posted",
+          category: "financial",
+          posts_to_gl: true,
+          record_command: "RecordEvent",
+          reversible_via_posting_reversal: true,
+          compensating_event_type: "posting.reversal",
+          description: "Pays a posted interest.accrued into DDA (reference_id = accrual event id; ADR-0021)",
+          lifecycle: "pending_to_posted",
+          allowed_channels: %w[system],
+          financial_impact: "gl_posting",
+          customer_visible: true,
+          statement_visible: true,
+          payload_schema: "docs/operational_events/interest-posted.md",
+          support_search_keys: %w[source_account_id reference_id]
+        ),
+        Entry.new(
+          event_type: "teller.drawer.variance.posted",
+          category: "financial",
+          posts_to_gl: true,
+          record_command: "RecordEvent",
+          reversible_via_posting_reversal: false,
+          compensating_event_type: nil,
+          description: "GL adjustment for non-zero teller drawer cash variance (system channel only; ADR-0020)",
+          lifecycle: "pending_to_posted",
+          allowed_channels: %w[system],
+          financial_impact: "optional_gl",
+          customer_visible: false,
+          statement_visible: false,
+          payload_schema: "docs/operational_events/teller-drawer-variance-posted.md",
+          support_search_keys: %w[teller_session_id reference_id]
+        ),
+        Entry.new(
+          event_type: "hold.placed",
+          category: "servicing",
+          posts_to_gl: false,
+          record_command: "PlaceHold",
+          reversible_via_posting_reversal: false,
+          compensating_event_type: nil,
+          description: "Posted hold on DDA (no GL posting)",
+          lifecycle: "posted_immediately",
+          allowed_channels: %w[teller branch api batch],
+          financial_impact: "no_gl",
+          customer_visible: true,
+          statement_visible: true,
+          payload_schema: "docs/operational_events/hold-placed.md",
+          support_search_keys: %w[source_account_id actor_id reference_id]
+        ),
+        Entry.new(
+          event_type: "hold.released",
+          category: "servicing",
+          posts_to_gl: false,
+          record_command: "ReleaseHold",
+          reversible_via_posting_reversal: false,
+          compensating_event_type: nil,
+          description: "Posted hold release (no GL posting)",
+          lifecycle: "posted_immediately",
+          allowed_channels: %w[teller branch api batch],
+          financial_impact: "no_gl",
+          customer_visible: true,
+          statement_visible: true,
+          payload_schema: "docs/operational_events/hold-released.md",
+          support_search_keys: %w[source_account_id reference_id actor_id]
+        ),
+        Entry.new(
+          event_type: "override.requested",
+          category: "operational",
+          posts_to_gl: false,
+          record_command: "RecordControlEvent",
+          reversible_via_posting_reversal: false,
+          compensating_event_type: nil,
+          description: "Supervisor override requested",
+          lifecycle: "posted_immediately",
+          allowed_channels: %w[teller branch batch],
+          financial_impact: "no_gl",
+          customer_visible: false,
+          statement_visible: false,
+          payload_schema: "docs/operational_events/override-requested.md",
+          support_search_keys: %w[reference_id actor_id]
+        ),
+        Entry.new(
+          event_type: "override.approved",
+          category: "operational",
+          posts_to_gl: false,
+          record_command: "RecordControlEvent",
+          reversible_via_posting_reversal: false,
+          compensating_event_type: nil,
+          description: "Supervisor override approved",
+          lifecycle: "posted_immediately",
+          allowed_channels: %w[teller branch batch],
+          financial_impact: "no_gl",
+          customer_visible: false,
+          statement_visible: false,
+          payload_schema: "docs/operational_events/override-approved.md",
+          support_search_keys: %w[reference_id actor_id]
+        ),
+        Entry.new(
+          event_type: "overdraft.nsf_denied",
+          category: "operational",
+          posts_to_gl: false,
+          record_command: "RecordControlEvent",
+          reversible_via_posting_reversal: false,
+          compensating_event_type: "fee.assessed",
+          description: "Denied overdraft/NSF debit attempt; may trigger linked NSF fee",
+          lifecycle: "posted_immediately",
+          allowed_channels: %w[teller api batch],
+          financial_impact: "no_gl",
+          customer_visible: true,
+          statement_visible: true,
+          payload_schema: "docs/operational_events/overdraft-nsf-denied.md",
+          support_search_keys: %w[source_account_id destination_account_id reference_id actor_id]
+        )
       ].freeze
 
       def self.all_entries
@@ -51,6 +254,26 @@ module Core
 
       def self.entry_for(event_type)
         ENTRIES.find { |e| e.event_type == event_type.to_s }
+      end
+
+      def self.statement_visible_event_types
+        ENTRIES.select(&:statement_visible).map(&:event_type)
+      end
+
+      def self.statement_visible_no_gl_event_types
+        ENTRIES.select { |e| e.statement_visible && e.financial_impact == "no_gl" }.map(&:event_type)
+      end
+
+      def self.customer_visible_event_types
+        ENTRIES.select(&:customer_visible).map(&:event_type)
+      end
+
+      def self.entries_for_channel(channel)
+        ENTRIES.select { |e| e.allowed_channels.include?(channel.to_s) }
+      end
+
+      def self.event_types_for_channel(channel)
+        entries_for_channel(channel).map(&:event_type)
       end
 
       def self.as_api_array
@@ -62,7 +285,14 @@ module Core
             record_command: e.record_command,
             reversible_via_posting_reversal: e.reversible_via_posting_reversal,
             compensating_event_type: e.compensating_event_type,
-            description: e.description
+            description: e.description,
+            lifecycle: e.lifecycle,
+            allowed_channels: e.allowed_channels,
+            financial_impact: e.financial_impact,
+            customer_visible: e.customer_visible,
+            statement_visible: e.statement_visible,
+            payload_schema: e.payload_schema,
+            support_search_keys: e.support_search_keys
           }
         end
       end

--- a/app/domains/deposits/queries/statement_activity.rb
+++ b/app/domains/deposits/queries/statement_activity.rb
@@ -4,7 +4,6 @@ module Deposits
   module Queries
     class StatementActivity
       GL_DDA = "2110"
-      VISIBLE_NO_GL_EVENT_TYPES = %w[hold.placed hold.released overdraft.nsf_denied].freeze
 
       Result = Data.define(
         :deposit_account,
@@ -109,13 +108,18 @@ module Deposits
       def self.no_gl_line_items(deposit_account_id, start_on, end_on)
         Core::OperationalEvents::Models::OperationalEvent
           .where(status: Core::OperationalEvents::Models::OperationalEvent::STATUS_POSTED)
-          .where(event_type: VISIBLE_NO_GL_EVENT_TYPES)
+          .where(event_type: statement_visible_no_gl_event_types)
           .where(source_account_id: deposit_account_id)
           .where(business_date: start_on..end_on)
           .order(:business_date, :id)
           .map { |event| no_gl_line_item(event) }
       end
       private_class_method :no_gl_line_items
+
+      def self.statement_visible_no_gl_event_types
+        Core::OperationalEvents::EventCatalog.statement_visible_no_gl_event_types
+      end
+      private_class_method :statement_visible_no_gl_event_types
 
       def self.no_gl_line_item(event)
         {

--- a/app/domains/products/commands/manage_effective_dated_rule.rb
+++ b/app/domains/products/commands/manage_effective_dated_rule.rb
@@ -114,7 +114,9 @@ module Products
           effective_on: parse_date!(attributes[:effective_on], "effective_on"),
           ended_on: parse_optional_date!(attributes[:ended_on], "ended_on"),
           description: attributes[:description].presence
-        )
+        ).tap do |rule|
+          rule.skip_effective_date_overlap_validation = true if rule.respond_to?(:skip_effective_date_overlap_validation=)
+        end
       end
 
       def validate_rule!(rule)

--- a/app/domains/products/models/deposit_product_fee_rule.rb
+++ b/app/domains/products/models/deposit_product_fee_rule.rb
@@ -4,6 +4,7 @@ module Products
   module Models
     class DepositProductFeeRule < ApplicationRecord
       self.table_name = "deposit_product_fee_rules"
+      attr_accessor :skip_effective_date_overlap_validation
 
       FEE_CODE_MONTHLY_MAINTENANCE = "monthly_maintenance"
       FEE_CODES = [ FEE_CODE_MONTHLY_MAINTENANCE ].freeze
@@ -21,6 +22,7 @@ module Products
       validates :effective_on, presence: true
       validate :ended_on_not_before_effective_on
       validate :currency_matches_deposit_product
+      validate :no_overlapping_active_monthly_maintenance_rule
 
       private
 
@@ -36,6 +38,15 @@ module Products
         return if currency == deposit_product.currency
 
         errors.add(:currency, "must match deposit product currency")
+      end
+
+      def no_overlapping_active_monthly_maintenance_rule
+        return if skip_effective_date_overlap_validation
+        return unless fee_code == FEE_CODE_MONTHLY_MAINTENANCE
+
+        return unless Services::EffectiveDatedResolver.overlap?(self, constraints: %i[deposit_product_id fee_code])
+
+        errors.add(:effective_on, "overlaps an active monthly maintenance rule for this product")
       end
     end
   end

--- a/app/domains/products/models/deposit_product_overdraft_policy.rb
+++ b/app/domains/products/models/deposit_product_overdraft_policy.rb
@@ -4,6 +4,7 @@ module Products
   module Models
     class DepositProductOverdraftPolicy < ApplicationRecord
       self.table_name = "deposit_product_overdraft_policies"
+      attr_accessor :skip_effective_date_overlap_validation
 
       MODE_DENY_NSF = "deny_nsf"
       MODES = [ MODE_DENY_NSF ].freeze
@@ -21,6 +22,7 @@ module Products
       validates :effective_on, presence: true
       validate :ended_on_not_before_effective_on
       validate :currency_matches_deposit_product
+      validate :no_overlapping_active_deny_nsf_policy
 
       private
 
@@ -36,6 +38,15 @@ module Products
         return if currency == deposit_product.currency
 
         errors.add(:currency, "must match deposit product currency")
+      end
+
+      def no_overlapping_active_deny_nsf_policy
+        return if skip_effective_date_overlap_validation
+        return unless mode == MODE_DENY_NSF
+
+        return unless Services::EffectiveDatedResolver.overlap?(self, constraints: %i[deposit_product_id mode])
+
+        errors.add(:effective_on, "overlaps an active deny NSF policy for this product")
       end
     end
   end

--- a/app/domains/products/models/deposit_product_statement_profile.rb
+++ b/app/domains/products/models/deposit_product_statement_profile.rb
@@ -4,6 +4,7 @@ module Products
   module Models
     class DepositProductStatementProfile < ApplicationRecord
       self.table_name = "deposit_product_statement_profiles"
+      attr_accessor :skip_effective_date_overlap_validation
 
       FREQUENCY_MONTHLY = "monthly"
       FREQUENCIES = [ FREQUENCY_MONTHLY ].freeze
@@ -24,6 +25,7 @@ module Products
       validates :effective_on, presence: true
       validate :ended_on_not_before_effective_on
       validate :currency_matches_deposit_product
+      validate :no_overlapping_active_monthly_profile
 
       private
 
@@ -39,6 +41,15 @@ module Products
         return if currency == deposit_product.currency
 
         errors.add(:currency, "must match deposit product currency")
+      end
+
+      def no_overlapping_active_monthly_profile
+        return if skip_effective_date_overlap_validation
+        return unless frequency == FREQUENCY_MONTHLY
+
+        return unless Services::EffectiveDatedResolver.overlap?(self, constraints: %i[deposit_product_id frequency])
+
+        errors.add(:effective_on, "overlaps an active monthly statement profile for this product")
       end
     end
   end

--- a/app/domains/products/queries/active_fee_rules.rb
+++ b/app/domains/products/queries/active_fee_rules.rb
@@ -7,14 +7,20 @@ module Products
         scope = Models::DepositProductFeeRule
           .includes(:deposit_product)
           .where(
-            fee_code: Models::DepositProductFeeRule::FEE_CODE_MONTHLY_MAINTENANCE,
-            status: Models::DepositProductFeeRule::STATUS_ACTIVE
+            fee_code: Models::DepositProductFeeRule::FEE_CODE_MONTHLY_MAINTENANCE
           )
-          .where("effective_on <= ?", business_date)
-          .where("ended_on IS NULL OR ended_on >= ?", business_date)
+        scope = Services::EffectiveDatedResolver.active_scope(scope, as_of: business_date)
           .order(:deposit_product_id, :effective_on, :id)
         scope = scope.where(deposit_product_id: deposit_product_id) if deposit_product_id.present?
         scope
+      end
+
+      def self.monthly_maintenance_for_product(business_date:, deposit_product_id:)
+        scope = Models::DepositProductFeeRule.where(
+          deposit_product_id: deposit_product_id,
+          fee_code: Models::DepositProductFeeRule::FEE_CODE_MONTHLY_MAINTENANCE
+        )
+        Services::EffectiveDatedResolver.resolve_one(scope, as_of: business_date)
       end
     end
   end

--- a/app/domains/products/queries/active_overdraft_policies.rb
+++ b/app/domains/products/queries/active_overdraft_policies.rb
@@ -7,18 +7,20 @@ module Products
         scope = Models::DepositProductOverdraftPolicy
           .includes(:deposit_product)
           .where(
-            mode: Models::DepositProductOverdraftPolicy::MODE_DENY_NSF,
-            status: Models::DepositProductOverdraftPolicy::STATUS_ACTIVE
+            mode: Models::DepositProductOverdraftPolicy::MODE_DENY_NSF
           )
-          .where("effective_on <= ?", business_date)
-          .where("ended_on IS NULL OR ended_on >= ?", business_date)
+        scope = Services::EffectiveDatedResolver.active_scope(scope, as_of: business_date)
           .order(:deposit_product_id, :effective_on, :id)
         scope = scope.where(deposit_product_id: deposit_product_id) if deposit_product_id.present?
         scope
       end
 
       def self.deny_nsf_for_product(business_date:, deposit_product_id:)
-        deny_nsf(business_date: business_date, deposit_product_id: deposit_product_id).last
+        scope = Models::DepositProductOverdraftPolicy.where(
+          deposit_product_id: deposit_product_id,
+          mode: Models::DepositProductOverdraftPolicy::MODE_DENY_NSF
+        )
+        Services::EffectiveDatedResolver.resolve_one(scope, as_of: business_date)
       end
     end
   end

--- a/app/domains/products/queries/active_statement_profiles.rb
+++ b/app/domains/products/queries/active_statement_profiles.rb
@@ -7,14 +7,20 @@ module Products
         scope = Models::DepositProductStatementProfile
           .includes(:deposit_product)
           .where(
-            frequency: Models::DepositProductStatementProfile::FREQUENCY_MONTHLY,
-            status: Models::DepositProductStatementProfile::STATUS_ACTIVE
+            frequency: Models::DepositProductStatementProfile::FREQUENCY_MONTHLY
           )
-          .where("effective_on <= ?", business_date)
-          .where("ended_on IS NULL OR ended_on >= ?", business_date)
+        scope = Services::EffectiveDatedResolver.active_scope(scope, as_of: business_date)
           .order(:deposit_product_id, :effective_on, :id)
         scope = scope.where(deposit_product_id: deposit_product_id) if deposit_product_id.present?
         scope
+      end
+
+      def self.monthly_for_product(business_date:, deposit_product_id:)
+        scope = Models::DepositProductStatementProfile.where(
+          deposit_product_id: deposit_product_id,
+          frequency: Models::DepositProductStatementProfile::FREQUENCY_MONTHLY
+        )
+        Services::EffectiveDatedResolver.resolve_one(scope, as_of: business_date)
       end
     end
   end

--- a/app/domains/products/services/deposit_product_resolver.rb
+++ b/app/domains/products/services/deposit_product_resolver.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Products
+  module Services
+    class DepositProductResolver
+      DepositBehavior = Data.define(
+        :deposit_product,
+        :monthly_maintenance_fee_rule,
+        :deny_nsf_policy,
+        :monthly_statement_profile
+      )
+
+      def self.call(as_of:, deposit_account: nil, deposit_product_id: nil)
+        product = resolve_product!(deposit_account: deposit_account, deposit_product_id: deposit_product_id)
+        product_id = product.id
+
+        DepositBehavior.new(
+          deposit_product: product,
+          monthly_maintenance_fee_rule: Queries::ActiveFeeRules.monthly_maintenance_for_product(
+            business_date: as_of,
+            deposit_product_id: product_id
+          ),
+          deny_nsf_policy: Queries::ActiveOverdraftPolicies.deny_nsf_for_product(
+            business_date: as_of,
+            deposit_product_id: product_id
+          ),
+          monthly_statement_profile: Queries::ActiveStatementProfiles.monthly_for_product(
+            business_date: as_of,
+            deposit_product_id: product_id
+          )
+        )
+      end
+
+      def self.resolve_product!(deposit_account:, deposit_product_id:)
+        if deposit_account
+          return deposit_account.deposit_product if deposit_account.respond_to?(:deposit_product)
+
+          return Models::DepositProduct.find(deposit_account.deposit_product_id)
+        end
+
+        raise ArgumentError, "deposit_account or deposit_product_id is required" if deposit_product_id.blank?
+
+        Models::DepositProduct.find(deposit_product_id)
+      end
+      private_class_method :resolve_product!
+    end
+  end
+end

--- a/app/domains/products/services/effective_dated_resolver.rb
+++ b/app/domains/products/services/effective_dated_resolver.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Products
+  module Services
+    module EffectiveDatedResolver
+      ACTIVE_STATUS = "active"
+
+      def self.active_scope(scope, as_of:)
+        on_date = as_of.to_date
+        scope
+          .where(status: ACTIVE_STATUS)
+          .where("effective_on <= ?", on_date)
+          .where("ended_on IS NULL OR ended_on >= ?", on_date)
+      end
+
+      def self.resolve_one(scope, as_of:)
+        active_scope(scope, as_of: as_of).order(effective_on: :desc, id: :desc).first
+      end
+
+      def self.overlap?(record, constraints:)
+        overlapping_active_scope(record, constraints: constraints).exists?
+      end
+
+      def self.overlapping_active_scope(record, constraints:)
+        return record.class.none unless active_record_with_window?(record)
+
+        scope = record.class.where(status: ACTIVE_STATUS)
+        constraints.each do |attribute|
+          value = record.public_send(attribute)
+          return record.class.none if value.blank?
+
+          scope = scope.where(attribute => value)
+        end
+
+        scope = scope.where.not(id: record.id) if record.persisted?
+        scope = scope.where("effective_on <= ?", record.ended_on) if record.ended_on.present?
+        scope.where("ended_on IS NULL OR ended_on >= ?", record.effective_on)
+      end
+
+      def self.active_record_with_window?(record)
+        record.status == ACTIVE_STATUS && record.effective_on.present?
+      end
+      private_class_method :active_record_with_window?
+    end
+  end
+end

--- a/docs/adr/0005-product-configuration-framework.md
+++ b/docs/adr/0005-product-configuration-framework.md
@@ -193,6 +193,15 @@ Product configurations MUST be versioned or otherwise auditable.
 * product-specific balance-basis rules  
 * promotional and time-bound configurations
 
+### 10.3 Phase 4.3 resolver baseline
+
+Phase 4.3 implements a narrow resolver baseline without completing the full profile framework:
+
+* `Products::Services::DepositProductResolver` exposes a stable per-product behavior contract for existing deposit behavior: monthly maintenance fee rule, deny-NSF overdraft policy, and monthly statement profile.
+* `Products::Services::EffectiveDatedResolver` centralizes active-on-date resolution: `status = active`, `effective_on <= as_of`, and `ended_on IS NULL OR ended_on >= as_of`.
+* Singular behavior families such as monthly maintenance rules, deny-NSF policies, and monthly statement profiles reject overlapping active windows at the model-validation layer.
+* Per-product GL mapping, reusable profile catalogs, product version migration, admin workflows, interest profile depth, and limit profile depth remain deferred until a selected channel or product requirement needs them.
+
 ---
 
 ## 11\. Related ADRs

--- a/docs/adr/0019-event-catalog-and-fee-events.md
+++ b/docs/adr/0019-event-catalog-and-fee-events.md
@@ -18,7 +18,7 @@
 ### 2.1 `Core::OperationalEvents::EventCatalog`
 
 - **Purpose:** machine-readable metadata for clients, tests, and drift checks—not a replacement for `operational_events.event_type` strings in the database.
-- **Contents:** each known `event_type` exposes at least: **`category`** (`financial` | `servicing` | `operational`), **`posts_to_gl`** (boolean), **`record_command`** (`RecordEvent` | `RecordControlEvent` | `PlaceHold` | `ReleaseHold` | `RecordReversal` | `other`), **`reversible_via_posting_reversal`** (boolean), **`compensating_event_type`** (nullable string; business compensator when not `posting.reversal`).
+- **Contents:** each known `event_type` exposes at least: **`category`** (`financial` | `servicing` | `operational`), **`posts_to_gl`** (boolean), **`record_command`** (`RecordEvent` | `RecordControlEvent` | `PlaceHold` | `ReleaseHold` | `RecordReversal` | `other`), **`reversible_via_posting_reversal`** (boolean), **`compensating_event_type`** (nullable string; business compensator when not `posting.reversal`). Phase 4.2 extends the same code-first catalog with lifecycle, allowed channel, financial-impact, customer/statement visibility, payload-schema, and support-search metadata so external channel planning does not create a second event semantics registry.
 - **HTTP:** **`GET /teller/event_types`** returns the catalog as JSON (operator auth per [ADR-0015](0015-teller-workspace-authentication.md); no supervisor gate, same posture as other teller reads).
 
 ### 2.2 Fee events (`fee.assessed`, `fee.waived`)

--- a/docs/operational_events/README.md
+++ b/docs/operational_events/README.md
@@ -14,7 +14,7 @@ Each spec uses the same headings so scans and diffs stay predictable:
 | Section | Purpose |
 | ------- | ------- |
 | **Summary** | One short paragraph: what business fact this row records. |
-| **Registry** | Canonical `event_type` string, category (financial / servicing / operational), MVP phase note. |
+| **Registry** | Canonical `event_type` string, category (financial / servicing / operational), MVP phase note, lifecycle, channel, visibility, payload schema, and support-search metadata. |
 | **Semantics** | Preconditions, postconditions, what must never happen. |
 | **Persistence** | Required and optional columns / FKs on `operational_events` (and related tables if this type owns rows elsewhere). |
 | **Lifecycle** | `pending` → `posted` (and any other allowed values); meaning of `posted` for non–GL-backed types. |
@@ -35,28 +35,37 @@ Every new **shipped** `event_type` must update these surfaces together before te
 - Add an entry to `Core::OperationalEvents::EventCatalog`.
 - Add a `PostingRules::Registry` handler when the event posts to GL.
 - Add or update the per-type spec in this directory, including the `## Registry` table.
-- Add or update the index row below so its `event_type` and GL posting columns match the catalog.
+- Add or update the index row below so its `event_type`, GL posting, command, lifecycle, channel, and visibility columns match the catalog.
+
+Catalog metadata fields:
+
+- **Lifecycle:** `pending_to_posted` means the event starts `pending` and is finalized by posting; `posted_immediately` means the command records durable business state without a GL posting step.
+- **Channels:** current producer channels allowed by the command path, such as `teller`, `branch`, `api`, `batch`, or `system`.
+- **Financial impact:** `gl_posting`, `optional_gl`, or `no_gl`.
+- **Customer visible / Statement visible:** eligibility for future customer-safe history and generated statement/history output after redaction and role checks.
+- **Payload schema:** stable reference to the per-type spec that describes required payload shape.
+- **Support search keys:** columns or references support/ops should be able to filter by as channel volume grows.
 
 ## Index
 
-| Spec | `event_type` | GL posting | Record command |
-| ---- | ------------ | ---------- | ---------------- |
-| [deposit-accepted.md](deposit-accepted.md) | `deposit.accepted` | Yes | `RecordEvent` |
-| [withdrawal-posted.md](withdrawal-posted.md) | `withdrawal.posted` | Yes | `RecordEvent` |
-| [transfer-completed.md](transfer-completed.md) | `transfer.completed` | Yes | `RecordEvent` |
-| [compensating-reversal.md](compensating-reversal.md) | `posting.reversal` | Yes | `RecordReversal` |
-| [hold-placed.md](hold-placed.md) | `hold.placed` | No | `Accounts::Commands::PlaceHold` |
-| [hold-released.md](hold-released.md) | `hold.released` | No | `Accounts::Commands::ReleaseHold` |
-| [teller-session-opened.md](teller-session-opened.md) | (table-first MVP; OE optional) | No | `Teller::Commands::OpenSession` |
-| [teller-session-closed.md](teller-session-closed.md) | (table-first MVP; OE optional) | No | `Teller::Commands::CloseSession` |
-| [override-requested.md](override-requested.md) | `override.requested` | No | `RecordControlEvent` |
-| [override-approved.md](override-approved.md) | `override.approved` | No | `RecordControlEvent` |
-| [overdraft-nsf-denied.md](overdraft-nsf-denied.md) | `overdraft.nsf_denied` | No | `RecordControlEvent` |
-| [fee-assessed.md](fee-assessed.md) | `fee.assessed` | Yes | `RecordEvent` |
-| [fee-waived.md](fee-waived.md) | `fee.waived` | Yes | `RecordEvent` |
-| [interest-accrued.md](interest-accrued.md) | `interest.accrued` | Yes | `RecordEvent` (`system` only; see [ADR-0021](../adr/0021-interest-accrual-and-payout-slice.md)) |
-| [interest-posted.md](interest-posted.md) | `interest.posted` | Yes | `RecordEvent` (`system` only; see [ADR-0021](../adr/0021-interest-accrual-and-payout-slice.md)) |
-| [teller-drawer-variance-posted.md](teller-drawer-variance-posted.md) | `teller.drawer.variance.posted` | Yes (optional flag) | `RecordEvent` (`system` only; see [ADR-0020](../adr/0020-teller-drawer-variance-gl-posting.md)) |
+| Spec | `event_type` | GL posting | Record command | Lifecycle | Channels | Customer visible | Statement visible |
+| ---- | ------------ | ---------- | -------------- | --------- | -------- | ---------------- | ----------------- |
+| [deposit-accepted.md](deposit-accepted.md) | `deposit.accepted` | Yes | `RecordEvent` | `pending_to_posted` | `teller`, `api`, `batch` | Yes | Yes |
+| [withdrawal-posted.md](withdrawal-posted.md) | `withdrawal.posted` | Yes | `RecordEvent` | `pending_to_posted` | `teller`, `api`, `batch` | Yes | Yes |
+| [transfer-completed.md](transfer-completed.md) | `transfer.completed` | Yes | `RecordEvent` | `pending_to_posted` | `teller`, `api`, `batch` | Yes | Yes |
+| [compensating-reversal.md](compensating-reversal.md) | `posting.reversal` | Yes | `RecordReversal` | `pending_to_posted` | `teller`, `branch`, `api`, `batch` | Yes | Yes |
+| [hold-placed.md](hold-placed.md) | `hold.placed` | No | `Accounts::Commands::PlaceHold` | `posted_immediately` | `teller`, `branch`, `api`, `batch` | Yes | Yes |
+| [hold-released.md](hold-released.md) | `hold.released` | No | `Accounts::Commands::ReleaseHold` | `posted_immediately` | `teller`, `branch`, `api`, `batch` | Yes | Yes |
+| [teller-session-opened.md](teller-session-opened.md) | (table-first MVP; OE optional) | No | `Teller::Commands::OpenSession` | n/a | `teller` | No | No |
+| [teller-session-closed.md](teller-session-closed.md) | (table-first MVP; OE optional) | No | `Teller::Commands::CloseSession` | n/a | `teller` | No | No |
+| [override-requested.md](override-requested.md) | `override.requested` | No | `RecordControlEvent` | `posted_immediately` | `teller`, `branch`, `batch` | No | No |
+| [override-approved.md](override-approved.md) | `override.approved` | No | `RecordControlEvent` | `posted_immediately` | `teller`, `branch`, `batch` | No | No |
+| [overdraft-nsf-denied.md](overdraft-nsf-denied.md) | `overdraft.nsf_denied` | No | `RecordControlEvent` | `posted_immediately` | `teller`, `api`, `batch` | Yes | Yes |
+| [fee-assessed.md](fee-assessed.md) | `fee.assessed` | Yes | `RecordEvent` | `pending_to_posted` | `teller`, `api`, `batch`, `system` | Yes | Yes |
+| [fee-waived.md](fee-waived.md) | `fee.waived` | Yes | `RecordEvent` | `pending_to_posted` | `teller`, `branch`, `api`, `batch` | Yes | Yes |
+| [interest-accrued.md](interest-accrued.md) | `interest.accrued` | Yes | `RecordEvent` | `pending_to_posted` | `system` | No | No |
+| [interest-posted.md](interest-posted.md) | `interest.posted` | Yes | `RecordEvent` | `pending_to_posted` | `system` | Yes | Yes |
+| [teller-drawer-variance-posted.md](teller-drawer-variance-posted.md) | `teller.drawer.variance.posted` | Yes (optional flag) | `RecordEvent` | `pending_to_posted` | `system` | No | No |
 
 **Teller JSON routes (workspace):** `POST /teller/operational_events`, `POST /teller/operational_events/:id/post`, `POST /teller/reversals`, `POST /teller/holds` (optional **`placed_for_operational_event_id`** on `hold` per [hold-placed.md](hold-placed.md) / [ADR-0013](../adr/0013-holds-available-and-servicing-events.md) §3), `POST /teller/holds/release`, `POST /teller/teller_sessions`, `POST /teller/teller_sessions/close`, `POST /teller/teller_sessions/approve_variance`, `POST /teller/overrides`, **`GET /teller/event_types`** ([ADR-0019](../adr/0019-event-catalog-and-fee-events.md)), **`GET /teller/operational_events`** ([ADR-0017](../adr/0017-deposit-products-fk-narrow-scope.md) §2.5), **`GET /teller/reports/trial_balance`**, **`GET /teller/reports/eod_readiness`** ([ADR-0016](../adr/0016-trial-balance-and-eod-readiness.md)) — see [config/routes.rb](../../config/routes.rb).
 

--- a/docs/operational_events/_template.md
+++ b/docs/operational_events/_template.md
@@ -13,6 +13,13 @@
 | **`event_type`** | `…` |
 | **Category** | Financial \| Servicing \| Operational |
 | **Phase** | Draft \| Phase 1 \| … |
+| **Lifecycle** | `pending_to_posted` \| `posted_immediately` |
+| **Allowed channels** | `teller`, `branch`, `api`, `batch`, `system` as applicable |
+| **Financial impact** | `gl_posting` \| `optional_gl` \| `no_gl` |
+| **Customer visible** | Yes \| No |
+| **Statement visible** | Yes \| No |
+| **Payload schema** | `docs/operational_events/<this-file>.md` |
+| **Support search keys** | `source_account_id`, `reference_id`, `actor_id`, etc. |
 
 ## Semantics
 

--- a/docs/operational_events/compensating-reversal.md
+++ b/docs/operational_events/compensating-reversal.md
@@ -18,6 +18,13 @@ Implementation uses a **generic** `posting.reversal` plus `Core::OperationalEven
 | **`event_type`** | **`posting.reversal`** — generic compensating row; original id in **`reversal_of_event_id`**. |
 | **Category** | Financial (produces GL) |
 | **Phase** | Phase 1 (reversal path + linkage + two journals). |
+| **Lifecycle** | `pending_to_posted` |
+| **Allowed channels** | `teller`, `branch`, `api`, `batch` |
+| **Financial impact** | `gl_posting` |
+| **Customer visible** | Yes |
+| **Statement visible** | Yes |
+| **Payload schema** | `docs/operational_events/compensating-reversal.md` |
+| **Support search keys** | `source_account_id`, `destination_account_id`, `reversal_of_event_id`, `actor_id` |
 
 ## Semantics
 

--- a/docs/operational_events/deposit-accepted.md
+++ b/docs/operational_events/deposit-accepted.md
@@ -11,6 +11,13 @@ Records that the institution **accepted** a cash deposit and intends to **credit
 | **`event_type`** | `deposit.accepted` |
 | **Category** | Financial (ADR-0002 §5.1) |
 | **Phase** | Implemented; **`actor_id`** on teller JSON per [ADR-0015](../adr/0015-teller-workspace-authentication.md). **`teller_session_id`** required for teller-channel cash when [ADR-0014](../adr/0014-teller-sessions-and-control-events.md) gate is on. |
+| **Lifecycle** | `pending_to_posted` |
+| **Allowed channels** | `teller`, `api`, `batch` |
+| **Financial impact** | `gl_posting` |
+| **Customer visible** | Yes |
+| **Statement visible** | Yes |
+| **Payload schema** | `docs/operational_events/deposit-accepted.md` |
+| **Support search keys** | `source_account_id`, `actor_id`, `teller_session_id` |
 
 ## Semantics
 

--- a/docs/operational_events/fee-assessed.md
+++ b/docs/operational_events/fee-assessed.md
@@ -11,6 +11,13 @@ Records a **deposit service charge** assessed to a demand deposit account (`sour
 | **`event_type`** | `fee.assessed` |
 | **Category** | Financial |
 | **Phase** | Implemented ([ADR-0019](../adr/0019-event-catalog-and-fee-events.md)). |
+| **Lifecycle** | `pending_to_posted` |
+| **Allowed channels** | `teller`, `api`, `batch`, `system` |
+| **Financial impact** | `gl_posting` |
+| **Customer visible** | Yes |
+| **Statement visible** | Yes |
+| **Payload schema** | `docs/operational_events/fee-assessed.md` |
+| **Support search keys** | `source_account_id`, `reference_id`, `actor_id` |
 
 ## Semantics
 

--- a/docs/operational_events/fee-waived.md
+++ b/docs/operational_events/fee-waived.md
@@ -11,6 +11,13 @@ Records a **full waiver** of a previously **posted** `fee.assessed` for the same
 | **`event_type`** | `fee.waived` |
 | **Category** | Financial |
 | **Phase** | Implemented ([ADR-0019](../adr/0019-event-catalog-and-fee-events.md)). |
+| **Lifecycle** | `pending_to_posted` |
+| **Allowed channels** | `teller`, `branch`, `api`, `batch` |
+| **Financial impact** | `gl_posting` |
+| **Customer visible** | Yes |
+| **Statement visible** | Yes |
+| **Payload schema** | `docs/operational_events/fee-waived.md` |
+| **Support search keys** | `source_account_id`, `reference_id`, `actor_id` |
 
 ## Semantics
 

--- a/docs/operational_events/hold-placed.md
+++ b/docs/operational_events/hold-placed.md
@@ -11,6 +11,13 @@ Records that an **active hold** was applied against a deposit account so **avail
 | **`event_type`** | `hold.placed` |
 | **Category** | Servicing (ADR-0002 §5.2) |
 | **Phase** | Phase 1 (spec; `holds` table ownership to confirm in implementation ADR). |
+| **Lifecycle** | `posted_immediately` |
+| **Allowed channels** | `teller`, `branch`, `api`, `batch` |
+| **Financial impact** | `no_gl` |
+| **Customer visible** | Yes |
+| **Statement visible** | Yes |
+| **Payload schema** | `docs/operational_events/hold-placed.md` |
+| **Support search keys** | `source_account_id`, `actor_id`, `reference_id` |
 
 ## Semantics
 

--- a/docs/operational_events/hold-released.md
+++ b/docs/operational_events/hold-released.md
@@ -11,6 +11,13 @@ Records that a previously **active** hold against a deposit account was **releas
 | **`event_type`** | `hold.released` |
 | **Category** | Servicing (ADR-0002 §5.2) |
 | **Phase** | Phase 1 (spec). |
+| **Lifecycle** | `posted_immediately` |
+| **Allowed channels** | `teller`, `branch`, `api`, `batch` |
+| **Financial impact** | `no_gl` |
+| **Customer visible** | Yes |
+| **Statement visible** | Yes |
+| **Payload schema** | `docs/operational_events/hold-released.md` |
+| **Support search keys** | `source_account_id`, `reference_id`, `actor_id` |
 
 ## Semantics
 

--- a/docs/operational_events/interest-accrued.md
+++ b/docs/operational_events/interest-accrued.md
@@ -11,6 +11,13 @@ Records ledger-recognized deposit interest expense and accrued payable for one d
 | **`event_type`** | `interest.accrued` |
 | **Category** | Financial |
 | **Phase** | P3-2 first vertical slice ([ADR-0021](../adr/0021-interest-accrual-and-payout-slice.md)). |
+| **Lifecycle** | `pending_to_posted` |
+| **Allowed channels** | `system` |
+| **Financial impact** | `gl_posting` |
+| **Customer visible** | No |
+| **Statement visible** | No |
+| **Payload schema** | `docs/operational_events/interest-accrued.md` |
+| **Support search keys** | `source_account_id`, `reference_id` |
 
 ## Semantics
 

--- a/docs/operational_events/interest-posted.md
+++ b/docs/operational_events/interest-posted.md
@@ -11,6 +11,13 @@ Records full payout of a posted `interest.accrued` event into the customer DDA. 
 | **`event_type`** | `interest.posted` |
 | **Category** | Financial |
 | **Phase** | P3-2 first vertical slice ([ADR-0021](../adr/0021-interest-accrual-and-payout-slice.md)). |
+| **Lifecycle** | `pending_to_posted` |
+| **Allowed channels** | `system` |
+| **Financial impact** | `gl_posting` |
+| **Customer visible** | Yes |
+| **Statement visible** | Yes |
+| **Payload schema** | `docs/operational_events/interest-posted.md` |
+| **Support search keys** | `source_account_id`, `reference_id` |
 
 ## Semantics
 

--- a/docs/operational_events/overdraft-nsf-denied.md
+++ b/docs/operational_events/overdraft-nsf-denied.md
@@ -11,6 +11,13 @@ Records that an attempted withdrawal or transfer was denied because available ba
 | **`event_type`** | `overdraft.nsf_denied` |
 | **Category** | Operational |
 | **Phase** | P3-4 first vertical slice ([ADR-0023](../adr/0023-overdraft-nsf-deny-and-fee.md)). |
+| **Lifecycle** | `posted_immediately` |
+| **Allowed channels** | `teller`, `api`, `batch` |
+| **Financial impact** | `no_gl` |
+| **Customer visible** | Yes |
+| **Statement visible** | Yes |
+| **Payload schema** | `docs/operational_events/overdraft-nsf-denied.md` |
+| **Support search keys** | `source_account_id`, `destination_account_id`, `reference_id`, `actor_id` |
 
 ## Semantics
 

--- a/docs/operational_events/override-approved.md
+++ b/docs/operational_events/override-approved.md
@@ -11,6 +11,13 @@ Records that a **supervisor** (or role with equivalent authority) **approved** a
 | **`event_type`** | `override.approved` |
 | **Category** | Operational (ADR-0002 §5.3) |
 | **Phase** | Optional Phase 1 (supervisor gates for variance / reversal). |
+| **Lifecycle** | `posted_immediately` |
+| **Allowed channels** | `teller`, `branch`, `batch` |
+| **Financial impact** | `no_gl` |
+| **Customer visible** | No |
+| **Statement visible** | No |
+| **Payload schema** | `docs/operational_events/override-approved.md` |
+| **Support search keys** | `reference_id`, `actor_id` |
 
 ## Semantics
 

--- a/docs/operational_events/override-requested.md
+++ b/docs/operational_events/override-requested.md
@@ -11,6 +11,13 @@ Records that an operator **requested** an exception to normal policy (e.g. large
 | **`event_type`** | `override.requested` |
 | **Category** | Operational (ADR-0002 §5.3) |
 | **Phase** | Optional Phase 1; use when you need a durable request row separate from RBAC logs. |
+| **Lifecycle** | `posted_immediately` |
+| **Allowed channels** | `teller`, `branch`, `batch` |
+| **Financial impact** | `no_gl` |
+| **Customer visible** | No |
+| **Statement visible** | No |
+| **Payload schema** | `docs/operational_events/override-requested.md` |
+| **Support search keys** | `reference_id`, `actor_id` |
 
 ## Semantics
 

--- a/docs/operational_events/teller-drawer-variance-posted.md
+++ b/docs/operational_events/teller-drawer-variance-posted.md
@@ -11,6 +11,13 @@ Records a **GL-only adjustment** for **non-zero teller drawer cash variance** wh
 | **`event_type`** | `teller.drawer.variance.posted` |
 | **Category** | financial |
 | **Phase** | Optional Phase 2 (product flag) |
+| **Lifecycle** | `pending_to_posted` |
+| **Allowed channels** | `system` |
+| **Financial impact** | `optional_gl` |
+| **Customer visible** | No |
+| **Statement visible** | No |
+| **Payload schema** | `docs/operational_events/teller-drawer-variance-posted.md` |
+| **Support search keys** | `teller_session_id`, `reference_id` |
 
 ## Semantics
 

--- a/docs/operational_events/transfer-completed.md
+++ b/docs/operational_events/transfer-completed.md
@@ -11,6 +11,13 @@ Records an **internal transfer** of funds between two deposit accounts (same ins
 | **`event_type`** | `transfer.completed` |
 | **Category** | Financial (ADR-0002 §5.1) |
 | **Phase** | Phase 1 (spec ahead of implementation). |
+| **Lifecycle** | `pending_to_posted` |
+| **Allowed channels** | `teller`, `api`, `batch` |
+| **Financial impact** | `gl_posting` |
+| **Customer visible** | Yes |
+| **Statement visible** | Yes |
+| **Payload schema** | `docs/operational_events/transfer-completed.md` |
+| **Support search keys** | `source_account_id`, `destination_account_id`, `actor_id` |
 
 ## Semantics
 

--- a/docs/operational_events/withdrawal-posted.md
+++ b/docs/operational_events/withdrawal-posted.md
@@ -13,6 +13,13 @@ Records that the institution **disbursed cash** to the customer and **debited** 
 | **`event_type`** | `withdrawal.posted` |
 | **Category** | Financial |
 | **Phase** | Phase 1 (spec ahead of implementation). |
+| **Lifecycle** | `pending_to_posted` |
+| **Allowed channels** | `teller`, `api`, `batch` |
+| **Financial impact** | `gl_posting` |
+| **Customer visible** | Yes |
+| **Statement visible** | Yes |
+| **Payload schema** | `docs/operational_events/withdrawal-posted.md` |
+| **Support search keys** | `source_account_id`, `actor_id`, `teller_session_id` |
 
 ## Semantics
 

--- a/docs/roadmap-deferred-completion.md
+++ b/docs/roadmap-deferred-completion.md
@@ -28,19 +28,19 @@ These capabilities will make multiple deferred tracks easier to complete.
 
 ### 2.1 Product Resolver Depth
 
-Current state: the narrow Products slice is shipped: `deposit_products`, `deposit_accounts.deposit_product_id`, cached `product_code`, product-aware operational-event reads, product-owned fee rules, overdraft policies, and statement profiles. Full ADR-0005 resolver depth and per-product GL mapping remain deferred.
+Current state: the narrow Products slice is shipped: `deposit_products`, `deposit_accounts.deposit_product_id`, cached `product_code`, product-aware operational-event reads, product-owned fee rules, overdraft policies, statement profiles, and the Phase 4.3 resolver baseline (`Products::Services::DepositProductResolver` plus shared effective-dated resolution helpers). Full ADR-0005 profile depth and per-product GL mapping remain deferred.
 
 To complete:
 
-- Define stable resolver contracts for product behavior: interest, fees, overdraft, statement cycles, limits, and GL mapping.
+- Extend stable resolver contracts for product behavior beyond the Phase 4.3 baseline: interest, limits, richer fees, and GL mapping.
 - Decide whether profiles are directly product-owned tables, reusable profile tables, or a hybrid.
-- Add effective-dated conflict rules so only one active behavior applies for a product/date where exclusivity is required.
+- Add database-backed effective-dated conflict rules if model-level overlap validation is not sufficient at scale.
 - Move remaining hardcoded behavior to resolver-backed decisions only when the resolver has tests and clear fallback semantics.
 
 Likely slices:
 
-- Product resolver contract ADR.
-- Shared effective-dated resolver helpers under `Products`.
+- Broader product resolver ADR if the next slice changes product versioning or GL mapping semantics.
+- Reusable profile-table design for behavior families that outgrow direct product-owned tables.
 - Per-product GL mapping profile for existing event types.
 - Migration path from current narrow rule tables to reusable profiles, if needed.
 
@@ -103,18 +103,18 @@ Likely slices:
 
 ### 3.2 Full Product Configuration
 
-Shipped narrow slice: `deposit_products` and `deposit_accounts.deposit_product_id` are in place, with cached `product_code` and narrow product-owned rule tables for fees, overdraft policy, and statement profiles. The current product model is intentionally narrower than ADR-0005's full resolver framework.
+Shipped narrow slice: `deposit_products` and `deposit_accounts.deposit_product_id` are in place, with cached `product_code`, narrow product-owned rule tables for fees, overdraft policy, and statement profiles, and a Phase 4.3 Products-owned resolver baseline over those tables. The current product model is intentionally narrower than ADR-0005's full resolver framework.
 
 To complete:
 
-- Implement ADR-0005 resolver contracts across product behavior.
+- Extend ADR-0005 resolver contracts beyond the shipped deposit behavior baseline.
 - Add reusable profiles or rule tables for interest, fees, limits, overdraft, statements, and GL mapping.
 - Define product versioning: when a product change affects new accounts only versus existing accounts.
 - Add admin/ops workflows for activating, retiring, and validating products.
 
 Likely slices:
 
-- Product resolver ADR and shared resolver conventions.
+- Product resolver ADR only when resolver semantics expand into versioning, GL mapping, or new behavior families.
 - Product version/effective-dating constraints.
 - Product validation command that verifies all required active profiles.
 - Per-product GL mapping for existing deposit event types.

--- a/test/domains/core/operational_events/event_catalog_test.rb
+++ b/test/domains/core/operational_events/event_catalog_test.rb
@@ -46,6 +46,44 @@ class CoreOperationalEventsEventCatalogTest < ActiveSupport::TestCase
     assert_equal event_types.uniq, event_types, "EventCatalog contains duplicate event_type values"
   end
 
+  test "catalog entries declare required channel metadata" do
+    valid_lifecycles = %w[pending_to_posted posted_immediately]
+    valid_financial_impacts = %w[gl_posting optional_gl no_gl]
+    valid_channels = Core::OperationalEvents::Commands::RecordEvent::CHANNELS
+
+    Core::OperationalEvents::EventCatalog.all_entries.each do |entry|
+      assert_includes valid_lifecycles, entry.lifecycle, "invalid lifecycle for #{entry.event_type}"
+      assert entry.allowed_channels.present?, "missing allowed_channels for #{entry.event_type}"
+      assert_empty entry.allowed_channels - valid_channels, "invalid allowed_channels for #{entry.event_type}"
+      assert_includes valid_financial_impacts, entry.financial_impact, "invalid financial_impact for #{entry.event_type}"
+      assert_includes [ true, false ], entry.customer_visible, "customer_visible must be explicit for #{entry.event_type}"
+      assert_includes [ true, false ], entry.statement_visible, "statement_visible must be explicit for #{entry.event_type}"
+      assert entry.payload_schema.present?, "missing payload_schema for #{entry.event_type}"
+      assert entry.support_search_keys.present?, "missing support_search_keys for #{entry.event_type}"
+    end
+  end
+
+  test "catalog financial impact is consistent with GL posting flag" do
+    Core::OperationalEvents::EventCatalog.all_entries.each do |entry|
+      if entry.posts_to_gl
+        assert_includes %w[gl_posting optional_gl], entry.financial_impact,
+          "GL-backed #{entry.event_type} must be gl_posting or optional_gl"
+      else
+        assert_equal "no_gl", entry.financial_impact,
+          "no-GL #{entry.event_type} must declare no_gl financial impact"
+      end
+    end
+  end
+
+  test "catalog visibility and channel helpers return event types" do
+    assert_includes Core::OperationalEvents::EventCatalog.statement_visible_event_types, "hold.placed"
+    assert_not_includes Core::OperationalEvents::EventCatalog.statement_visible_event_types, "interest.accrued"
+    assert_equal %w[hold.placed hold.released overdraft.nsf_denied],
+      Core::OperationalEvents::EventCatalog.statement_visible_no_gl_event_types
+    assert_includes Core::OperationalEvents::EventCatalog.customer_visible_event_types, "fee.assessed"
+    assert_includes Core::OperationalEvents::EventCatalog.event_types_for_channel("branch"), "fee.waived"
+  end
+
   test "every GL-backed catalog entry has posting registry handler" do
     Core::OperationalEvents::EventCatalog.all_entries.each do |entry|
       next unless entry.posts_to_gl
@@ -103,6 +141,48 @@ class CoreOperationalEventsEventCatalogTest < ActiveSupport::TestCase
     end
   end
 
+  test "docs index metadata columns match EventCatalog" do
+    rows_by_type = readme_index_rows_by_event_type
+
+    Core::OperationalEvents::EventCatalog.all_entries.each do |entry|
+      row = rows_by_type.fetch(entry.event_type)
+
+      assert row.fetch(:record_command).include?(entry.record_command),
+        "README record command for #{entry.event_type} should include #{entry.record_command}"
+      assert_equal entry.lifecycle, extract_backticked_value(row.fetch(:lifecycle)),
+        "README lifecycle mismatch for #{entry.event_type}"
+      assert_equal entry.allowed_channels, extract_backticked_values(row.fetch(:channels)),
+        "README channels mismatch for #{entry.event_type}"
+      assert_equal yes_no(entry.customer_visible), row.fetch(:customer_visible),
+        "README customer visibility mismatch for #{entry.event_type}"
+      assert_equal yes_no(entry.statement_visible), row.fetch(:statement_visible),
+        "README statement visibility mismatch for #{entry.event_type}"
+    end
+  end
+
+  test "catalog specs declare metadata matching EventCatalog" do
+    rows_by_type = readme_index_rows_by_event_type
+
+    Core::OperationalEvents::EventCatalog.all_entries.each do |entry|
+      values = spec_registry_values(rows_by_type.fetch(entry.event_type).fetch(:path))
+
+      assert_equal entry.lifecycle, extract_backticked_value(values.fetch("Lifecycle")),
+        "spec lifecycle mismatch for #{entry.event_type}"
+      assert_equal entry.allowed_channels, extract_backticked_values(values.fetch("Allowed channels")),
+        "spec allowed channels mismatch for #{entry.event_type}"
+      assert_equal entry.financial_impact, extract_backticked_value(values.fetch("Financial impact")),
+        "spec financial impact mismatch for #{entry.event_type}"
+      assert_equal yes_no(entry.customer_visible), values.fetch("Customer visible"),
+        "spec customer visibility mismatch for #{entry.event_type}"
+      assert_equal yes_no(entry.statement_visible), values.fetch("Statement visible"),
+        "spec statement visibility mismatch for #{entry.event_type}"
+      assert_equal entry.payload_schema, extract_backticked_value(values.fetch("Payload schema")),
+        "spec payload schema mismatch for #{entry.event_type}"
+      assert_equal entry.support_search_keys, extract_backticked_values(values.fetch("Support search keys")),
+        "spec support search keys mismatch for #{entry.event_type}"
+    end
+  end
+
   test "non-catalog operational event docs are explicitly allowed" do
     catalog_spec_files = readme_index_rows_by_event_type.values.map { |row| row.fetch(:path) }
     indexed_spec_files = readme_index_rows.map { |row| row.fetch(:path) }
@@ -135,24 +215,23 @@ class CoreOperationalEventsEventCatalogTest < ActiveSupport::TestCase
   end
 
   def parse_readme_index_row(line)
-    match = line.match(/\|\s*\[[^\]]+\]\(([^)]+)\)\s*\|\s*(.*?)\s*\|\s*(.*?)\s*\|\s*(.*?)\s*\|/)
-    return unless match
+    cells = line.split("|").map(&:strip)
+    return unless cells.length >= 9 && cells[1].start_with?("[")
 
     {
-      path: match[1],
-      event_type: extract_backticked_value(match[2]),
-      gl_posting: match[3].strip,
-      record_command: match[4].strip
+      path: cells[1].match(/\[[^\]]+\]\(([^)]+)\)/)&.[](1),
+      event_type: extract_backticked_value(cells[2]),
+      gl_posting: cells[3],
+      record_command: cells[4],
+      lifecycle: cells[5],
+      channels: cells[6],
+      customer_visible: cells[7],
+      statement_visible: cells[8]
     }
   end
 
   def spec_registry_event_type(relative_path)
-    content = File.read(spec_path(relative_path))
-    registry_section = content.split("## Registry", 2).fetch(1, "")
-    row = registry_section.lines.find { |line| line.include?("**`event_type`**") }
-    value_cell = row&.split("|")&.[](2)
-
-    extract_backticked_value(value_cell.to_s)
+    extract_backticked_value(spec_registry_values(relative_path).fetch("event_type", ""))
   end
 
   def spec_path(relative_path)
@@ -161,5 +240,28 @@ class CoreOperationalEventsEventCatalogTest < ActiveSupport::TestCase
 
   def extract_backticked_value(value)
     value.match(/`([^`]+)`/)&.[](1)
+  end
+
+  def extract_backticked_values(value)
+    value.scan(/`([^`]+)`/).flatten
+  end
+
+  def spec_registry_values(relative_path)
+    content = File.read(spec_path(relative_path))
+    registry_section = content.split("## Registry", 2).fetch(1, "").split(/^## /, 2).first
+
+    registry_section.lines.each_with_object({}) do |line, memo|
+      next unless line.start_with?("|")
+
+      cells = line.split("|").map(&:strip)
+      next unless cells.length >= 3
+
+      label = cells[1].gsub("*", "").gsub("`", "").strip
+      memo[label] = cells[2]
+    end
+  end
+
+  def yes_no(value)
+    value ? "Yes" : "No"
   end
 end

--- a/test/domains/products/active_fee_rules_test.rb
+++ b/test/domains/products/active_fee_rules_test.rb
@@ -9,10 +9,10 @@ class ProductsActiveFeeRulesTest < ActiveSupport::TestCase
   end
 
   test "returns active monthly maintenance rules effective on date" do
-    active = create_rule!(@product, effective_on: Date.new(2026, 4, 1))
+    active = create_rule!(@product, effective_on: Date.new(2026, 4, 1), ended_on: Date.new(2026, 4, 30))
     create_rule!(@product, status: Products::Models::DepositProductFeeRule::STATUS_INACTIVE)
     create_rule!(@product, effective_on: Date.new(2026, 5, 1))
-    create_rule!(@product, effective_on: Date.new(2026, 3, 1), ended_on: Date.new(2026, 4, 20))
+    create_rule!(@product, effective_on: Date.new(2026, 3, 1), ended_on: Date.new(2026, 3, 31))
 
     rules = Products::Queries::ActiveFeeRules.monthly_maintenance(
       business_date: Date.new(2026, 4, 22),
@@ -20,6 +20,18 @@ class ProductsActiveFeeRulesTest < ActiveSupport::TestCase
     )
 
     assert_equal [ active.id ], rules.map(&:id)
+  end
+
+  test "resolves one monthly maintenance rule for product" do
+    create_rule!(@product, effective_on: Date.new(2026, 4, 1), ended_on: Date.new(2026, 4, 30))
+    future = create_rule!(@product, effective_on: Date.new(2026, 5, 1))
+
+    rule = Products::Queries::ActiveFeeRules.monthly_maintenance_for_product(
+      business_date: Date.new(2026, 5, 15),
+      deposit_product_id: @product.id
+    )
+
+    assert_equal future, rule
   end
 
   test "filters by deposit product" do

--- a/test/domains/products/active_overdraft_policies_test.rb
+++ b/test/domains/products/active_overdraft_policies_test.rb
@@ -9,10 +9,10 @@ class ProductsActiveOverdraftPoliciesTest < ActiveSupport::TestCase
   end
 
   test "returns active deny NSF policies effective on date" do
-    active = create_policy!(@product, effective_on: Date.new(2026, 4, 1))
+    active = create_policy!(@product, effective_on: Date.new(2026, 4, 1), ended_on: Date.new(2026, 4, 30))
     create_policy!(@product, status: Products::Models::DepositProductOverdraftPolicy::STATUS_INACTIVE)
     create_policy!(@product, effective_on: Date.new(2026, 5, 1))
-    create_policy!(@product, effective_on: Date.new(2026, 3, 1), ended_on: Date.new(2026, 4, 20))
+    create_policy!(@product, effective_on: Date.new(2026, 3, 1), ended_on: Date.new(2026, 3, 31))
 
     policies = Products::Queries::ActiveOverdraftPolicies.deny_nsf(
       business_date: Date.new(2026, 4, 22),
@@ -20,6 +20,18 @@ class ProductsActiveOverdraftPoliciesTest < ActiveSupport::TestCase
     )
 
     assert_equal [ active.id ], policies.map(&:id)
+  end
+
+  test "resolves one deny NSF policy for product" do
+    create_policy!(@product, effective_on: Date.new(2026, 4, 1), ended_on: Date.new(2026, 4, 30))
+    future = create_policy!(@product, effective_on: Date.new(2026, 5, 1))
+
+    policy = Products::Queries::ActiveOverdraftPolicies.deny_nsf_for_product(
+      business_date: Date.new(2026, 5, 15),
+      deposit_product_id: @product.id
+    )
+
+    assert_equal future, policy
   end
 
   test "filters by deposit product" do

--- a/test/domains/products/active_statement_profiles_test.rb
+++ b/test/domains/products/active_statement_profiles_test.rb
@@ -9,7 +9,7 @@ class ProductsActiveStatementProfilesTest < ActiveSupport::TestCase
   end
 
   test "returns active monthly profiles effective on business date" do
-    active = create_profile!(@product, effective_on: Date.new(2026, 4, 1))
+    active = create_profile!(@product, effective_on: Date.new(2026, 4, 1), ended_on: Date.new(2026, 4, 30))
     create_profile!(@product, effective_on: Date.new(2026, 5, 1))
     create_profile!(@product, status: Products::Models::DepositProductStatementProfile::STATUS_INACTIVE)
     create_profile!(@product, effective_on: Date.new(2026, 3, 1), ended_on: Date.new(2026, 3, 31))
@@ -18,6 +18,18 @@ class ProductsActiveStatementProfilesTest < ActiveSupport::TestCase
 
     assert_includes profiles, active
     assert_equal 1, profiles.count { |p| p.deposit_product_id == @product.id }
+  end
+
+  test "resolves one monthly statement profile for product" do
+    create_profile!(@product, effective_on: Date.new(2026, 4, 1), ended_on: Date.new(2026, 4, 30))
+    future = create_profile!(@product, effective_on: Date.new(2026, 5, 1))
+
+    profile = Products::Queries::ActiveStatementProfiles.monthly_for_product(
+      business_date: Date.new(2026, 5, 15),
+      deposit_product_id: @product.id
+    )
+
+    assert_equal future, profile
   end
 
   test "product filter limits profiles" do

--- a/test/domains/products/deposit_product_fee_rule_test.rb
+++ b/test/domains/products/deposit_product_fee_rule_test.rb
@@ -49,6 +49,21 @@ class ProductsDepositProductFeeRuleTest < ActiveSupport::TestCase
     assert_includes rule.errors[:currency], "must match deposit product currency"
   end
 
+  test "rejects overlapping active monthly maintenance rule" do
+    build_rule(effective_on: Date.new(2026, 4, 1), ended_on: Date.new(2026, 4, 30)).save!
+    rule = build_rule(effective_on: Date.new(2026, 4, 15))
+
+    assert_not rule.valid?
+    assert_includes rule.errors[:effective_on], "overlaps an active monthly maintenance rule for this product"
+  end
+
+  test "allows adjacent active monthly maintenance rule" do
+    build_rule(effective_on: Date.new(2026, 4, 1), ended_on: Date.new(2026, 4, 30)).save!
+    rule = build_rule(effective_on: Date.new(2026, 5, 1))
+
+    assert_predicate rule, :valid?
+  end
+
   private
 
   def build_rule(attrs = {})

--- a/test/domains/products/deposit_product_overdraft_policy_test.rb
+++ b/test/domains/products/deposit_product_overdraft_policy_test.rb
@@ -41,6 +41,21 @@ class ProductsDepositProductOverdraftPolicyTest < ActiveSupport::TestCase
     assert_includes policy.errors[:currency], "must match deposit product currency"
   end
 
+  test "rejects overlapping active deny NSF policy" do
+    build_policy(effective_on: Date.new(2026, 4, 1), ended_on: Date.new(2026, 4, 30)).save!
+    policy = build_policy(effective_on: Date.new(2026, 4, 15))
+
+    assert_not policy.valid?
+    assert_includes policy.errors[:effective_on], "overlaps an active deny NSF policy for this product"
+  end
+
+  test "allows adjacent active deny NSF policy" do
+    build_policy(effective_on: Date.new(2026, 4, 1), ended_on: Date.new(2026, 4, 30)).save!
+    policy = build_policy(effective_on: Date.new(2026, 5, 1))
+
+    assert_predicate policy, :valid?
+  end
+
   private
 
   def build_policy(attrs = {})

--- a/test/domains/products/deposit_product_resolver_test.rb
+++ b/test/domains/products/deposit_product_resolver_test.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ProductsDepositProductResolverTest < ActiveSupport::TestCase
+  setup do
+    Core::BusinessDate::Models::BusinessDateSetting.delete_all
+    Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.new(2026, 4, 22))
+    @product = create_product!("resolver")
+    @account = open_account!(@product)
+  end
+
+  test "resolves deposit behavior for account and date" do
+    fee_rule = create_fee_rule!(@product)
+    overdraft_policy = create_overdraft_policy!(@product)
+    statement_profile = create_statement_profile!(@product)
+
+    behavior = Products::Services::DepositProductResolver.call(
+      deposit_account: @account,
+      as_of: Date.new(2026, 4, 22)
+    )
+
+    assert_equal @product, behavior.deposit_product
+    assert_equal fee_rule, behavior.monthly_maintenance_fee_rule
+    assert_equal overdraft_policy, behavior.deny_nsf_policy
+    assert_equal statement_profile, behavior.monthly_statement_profile
+  end
+
+  test "resolves nil behavior when product rows are not active" do
+    create_fee_rule!(@product, effective_on: Date.new(2026, 5, 1))
+    create_overdraft_policy!(@product, status: Products::Models::DepositProductOverdraftPolicy::STATUS_INACTIVE)
+    create_statement_profile!(@product, effective_on: Date.new(2026, 3, 1), ended_on: Date.new(2026, 3, 31))
+
+    behavior = Products::Services::DepositProductResolver.call(
+      deposit_product_id: @product.id,
+      as_of: Date.new(2026, 4, 22)
+    )
+
+    assert_equal @product, behavior.deposit_product
+    assert_nil behavior.monthly_maintenance_fee_rule
+    assert_nil behavior.deny_nsf_policy
+    assert_nil behavior.monthly_statement_profile
+  end
+
+  test "requires account or product id" do
+    assert_raises(ArgumentError) do
+      Products::Services::DepositProductResolver.call(as_of: Date.new(2026, 4, 22))
+    end
+  end
+
+  private
+
+  def create_product!(prefix)
+    Products::Models::DepositProduct.create!(
+      product_code: "#{prefix}-#{SecureRandom.hex(4)}",
+      name: prefix,
+      status: Products::Models::DepositProduct::STATUS_ACTIVE,
+      currency: "USD"
+    )
+  end
+
+  def open_account!(product)
+    party = Party::Commands::CreateParty.call(
+      party_type: "individual",
+      first_name: "Resolver",
+      last_name: SecureRandom.hex(3)
+    )
+    Accounts::Commands::OpenAccount.call(party_record_id: party.id, deposit_product_id: product.id)
+  end
+
+  def create_fee_rule!(product, attrs = {})
+    Products::Models::DepositProductFeeRule.create!({
+      deposit_product: product,
+      fee_code: Products::Models::DepositProductFeeRule::FEE_CODE_MONTHLY_MAINTENANCE,
+      amount_minor_units: 500,
+      currency: "USD",
+      status: Products::Models::DepositProductFeeRule::STATUS_ACTIVE,
+      effective_on: Date.new(2026, 4, 1)
+    }.merge(attrs))
+  end
+
+  def create_overdraft_policy!(product, attrs = {})
+    Products::Models::DepositProductOverdraftPolicy.create!({
+      deposit_product: product,
+      mode: Products::Models::DepositProductOverdraftPolicy::MODE_DENY_NSF,
+      nsf_fee_minor_units: 3_500,
+      currency: "USD",
+      status: Products::Models::DepositProductOverdraftPolicy::STATUS_ACTIVE,
+      effective_on: Date.new(2026, 4, 1)
+    }.merge(attrs))
+  end
+
+  def create_statement_profile!(product, attrs = {})
+    Products::Models::DepositProductStatementProfile.create!({
+      deposit_product: product,
+      frequency: Products::Models::DepositProductStatementProfile::FREQUENCY_MONTHLY,
+      cycle_day: 1,
+      currency: "USD",
+      status: Products::Models::DepositProductStatementProfile::STATUS_ACTIVE,
+      effective_on: Date.new(2026, 4, 1)
+    }.merge(attrs))
+  end
+end

--- a/test/domains/products/deposit_product_statement_profile_test.rb
+++ b/test/domains/products/deposit_product_statement_profile_test.rb
@@ -41,6 +41,21 @@ class ProductsDepositProductStatementProfileTest < ActiveSupport::TestCase
     assert_includes profile.errors[:currency], "must match deposit product currency"
   end
 
+  test "rejects overlapping active monthly statement profile" do
+    build_profile(effective_on: Date.new(2026, 4, 1), ended_on: Date.new(2026, 4, 30)).save!
+    profile = build_profile(effective_on: Date.new(2026, 4, 15))
+
+    assert_not profile.valid?
+    assert_includes profile.errors[:effective_on], "overlaps an active monthly statement profile for this product"
+  end
+
+  test "allows adjacent active monthly statement profile" do
+    build_profile(effective_on: Date.new(2026, 4, 1), ended_on: Date.new(2026, 4, 30)).save!
+    profile = build_profile(effective_on: Date.new(2026, 5, 1))
+
+    assert_predicate profile, :valid?
+  end
+
   private
 
   def build_profile(attrs = {})

--- a/test/integration/admin_products_test.rb
+++ b/test/integration/admin_products_test.rb
@@ -159,6 +159,7 @@ class AdminProductsTest < ActionDispatch::IntegrationTest
       currency: "USD",
       status: Products::Models::DepositProductOverdraftPolicy::STATUS_ACTIVE,
       effective_on: Date.new(2026, 4, 1),
+      ended_on: Date.new(2026, 12, 31),
       description: "Seeded deny-NSF policy"
     )
     Products::Models::DepositProductStatementProfile.create!(
@@ -168,6 +169,7 @@ class AdminProductsTest < ActionDispatch::IntegrationTest
       currency: "USD",
       status: Products::Models::DepositProductStatementProfile::STATUS_ACTIVE,
       effective_on: Date.new(2026, 4, 1),
+      ended_on: Date.new(2026, 12, 31),
       description: "Seeded monthly statement profile"
     )
   end

--- a/test/integration/operational_events_money_flows_test.rb
+++ b/test/integration/operational_events_money_flows_test.rb
@@ -30,6 +30,13 @@ class OperationalEventsMoneyFlowsTest < ActionDispatch::IntegrationTest
     fee = types.find { |h| h["event_type"] == "fee.assessed" }
     assert fee["posts_to_gl"]
     assert_equal "fee.waived", fee["compensating_event_type"]
+    assert_equal "pending_to_posted", fee["lifecycle"]
+    assert_includes fee["allowed_channels"], "system"
+    assert_equal "gl_posting", fee["financial_impact"]
+    assert_equal true, fee["customer_visible"]
+    assert_equal true, fee["statement_visible"]
+    assert_equal "docs/operational_events/fee-assessed.md", fee["payload_schema"]
+    assert_includes fee["support_search_keys"], "source_account_id"
   end
 
   test "fee assessed post waive posts end to end via teller JSON" do


### PR DESCRIPTION
## Summary
- Expand the operational event catalog with lifecycle, channel, visibility, schema, and support-search metadata, plus docs/spec drift checks.
- Add a Products-owned resolver baseline with shared effective-dated resolution and singular behavior overlap validation.
- Keep ACH, external APIs, per-product GL mapping, and full product-engine breadth deferred while preparing safer channel work.

## Test plan
- Docker: `docker compose run --rm web bin/rails test test/domains/core/operational_events/event_catalog_test.rb test/domains/deposits/statement_activity_test.rb test/integration/operational_events_money_flows_test.rb`
- Docker: `docker compose run --rm web bin/rails test test/domains/products test/domains/accounts/assess_monthly_maintenance_fees_test.rb test/domains/accounts/authorize_debit_test.rb test/domains/deposits/generate_deposit_statements_test.rb`
- Local Rails test commands were attempted but blocked by Ruby 2.6.10 vs Gemfile Ruby 3.4.9.


Made with [Cursor](https://cursor.com)