### PR TITLE
Add capability-based RBAC foundation

### DIFF
--- a/app/controllers/branch/account_holds_controller.rb
+++ b/app/controllers/branch/account_holds_controller.rb
@@ -3,7 +3,7 @@
 module Branch
   class AccountHoldsController < ApplicationController
     before_action :load_account
-    before_action :require_branch_supervisor!, only: %i[release create_release]
+    before_action :require_hold_release_capability!, only: %i[release create_release]
 
     def index
       @holds = Accounts::Queries::ListHoldsForAccount.call(
@@ -69,6 +69,10 @@ module Branch
     end
 
     private
+
+    def require_hold_release_capability!
+      require_branch_capability!(Workspace::Authorization::CapabilityRegistry::HOLD_RELEASE)
+    end
 
     def load_account
       @account = Accounts::Models::DepositAccount.find(params[:deposit_account_id])

--- a/app/controllers/branch/account_parties_controller.rb
+++ b/app/controllers/branch/account_parties_controller.rb
@@ -3,7 +3,7 @@
 module Branch
   class AccountPartiesController < ApplicationController
     before_action :load_account
-    before_action :require_branch_supervisor!
+    before_action :require_account_maintain_capability!
 
     def new_authorized_signer
       @authorized_signer = default_add_params
@@ -53,6 +53,10 @@ module Branch
     end
 
     private
+
+    def require_account_maintain_capability!
+      require_branch_capability!(Workspace::Authorization::CapabilityRegistry::ACCOUNT_MAINTAIN)
+    end
 
     def load_account
       @account = Accounts::Models::DepositAccount.find(params[:deposit_account_id])

--- a/app/controllers/branch/application_controller.rb
+++ b/app/controllers/branch/application_controller.rb
@@ -32,24 +32,30 @@ module Branch
       redirect_to branch_path, alert: "Supervisor role required"
     end
 
+    def require_branch_capability!(capability_code, alert: "Supervisor role required")
+      return if current_operator&.has_capability?(capability_code)
+
+      redirect_to branch_path, alert: alert
+    end
+
     def can_place_servicing_hold?
       current_operator&.teller? || current_operator&.supervisor?
     end
 
     def can_release_servicing_hold?
-      current_operator&.supervisor?
+      current_operator&.has_capability?(Workspace::Authorization::CapabilityRegistry::HOLD_RELEASE)
     end
 
     def can_waive_fee?
-      current_operator&.supervisor?
+      current_operator&.has_capability?(Workspace::Authorization::CapabilityRegistry::FEE_WAIVE)
     end
 
     def can_reverse_event?
-      current_operator&.supervisor?
+      current_operator&.has_capability?(Workspace::Authorization::CapabilityRegistry::REVERSAL_CREATE)
     end
 
     def can_manage_authorized_signers?
-      current_operator&.supervisor?
+      current_operator&.has_capability?(Workspace::Authorization::CapabilityRegistry::ACCOUNT_MAINTAIN)
     end
   end
 end

--- a/app/controllers/branch/fee_waivers_controller.rb
+++ b/app/controllers/branch/fee_waivers_controller.rb
@@ -2,7 +2,7 @@
 
 module Branch
   class FeeWaiversController < ApplicationController
-    before_action :require_branch_supervisor!
+    before_action :require_fee_waive_capability!
     before_action :load_account
 
     def new
@@ -34,9 +34,16 @@ module Branch
       Core::Posting::Commands::PostEvent::InvalidState => e
       @error_message = e.message
       render :new, status: :unprocessable_entity
+    rescue Workspace::Authorization::Forbidden => e
+      @error_message = e.message
+      render :new, status: :forbidden
     end
 
     private
+
+    def require_fee_waive_capability!
+      require_branch_capability!(Workspace::Authorization::CapabilityRegistry::FEE_WAIVE)
+    end
 
     def load_account
       @account = Accounts::Models::DepositAccount.find(params[:deposit_account_id])

--- a/app/controllers/branch/holds_controller.rb
+++ b/app/controllers/branch/holds_controller.rb
@@ -2,6 +2,8 @@
 
 module Branch
   class HoldsController < ApplicationController
+    before_action :require_hold_release_capability!, only: %i[release create_release]
+
     def new
       @hold = default_hold_params("branch-hold")
     end
@@ -49,6 +51,10 @@ module Branch
     end
 
     private
+
+    def require_hold_release_capability!
+      require_branch_capability!(Workspace::Authorization::CapabilityRegistry::HOLD_RELEASE)
+    end
 
     def default_hold_params(prefix)
       {

--- a/app/controllers/branch/reversals_controller.rb
+++ b/app/controllers/branch/reversals_controller.rb
@@ -2,7 +2,7 @@
 
 module Branch
   class ReversalsController < ApplicationController
-    before_action :require_branch_supervisor!
+    before_action :require_reversal_capability!
 
     def new
       @reversal = default_form_params("branch-reversal")
@@ -23,6 +23,7 @@ module Branch
     rescue Core::OperationalEvents::Commands::RecordReversal::InvalidRequest,
       Core::OperationalEvents::Commands::RecordReversal::MismatchedIdempotency,
       Core::OperationalEvents::Commands::RecordReversal::PostedReplay,
+      Workspace::Authorization::Forbidden,
       Core::Posting::Commands::PostEvent::InvalidState => e
       @error_message = e.message
       render :new, status: :unprocessable_entity
@@ -32,6 +33,10 @@ module Branch
     end
 
     private
+
+    def require_reversal_capability!
+      require_branch_capability!(Workspace::Authorization::CapabilityRegistry::REVERSAL_CREATE)
+    end
 
     def default_form_params(prefix)
       {

--- a/app/controllers/concerns/teller/authenticate_operator.rb
+++ b/app/controllers/concerns/teller/authenticate_operator.rb
@@ -32,6 +32,13 @@ module Teller
       render json: { error: "forbidden", message: "supervisor role required" }, status: :forbidden
     end
 
+    def require_capability!(capability_code, message: "supervisor role required")
+      return if performed?
+      return if current_operator&.has_capability?(capability_code)
+
+      render json: { error: "forbidden", message: message }, status: :forbidden
+    end
+
     def current_operator
       @current_operator
     end

--- a/app/controllers/internal/application_controller.rb
+++ b/app/controllers/internal/application_controller.rb
@@ -45,15 +45,33 @@ module Internal
     end
 
     def branch_access?
-      current_operator&.teller? || current_operator&.supervisor?
+      has_any_capability?(
+        Workspace::Authorization::CapabilityRegistry::DEPOSIT_ACCEPT,
+        Workspace::Authorization::CapabilityRegistry::ACCOUNT_OPEN,
+        Workspace::Authorization::CapabilityRegistry::ACCOUNT_MAINTAIN,
+        Workspace::Authorization::CapabilityRegistry::HOLD_PLACE
+      )
     end
 
     def ops_access?
-      current_operator&.operations? || current_operator&.admin?
+      has_any_capability?(
+        Workspace::Authorization::CapabilityRegistry::OPS_BATCH_PROCESS,
+        Workspace::Authorization::CapabilityRegistry::OPS_EXCEPTION_RESOLVE,
+        Workspace::Authorization::CapabilityRegistry::OPS_RECONCILIATION_PERFORM,
+        Workspace::Authorization::CapabilityRegistry::SYSTEM_CONFIGURE
+      )
     end
 
     def admin_access?
-      current_operator&.admin?
+      has_any_capability?(
+        Workspace::Authorization::CapabilityRegistry::USER_MANAGE,
+        Workspace::Authorization::CapabilityRegistry::ROLE_MANAGE,
+        Workspace::Authorization::CapabilityRegistry::SYSTEM_CONFIGURE
+      )
+    end
+
+    def has_any_capability?(*capability_codes)
+      capability_codes.any? { |code| current_operator&.has_capability?(code) }
     end
   end
 end

--- a/app/controllers/ops/business_date_closes_controller.rb
+++ b/app/controllers/ops/business_date_closes_controller.rb
@@ -24,6 +24,9 @@ module Ops
     rescue Core::BusinessDate::Errors::NotSet, ArgumentError => e
       @error_message = e.message
       render :new, status: :unprocessable_entity
+    rescue Workspace::Authorization::Forbidden => e
+      @error_message = e.message
+      render :new, status: :forbidden
     end
 
     private

--- a/app/controllers/ops/teller_variances_controller.rb
+++ b/app/controllers/ops/teller_variances_controller.rb
@@ -18,6 +18,8 @@ module Ops
         notice: "Approved variance for teller session ##{session.id}."
     rescue Teller::Commands::ApproveSessionVariance::Error => e
       redirect_to ops_teller_variances_path, alert: e.message
+    rescue Workspace::Authorization::Forbidden => e
+      redirect_to ops_teller_variances_path, alert: e.message
     end
   end
 end

--- a/app/controllers/teller/business_date_closes_controller.rb
+++ b/app/controllers/teller/business_date_closes_controller.rb
@@ -2,7 +2,7 @@
 
 module Teller
   class BusinessDateClosesController < ApplicationController
-    before_action :require_supervisor!
+    before_action :require_business_date_close_capability!
 
     def create
       optional_date = parse_optional_business_date
@@ -24,11 +24,17 @@ module Teller
       render json: body, status: :unprocessable_entity
     rescue Core::BusinessDate::Errors::NotSet => e
       render json: { error: "business_date_not_set", message: e.message }, status: :unprocessable_entity
+    rescue Workspace::Authorization::Forbidden
+      render json: { error: "forbidden", message: "supervisor role required" }, status: :forbidden
     rescue ArgumentError => e
       render json: { error: "invalid_request", message: e.message }, status: :unprocessable_entity
     end
 
     private
+
+    def require_business_date_close_capability!
+      require_capability!(Workspace::Authorization::CapabilityRegistry::BUSINESS_DATE_CLOSE)
+    end
 
     def parse_optional_business_date
       raw = params[:business_date].presence || params.dig(:business_date_close, :business_date).presence

--- a/app/controllers/teller/holds_controller.rb
+++ b/app/controllers/teller/holds_controller.rb
@@ -18,7 +18,7 @@ module Teller
         attrs.delete(:business_date)
       end
 
-      result = Accounts::Commands::PlaceHold.call(**attrs)
+      result = Accounts::Commands::PlaceHold.call(**attrs, actor_id: current_operator.id)
       status = result[:outcome] == :created ? :created : :ok
       render json: { hold_id: result[:hold].id, operational_event_id: result[:event].id, outcome: result[:outcome] }, status: status
     rescue Accounts::Commands::PlaceHold::InvalidRequest => e
@@ -34,13 +34,15 @@ module Teller
         attrs.delete(:business_date)
       end
 
-      result = Accounts::Commands::ReleaseHold.call(**attrs)
+      result = Accounts::Commands::ReleaseHold.call(**attrs, actor_id: current_operator.id)
       status = result[:outcome] == :created ? :created : :ok
       render json: { operational_event_id: result[:event].id, outcome: result[:outcome] }, status: status
     rescue Accounts::Commands::ReleaseHold::InvalidRequest => e
       render json: { error: "invalid_request", message: e.message }, status: :unprocessable_entity
     rescue Accounts::Commands::ReleaseHold::HoldNotFound => e
       render json: { error: "not_found", message: e.message }, status: :not_found
+    rescue Workspace::Authorization::Forbidden
+      render json: { error: "forbidden", message: "supervisor role required" }, status: :forbidden
     end
   end
 end

--- a/app/controllers/teller/operational_events_controller.rb
+++ b/app/controllers/teller/operational_events_controller.rb
@@ -88,6 +88,8 @@ module Teller
       render json: { error: "idempotency_conflict", fingerprint: e.fingerprint }, status: :conflict
     rescue Core::OperationalEvents::Commands::RecordEvent::PostedReplay => e
       render json: { error: "posted_replay", message: e.message.presence || "already posted" }, status: :conflict
+    rescue Workspace::Authorization::Forbidden
+      render json: { error: "forbidden", message: "supervisor role required" }, status: :forbidden
     end
 
     private

--- a/app/controllers/teller/reversals_controller.rb
+++ b/app/controllers/teller/reversals_controller.rb
@@ -2,7 +2,7 @@
 
 module Teller
   class ReversalsController < ApplicationController
-    before_action :require_supervisor!, only: [ :create ]
+    before_action :require_reversal_capability!, only: [ :create ]
 
     def create
       attrs = params.require(:reversal).permit(:original_operational_event_id, :channel, :idempotency_key, :business_date).to_h.symbolize_keys
@@ -24,6 +24,14 @@ module Teller
       render json: { error: "idempotency_conflict", fingerprint: e.fingerprint }, status: :conflict
     rescue Core::OperationalEvents::Commands::RecordReversal::PostedReplay => e
       render json: { error: "posted_replay", message: e.message.presence || "already posted" }, status: :conflict
+    rescue Workspace::Authorization::Forbidden
+      render json: { error: "forbidden", message: "supervisor role required" }, status: :forbidden
+    end
+
+    private
+
+    def require_reversal_capability!
+      require_capability!(Workspace::Authorization::CapabilityRegistry::REVERSAL_CREATE)
     end
   end
 end

--- a/app/controllers/teller/teller_sessions_controller.rb
+++ b/app/controllers/teller/teller_sessions_controller.rb
@@ -2,7 +2,7 @@
 
 module Teller
   class TellerSessionsController < ApplicationController
-    before_action :require_supervisor!, only: [ :approve_variance ]
+    before_action :require_variance_approval_capability!, only: [ :approve_variance ]
 
     def create
       drawer = params.permit(:drawer_code)[:drawer_code]
@@ -47,6 +47,14 @@ module Teller
       render json: { error: "not_found", message: e.message }, status: :not_found
     rescue Teller::Commands::ApproveSessionVariance::InvalidState => e
       render json: { error: "invalid_state", message: e.message }, status: :unprocessable_entity
+    rescue Workspace::Authorization::Forbidden
+      render json: { error: "forbidden", message: "supervisor role required" }, status: :forbidden
+    end
+
+    private
+
+    def require_variance_approval_capability!
+      require_capability!(Workspace::Authorization::CapabilityRegistry::TELLER_SESSION_VARIANCE_APPROVE)
     end
   end
 end

--- a/app/domains/accounts/commands/add_authorized_signer.rb
+++ b/app/domains/accounts/commands/add_authorized_signer.rb
@@ -21,7 +21,7 @@ module Accounts
 
           account = find_open_account!(deposit_account_id)
           party = find_party!(party_record_id)
-          actor = find_supervisor!(actor_id)
+        actor = authorize_actor!(actor_id)
           ensure_no_open_authorized_signer!(account.id, party.id)
 
           relationship = Models::DepositAccountParty.create!(
@@ -103,14 +103,15 @@ module Accounts
       end
       private_class_method :find_party!
 
-      def self.find_supervisor!(actor_id)
-        actor = Workspace::Models::Operator.find_by(id: actor_id)
-        raise InvalidRequest, "actor_id not found" if actor.nil?
-        return actor if actor.active? && actor.supervisor?
-
-        raise InvalidRequest, "actor must be an active supervisor"
+      def self.authorize_actor!(actor_id)
+        Workspace::Authorization::Authorizer.require_capability!(
+          actor_id: actor_id,
+          capability_code: Workspace::Authorization::CapabilityRegistry::ACCOUNT_MAINTAIN
+        )
+      rescue Workspace::Authorization::Forbidden => e
+        raise InvalidRequest, e.message
       end
-      private_class_method :find_supervisor!
+      private_class_method :authorize_actor!
 
       def self.ensure_no_open_authorized_signer!(deposit_account_id, party_record_id)
         existing = Models::DepositAccountParty.exists?(

--- a/app/domains/accounts/commands/end_authorized_signer.rb
+++ b/app/domains/accounts/commands/end_authorized_signer.rb
@@ -21,7 +21,7 @@ module Accounts
 
           relationship = find_open_authorized_signer!(deposit_account_party_id)
           account = find_open_account!(relationship.deposit_account_id)
-          actor = find_supervisor!(actor_id)
+        actor = authorize_actor!(actor_id)
           raise InvalidRequest, "ended_on cannot be before effective_on" if end_date < relationship.effective_on
 
           relationship.update!(
@@ -106,14 +106,15 @@ module Accounts
       end
       private_class_method :find_open_account!
 
-      def self.find_supervisor!(actor_id)
-        actor = Workspace::Models::Operator.find_by(id: actor_id)
-        raise InvalidRequest, "actor_id not found" if actor.nil?
-        return actor if actor.active? && actor.supervisor?
-
-        raise InvalidRequest, "actor must be an active supervisor"
+      def self.authorize_actor!(actor_id)
+        Workspace::Authorization::Authorizer.require_capability!(
+          actor_id: actor_id,
+          capability_code: Workspace::Authorization::CapabilityRegistry::ACCOUNT_MAINTAIN
+        )
+      rescue Workspace::Authorization::Forbidden => e
+        raise InvalidRequest, e.message
       end
-      private_class_method :find_supervisor!
+      private_class_method :authorize_actor!
 
       def self.validate_end_replay!(audit, deposit_account_party_id, actor_id, ended_on)
         unless audit.action == Models::DepositAccountPartyMaintenanceAudit::ACTION_AUTHORIZED_SIGNER_ENDED &&

--- a/app/domains/accounts/commands/release_hold.rb
+++ b/app/domains/accounts/commands/release_hold.rb
@@ -6,6 +6,7 @@ module Accounts
       class Error < StandardError; end
       class InvalidRequest < Error; end
       class HoldNotFound < Error; end
+      STAFF_CHANNELS = %w[teller branch].freeze
 
       # Releases an active hold; creates a posted `hold.released` operational event (no GL).
       def self.call(hold_id:, channel:, idempotency_key:, business_date: nil, actor_id: nil)
@@ -13,6 +14,7 @@ module Accounts
         unless Core::OperationalEvents::Commands::RecordEvent::CHANNELS.include?(ch)
           raise InvalidRequest, "channel must be one of: #{Core::OperationalEvents::Commands::RecordEvent::CHANNELS.join(", ")}"
         end
+        authorize_staff_release!(ch, actor_id)
 
         on_date = business_date || Core::BusinessDate::Services::CurrentBusinessDate.call
         begin
@@ -60,6 +62,16 @@ module Accounts
         hold = Accounts::Models::Hold.find(hold_id)
         { outcome: :replay, event: existing, hold: hold.reload }
       end
+
+      def self.authorize_staff_release!(channel, actor_id)
+        return unless STAFF_CHANNELS.include?(channel)
+
+        Workspace::Authorization::Authorizer.require_capability!(
+          actor_id: actor_id,
+          capability_code: Workspace::Authorization::CapabilityRegistry::HOLD_RELEASE
+        )
+      end
+      private_class_method :authorize_staff_release!
     end
   end
 end

--- a/app/domains/core/business_date/commands/close_business_date.rb
+++ b/app/domains/core/business_date/commands/close_business_date.rb
@@ -9,6 +9,11 @@ module Core
         # @param business_date [Date, nil] when present, must equal current open day
         # @return [Hash] :setting (reload), :closed_on (Date), :previous_business_on (same as closed_on)
         def self.call(closed_by_operator_id: nil, business_date: nil)
+          Workspace::Authorization::Authorizer.require_capability!(
+            actor_id: closed_by_operator_id,
+            capability_code: Workspace::Authorization::CapabilityRegistry::BUSINESS_DATE_CLOSE
+          )
+
           Models::BusinessDateSetting.transaction do
             setting = Models::BusinessDateSetting.lock.first
             raise Errors::NotSet, "core_business_date_settings has no row" if setting.nil?

--- a/app/domains/core/operational_events/commands/record_event.rb
+++ b/app/domains/core/operational_events/commands/record_event.rb
@@ -31,6 +31,7 @@ module Core
             INTEREST_EVENT_TYPES + [ DRAWER_VARIANCE_POSTED ]
         ).freeze
         CHANNELS = %w[teller branch api batch system].freeze
+        STAFF_CHANNELS = %w[teller branch].freeze
         TELLER_CASH_EVENT_TYPES = %w[deposit.accepted withdrawal.posted].freeze
 
         # @return [Hash] `{ outcome: :created|:replay, event: OperationalEvent }`
@@ -50,6 +51,7 @@ module Core
         )
           validate_channel!(channel)
           validate_event_type!(event_type)
+          authorize_fee_waiver!(event_type, channel, actor_id)
           validate_financial_amounts!(event_type, amount_minor_units, currency, source_account_id, destination_account_id)
           validate_source_account!(event_type, source_account_id)
           validate_destination_account!(event_type, destination_account_id)
@@ -315,6 +317,17 @@ module Core
           end
         end
         private_class_method :validate_fee_waived!
+
+        def self.authorize_fee_waiver!(event_type, channel, actor_id)
+          return unless event_type.to_s == "fee.waived"
+          return unless STAFF_CHANNELS.include?(channel.to_s)
+
+          Workspace::Authorization::Authorizer.require_capability!(
+            actor_id: actor_id,
+            capability_code: Workspace::Authorization::CapabilityRegistry::FEE_WAIVE
+          )
+        end
+        private_class_method :authorize_fee_waiver!
 
         def self.validate_ach_credit_received!(event_type, channel, reference_id)
           return unless event_type.to_s == "ach.credit.received"

--- a/app/domains/core/operational_events/commands/record_reversal.rb
+++ b/app/domains/core/operational_events/commands/record_reversal.rb
@@ -22,9 +22,11 @@ module Core
         end
 
         REVERSIBLE_TYPES = %w[deposit.accepted withdrawal.posted transfer.completed interest.accrued interest.posted].freeze
+        STAFF_CHANNELS = %w[teller branch].freeze
 
         def self.call(original_operational_event_id:, channel:, idempotency_key:, business_date: nil, actor_id: nil)
           RecordEvent.validate_channel!(channel)
+          authorize_staff_reversal!(channel, actor_id)
 
           original = Models::OperationalEvent.find_by(id: original_operational_event_id)
           raise NotFound, "original_operational_event_id=#{original_operational_event_id}" if original.nil?
@@ -115,6 +117,16 @@ module Core
           { outcome: :replay, event: existing }
         end
         private_class_method :handle_existing
+
+        def self.authorize_staff_reversal!(channel, actor_id)
+          return unless STAFF_CHANNELS.include?(channel.to_s)
+
+          Workspace::Authorization::Authorizer.require_capability!(
+            actor_id: actor_id,
+            capability_code: Workspace::Authorization::CapabilityRegistry::REVERSAL_CREATE
+          )
+        end
+        private_class_method :authorize_staff_reversal!
       end
     end
   end

--- a/app/domains/teller/commands/approve_session_variance.rb
+++ b/app/domains/teller/commands/approve_session_variance.rb
@@ -9,6 +9,11 @@ module Teller
 
       # @param supervisor_operator_id [Integer, nil] FK to operators; from current_operator in teller workspace.
       def self.call(teller_session_id:, supervisor_operator_id: nil)
+        Workspace::Authorization::Authorizer.require_capability!(
+          actor_id: supervisor_operator_id,
+          capability_code: Workspace::Authorization::CapabilityRegistry::TELLER_SESSION_VARIANCE_APPROVE
+        )
+
         Teller::Models::TellerSession.transaction do
           session = Teller::Models::TellerSession.lock.find_by(id: teller_session_id)
           raise NotFound, "teller_session_id=#{teller_session_id}" if session.nil?

--- a/app/domains/workspace/authorization.rb
+++ b/app/domains/workspace/authorization.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Authorization
+    class Error < StandardError; end
+
+    class Forbidden < Error; end
+  end
+end

--- a/app/domains/workspace/authorization/authorizer.rb
+++ b/app/domains/workspace/authorization/authorizer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Authorization
+    module Authorizer
+      def self.require_capability!(actor_id:, capability_code:, scope: nil)
+        actor = Models::Operator.find_by(id: actor_id)
+        unless actor&.active?
+          raise Forbidden, "actor must be an active operator"
+        end
+
+        return actor if CapabilityResolver.has_capability?(operator: actor, capability_code: capability_code, scope: scope)
+
+        raise Forbidden, "operator is not authorized for #{capability_code}"
+      end
+    end
+  end
+end

--- a/app/domains/workspace/authorization/capability_registry.rb
+++ b/app/domains/workspace/authorization/capability_registry.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Authorization
+    module CapabilityRegistry
+      DEPOSIT_ACCEPT = "deposit.accept"
+      WITHDRAWAL_POST = "withdrawal.post"
+      TRANSFER_COMPLETE = "transfer.complete"
+      TELLER_SESSION_OPEN = "teller_session.open"
+      TELLER_SESSION_CLOSE = "teller_session.close"
+      CASH_DRAWER_MANAGE = "cash_drawer.manage"
+      PARTY_CREATE = "party.create"
+      ACCOUNT_OPEN = "account.open"
+      ACCOUNT_MAINTAIN = "account.maintain"
+      HOLD_PLACE = "hold.place"
+      FEE_WAIVE = "fee.waive"
+      HOLD_RELEASE = "hold.release"
+      BUSINESS_DATE_CLOSE = "business_date.close"
+      TELLER_SESSION_VARIANCE_APPROVE = "teller_session_variance.approve"
+      REVERSAL_CREATE = "reversal.create"
+      OPS_BATCH_PROCESS = "ops.batch.process"
+      OPS_EXCEPTION_RESOLVE = "ops.exception.resolve"
+      OPS_RECONCILIATION_PERFORM = "ops.reconciliation.perform"
+      OPERATIONAL_EVENT_VIEW = "operational_event.view"
+      JOURNAL_ENTRY_VIEW = "journal_entry.view"
+      AUDIT_EXPORT = "audit.export"
+      REPORT_VIEW = "report.view"
+      USER_MANAGE = "user.manage"
+      ROLE_MANAGE = "role.manage"
+      SYSTEM_CONFIGURE = "system.configure"
+
+      TELLER = "teller"
+      BRANCH_SUPERVISOR = "branch_supervisor"
+      CSR = "csr"
+      BRANCH_MANAGER = "branch_manager"
+      OPERATIONS = "operations"
+      AUDITOR = "auditor"
+      SYSTEM_ADMIN = "system_admin"
+
+      CAPABILITIES = [
+        { code: DEPOSIT_ACCEPT, name: "Accept deposit", category: "transaction",
+          description: "May accept a deposit transaction." },
+        { code: WITHDRAWAL_POST, name: "Post withdrawal", category: "transaction",
+          description: "May post a withdrawal transaction." },
+        { code: TRANSFER_COMPLETE, name: "Complete transfer", category: "transaction",
+          description: "May complete an internal transfer." },
+        { code: TELLER_SESSION_OPEN, name: "Open teller session", category: "teller",
+          description: "May open a teller drawer/session." },
+        { code: TELLER_SESSION_CLOSE, name: "Close teller session", category: "teller",
+          description: "May close a teller drawer/session." },
+        { code: CASH_DRAWER_MANAGE, name: "Manage cash drawer", category: "cash",
+          description: "May perform teller cash drawer operations." },
+        { code: PARTY_CREATE, name: "Create party", category: "party",
+          description: "May create party records." },
+        { code: ACCOUNT_OPEN, name: "Open account", category: "account",
+          description: "May open deposit accounts." },
+        { code: ACCOUNT_MAINTAIN, name: "Maintain account", category: "account",
+          description: "May maintain account relationships and servicing attributes." },
+        { code: HOLD_PLACE, name: "Place hold", category: "control",
+          description: "May place account holds." },
+        { code: FEE_WAIVE, name: "Waive fee", category: "control",
+          description: "May waive posted account fees." },
+        { code: HOLD_RELEASE, name: "Release hold", category: "control",
+          description: "May release active account holds." },
+        { code: BUSINESS_DATE_CLOSE, name: "Close business date", category: "control",
+          description: "May close the current business date after readiness checks." },
+        { code: TELLER_SESSION_VARIANCE_APPROVE, name: "Approve teller session variance", category: "control",
+          description: "May approve a teller session variance." },
+        { code: REVERSAL_CREATE, name: "Create reversal", category: "control",
+          description: "May create controlled reversals." },
+        { code: OPS_BATCH_PROCESS, name: "Process operations batch", category: "operations",
+          description: "May run operations batch processes." },
+        { code: OPS_EXCEPTION_RESOLVE, name: "Resolve operations exception", category: "operations",
+          description: "May resolve operations exceptions." },
+        { code: OPS_RECONCILIATION_PERFORM, name: "Perform reconciliation", category: "operations",
+          description: "May perform operations reconciliation." },
+        { code: OPERATIONAL_EVENT_VIEW, name: "View operational events", category: "audit",
+          description: "May view operational event records." },
+        { code: JOURNAL_ENTRY_VIEW, name: "View journal entries", category: "audit",
+          description: "May view journal entries and journal lines." },
+        { code: AUDIT_EXPORT, name: "Export audit data", category: "audit",
+          description: "May export audit evidence." },
+        { code: REPORT_VIEW, name: "View reports", category: "reporting",
+          description: "May view internal operational reports." },
+        { code: USER_MANAGE, name: "Manage users", category: "admin",
+          description: "May manage internal users/operators." },
+        { code: ROLE_MANAGE, name: "Manage roles", category: "admin",
+          description: "May manage RBAC role assignments." },
+        { code: SYSTEM_CONFIGURE, name: "Configure system", category: "admin",
+          description: "May configure internal system settings." }
+      ].freeze
+
+      ROLES = [
+        { code: TELLER, name: "Teller", description: "Branch teller transaction operator." },
+        { code: BRANCH_SUPERVISOR, name: "Branch Supervisor", description: "Supervisor for branch and teller controls." },
+        { code: CSR, name: "CSR", description: "Customer service representative for branch servicing." },
+        { code: BRANCH_MANAGER, name: "Branch Manager", description: "Branch manager servicing and control authority." },
+        { code: OPERATIONS, name: "Operations", description: "Back-office operations staff." },
+        { code: AUDITOR, name: "Auditor", description: "Read-only audit and evidence reviewer." },
+        { code: SYSTEM_ADMIN, name: "System Administrator", description: "Technology administration staff." }
+      ].freeze
+
+      ROLE_CAPABILITIES = {
+        TELLER => [
+          DEPOSIT_ACCEPT, WITHDRAWAL_POST, TRANSFER_COMPLETE, TELLER_SESSION_OPEN, TELLER_SESSION_CLOSE,
+          CASH_DRAWER_MANAGE, PARTY_CREATE, ACCOUNT_OPEN, HOLD_PLACE, REPORT_VIEW
+        ],
+        BRANCH_SUPERVISOR => [
+          DEPOSIT_ACCEPT, WITHDRAWAL_POST, TRANSFER_COMPLETE, TELLER_SESSION_OPEN, TELLER_SESSION_CLOSE,
+          CASH_DRAWER_MANAGE, PARTY_CREATE, ACCOUNT_OPEN, ACCOUNT_MAINTAIN, HOLD_PLACE, FEE_WAIVE, HOLD_RELEASE,
+          BUSINESS_DATE_CLOSE, TELLER_SESSION_VARIANCE_APPROVE, REVERSAL_CREATE, OPERATIONAL_EVENT_VIEW, REPORT_VIEW
+        ],
+        CSR => [
+          PARTY_CREATE, ACCOUNT_OPEN, ACCOUNT_MAINTAIN, HOLD_PLACE, OPERATIONAL_EVENT_VIEW, REPORT_VIEW
+        ],
+        BRANCH_MANAGER => [
+          PARTY_CREATE, ACCOUNT_OPEN, ACCOUNT_MAINTAIN, HOLD_PLACE, FEE_WAIVE, HOLD_RELEASE, REVERSAL_CREATE,
+          OPERATIONAL_EVENT_VIEW, JOURNAL_ENTRY_VIEW, REPORT_VIEW
+        ],
+        OPERATIONS => [
+          OPS_BATCH_PROCESS, OPS_EXCEPTION_RESOLVE, OPS_RECONCILIATION_PERFORM, OPERATIONAL_EVENT_VIEW,
+          JOURNAL_ENTRY_VIEW, AUDIT_EXPORT, REPORT_VIEW, BUSINESS_DATE_CLOSE, TELLER_SESSION_VARIANCE_APPROVE
+        ],
+        AUDITOR => [
+          OPERATIONAL_EVENT_VIEW, JOURNAL_ENTRY_VIEW, AUDIT_EXPORT, REPORT_VIEW
+        ],
+        SYSTEM_ADMIN => [
+          USER_MANAGE, ROLE_MANAGE, SYSTEM_CONFIGURE, OPERATIONAL_EVENT_VIEW, REPORT_VIEW
+        ]
+      }.freeze
+
+      LEGACY_ROLE_MAPPING = {
+        "teller" => TELLER,
+        "supervisor" => BRANCH_SUPERVISOR,
+        "operations" => OPERATIONS,
+        "admin" => SYSTEM_ADMIN
+      }.freeze
+
+      def self.capability_codes
+        CAPABILITIES.map { |capability| capability.fetch(:code) }
+      end
+
+      def self.role_codes
+        ROLES.map { |role| role.fetch(:code) }
+      end
+
+      def self.role_capability_pairs
+        ROLE_CAPABILITIES.flat_map do |role_code, capability_codes|
+          capability_codes.map { |capability_code| { role_code: role_code, capability_code: capability_code } }
+        end
+      end
+    end
+  end
+end

--- a/app/domains/workspace/authorization/capability_resolver.rb
+++ b/app/domains/workspace/authorization/capability_resolver.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Authorization
+    module CapabilityResolver
+      def self.capabilities_for(operator:, scope: nil)
+        return [] if operator.nil? || !operator.active?
+
+        Models::Capability
+          .joins(roles: :operator_role_assignments)
+          .where(active: true)
+          .where(roles: { active: true })
+          .where(operator_role_assignments: {
+            operator_id: operator.id,
+            active: true,
+            scope_type: nil,
+            scope_id: nil
+          })
+          .where("operator_role_assignments.starts_at IS NULL OR operator_role_assignments.starts_at <= ?", Time.current)
+          .where("operator_role_assignments.ends_at IS NULL OR ? < operator_role_assignments.ends_at", Time.current)
+          .distinct
+          .order(:code)
+          .pluck(:code)
+      end
+
+      def self.has_capability?(operator:, capability_code:, scope: nil)
+        return false if capability_code.blank?
+
+        capabilities_for(operator: operator, scope: scope).include?(capability_code.to_s)
+      end
+    end
+  end
+end

--- a/app/domains/workspace/models/capability.rb
+++ b/app/domains/workspace/models/capability.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Models
+    class Capability < ApplicationRecord
+      self.table_name = "capabilities"
+
+      has_many :role_capabilities, class_name: "Workspace::Models::RoleCapability", dependent: :restrict_with_exception
+      has_many :roles, through: :role_capabilities, class_name: "Workspace::Models::Role"
+
+      validates :code, presence: true, uniqueness: true
+      validates :name, :category, presence: true
+    end
+  end
+end

--- a/app/domains/workspace/models/operator.rb
+++ b/app/domains/workspace/models/operator.rb
@@ -8,8 +8,12 @@ module Workspace
       ROLES = %w[teller supervisor operations admin].freeze
 
       has_one :credential, class_name: "Workspace::Models::OperatorCredential", dependent: :destroy
+      has_many :operator_role_assignments, class_name: "Workspace::Models::OperatorRoleAssignment", dependent: :destroy
+      has_many :roles, through: :operator_role_assignments, class_name: "Workspace::Models::Role"
 
       validates :role, presence: true, inclusion: { in: ROLES }
+
+      after_create :assign_legacy_compatible_role
 
       def teller?
         role == "teller"
@@ -25,6 +29,35 @@ module Workspace
 
       def admin?
         role == "admin"
+      end
+
+      def capabilities(scope: nil)
+        Workspace::Authorization::CapabilityResolver.capabilities_for(operator: self, scope: scope)
+      end
+
+      def has_capability?(capability_code, scope: nil)
+        Workspace::Authorization::CapabilityResolver.has_capability?(
+          operator: self,
+          capability_code: capability_code,
+          scope: scope
+        )
+      end
+
+      private
+
+      def assign_legacy_compatible_role
+        role_code = Workspace::Authorization::CapabilityRegistry::LEGACY_ROLE_MAPPING[role]
+        return if role_code.blank?
+
+        role_record = Workspace::Models::Role.find_by(code: role_code)
+        return if role_record.nil?
+
+        operator_role_assignments.find_or_create_by!(role: role_record, scope_type: nil, scope_id: nil) do |assignment|
+          assignment.active = true
+        end
+      rescue ActiveRecord::StatementInvalid
+        # Operators can be created while RBAC tables are not present during a fresh migration.
+        nil
       end
     end
   end

--- a/app/domains/workspace/models/operator_role_assignment.rb
+++ b/app/domains/workspace/models/operator_role_assignment.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Models
+    class OperatorRoleAssignment < ApplicationRecord
+      self.table_name = "operator_role_assignments"
+
+      belongs_to :operator, class_name: "Workspace::Models::Operator"
+      belongs_to :role, class_name: "Workspace::Models::Role"
+
+      validates :operator_id, uniqueness: {
+        scope: :role_id,
+        conditions: -> { where(scope_type: nil, scope_id: nil) },
+        message: "already has this global role"
+      }, if: :global_scope?
+
+      validate :scope_pair_is_complete
+      validate :ends_after_starts
+
+      def global_scope?
+        scope_type.nil? && scope_id.nil?
+      end
+
+      private
+
+      def scope_pair_is_complete
+        return if scope_type.present? == scope_id.present?
+
+        errors.add(:scope_id, "must be present with scope_type")
+      end
+
+      def ends_after_starts
+        return if starts_at.blank? || ends_at.blank? || starts_at < ends_at
+
+        errors.add(:ends_at, "must be after starts_at")
+      end
+    end
+  end
+end

--- a/app/domains/workspace/models/role.rb
+++ b/app/domains/workspace/models/role.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Models
+    class Role < ApplicationRecord
+      self.table_name = "roles"
+
+      has_many :role_capabilities, class_name: "Workspace::Models::RoleCapability", dependent: :restrict_with_exception
+      has_many :capabilities, through: :role_capabilities, class_name: "Workspace::Models::Capability"
+      has_many :operator_role_assignments, class_name: "Workspace::Models::OperatorRoleAssignment",
+        dependent: :restrict_with_exception
+      has_many :operators, through: :operator_role_assignments, class_name: "Workspace::Models::Operator"
+
+      validates :code, presence: true, uniqueness: true
+      validates :name, presence: true
+    end
+  end
+end

--- a/app/domains/workspace/models/role_capability.rb
+++ b/app/domains/workspace/models/role_capability.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Models
+    class RoleCapability < ApplicationRecord
+      self.table_name = "role_capabilities"
+
+      belongs_to :role, class_name: "Workspace::Models::Role"
+      belongs_to :capability, class_name: "Workspace::Models::Capability"
+
+      validates :role_id, uniqueness: { scope: :capability_id }
+    end
+  end
+end

--- a/db/migrate/20260424120016_create_rbac_tables.rb
+++ b/db/migrate/20260424120016_create_rbac_tables.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+class CreateRbacTables < ActiveRecord::Migration[8.1]
+  class MigrationCapability < ActiveRecord::Base
+    self.table_name = "capabilities"
+  end
+
+  class MigrationRole < ActiveRecord::Base
+    self.table_name = "roles"
+  end
+
+  class MigrationRoleCapability < ActiveRecord::Base
+    self.table_name = "role_capabilities"
+  end
+
+  class MigrationOperator < ActiveRecord::Base
+    self.table_name = "operators"
+  end
+
+  class MigrationOperatorRoleAssignment < ActiveRecord::Base
+    self.table_name = "operator_role_assignments"
+  end
+
+  def up
+    create_table :capabilities do |t|
+      t.string :code, null: false
+      t.string :name, null: false
+      t.text :description
+      t.string :category, null: false
+      t.boolean :active, null: false, default: true
+      t.timestamps
+    end
+
+    add_index :capabilities, :code, unique: true
+    add_check_constraint :capabilities, "btrim(code) <> ''", name: "capabilities_code_present_check"
+    add_check_constraint :capabilities, "btrim(name) <> ''", name: "capabilities_name_present_check"
+    add_check_constraint :capabilities, "btrim(category) <> ''", name: "capabilities_category_present_check"
+
+    create_table :roles do |t|
+      t.string :code, null: false
+      t.string :name, null: false
+      t.text :description
+      t.boolean :active, null: false, default: true
+      t.boolean :system_role, null: false, default: true
+      t.timestamps
+    end
+
+    add_index :roles, :code, unique: true
+    add_check_constraint :roles, "btrim(code) <> ''", name: "roles_code_present_check"
+    add_check_constraint :roles, "btrim(name) <> ''", name: "roles_name_present_check"
+
+    create_table :role_capabilities do |t|
+      t.references :role, null: false, foreign_key: true
+      t.references :capability, null: false, foreign_key: true
+      t.timestamps
+    end
+
+    add_index :role_capabilities, [ :role_id, :capability_id ], unique: true,
+      name: "index_role_capabilities_on_role_and_capability"
+
+    create_table :operator_role_assignments do |t|
+      t.references :operator, null: false, foreign_key: true
+      t.references :role, null: false, foreign_key: true
+      t.string :scope_type
+      t.bigint :scope_id
+      t.boolean :active, null: false, default: true
+      t.datetime :starts_at
+      t.datetime :ends_at
+      t.timestamps
+    end
+
+    add_index :operator_role_assignments, [ :operator_id, :role_id ],
+      unique: true,
+      where: "scope_type IS NULL AND scope_id IS NULL",
+      name: "index_operator_role_assignments_on_global_role"
+    add_index :operator_role_assignments, [ :operator_id, :role_id, :scope_type, :scope_id ],
+      unique: true,
+      where: "scope_type IS NOT NULL AND scope_id IS NOT NULL",
+      name: "index_operator_role_assignments_on_scoped_role"
+    add_check_constraint :operator_role_assignments,
+      "((scope_type IS NULL AND scope_id IS NULL) OR (scope_type IS NOT NULL AND scope_id IS NOT NULL))",
+      name: "operator_role_assignments_scope_pair_check"
+    add_check_constraint :operator_role_assignments,
+      "(starts_at IS NULL OR ends_at IS NULL OR starts_at < ends_at)",
+      name: "operator_role_assignments_time_window_check"
+
+    seed_baseline_rbac_data
+    backfill_legacy_operator_roles
+  end
+
+  def down
+    drop_table :operator_role_assignments
+    drop_table :role_capabilities
+    drop_table :roles
+    drop_table :capabilities
+  end
+
+  private
+
+  def seed_baseline_rbac_data
+    now = Time.current
+
+    Workspace::Authorization::CapabilityRegistry::CAPABILITIES.each do |attrs|
+      MigrationCapability.upsert(
+        attrs.merge(active: true, created_at: now, updated_at: now),
+        unique_by: :index_capabilities_on_code
+      )
+    end
+
+    Workspace::Authorization::CapabilityRegistry::ROLES.each do |attrs|
+      MigrationRole.upsert(
+        attrs.merge(active: true, system_role: true, created_at: now, updated_at: now),
+        unique_by: :index_roles_on_code
+      )
+    end
+
+    capability_ids = MigrationCapability.pluck(:code, :id).to_h
+    role_ids = MigrationRole.pluck(:code, :id).to_h
+
+    Workspace::Authorization::CapabilityRegistry.role_capability_pairs.each do |pair|
+      MigrationRoleCapability.upsert(
+        {
+          role_id: role_ids.fetch(pair.fetch(:role_code)),
+          capability_id: capability_ids.fetch(pair.fetch(:capability_code)),
+          created_at: now,
+          updated_at: now
+        },
+        unique_by: :index_role_capabilities_on_role_and_capability
+      )
+    end
+  end
+
+  def backfill_legacy_operator_roles
+    now = Time.current
+    role_ids = MigrationRole.pluck(:code, :id).to_h
+
+    MigrationOperator.find_each do |operator|
+      role_code = Workspace::Authorization::CapabilityRegistry::LEGACY_ROLE_MAPPING[operator.role]
+      next if role_code.blank?
+
+      MigrationOperatorRoleAssignment.upsert(
+        {
+          operator_id: operator.id,
+          role_id: role_ids.fetch(role_code),
+          scope_type: nil,
+          scope_id: nil,
+          active: true,
+          starts_at: nil,
+          ends_at: nil,
+          created_at: now,
+          updated_at: now
+        },
+        unique_by: :index_operator_role_assignments_on_global_role
+      )
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,6 +7,7 @@
 require_relative "../lib/bank_core/seeds/gl_coa"
 require_relative "../lib/bank_core/seeds/deposit_products"
 require_relative "../lib/bank_core/seeds/operators"
+require_relative "../lib/bank_core/seeds/rbac"
 
 BankCore::Seeds::GlCoa.seed!
 BankCore::Seeds::DepositProducts.seed!
@@ -18,3 +19,5 @@ end
 if Rails.env.development? || Rails.env.test?
   BankCore::Seeds::Operators.seed!
 end
+
+BankCore::Seeds::Rbac.seed!

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -111,6 +111,44 @@ CREATE TABLE public.ar_internal_metadata (
 
 
 --
+-- Name: capabilities; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.capabilities (
+    id bigint NOT NULL,
+    code character varying NOT NULL,
+    name character varying NOT NULL,
+    description text,
+    category character varying NOT NULL,
+    active boolean DEFAULT true NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    CONSTRAINT capabilities_category_present_check CHECK ((btrim((category)::text) <> ''::text)),
+    CONSTRAINT capabilities_code_present_check CHECK ((btrim((code)::text) <> ''::text)),
+    CONSTRAINT capabilities_name_present_check CHECK ((btrim((name)::text) <> ''::text))
+);
+
+
+--
+-- Name: capabilities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.capabilities_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: capabilities_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.capabilities_id_seq OWNED BY public.capabilities.id;
+
+
+--
 -- Name: core_business_date_close_events; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -740,6 +778,45 @@ ALTER SEQUENCE public.operator_credentials_id_seq OWNED BY public.operator_crede
 
 
 --
+-- Name: operator_role_assignments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.operator_role_assignments (
+    id bigint NOT NULL,
+    operator_id bigint NOT NULL,
+    role_id bigint NOT NULL,
+    scope_type character varying,
+    scope_id bigint,
+    active boolean DEFAULT true NOT NULL,
+    starts_at timestamp(6) without time zone,
+    ends_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    CONSTRAINT operator_role_assignments_scope_pair_check CHECK ((((scope_type IS NULL) AND (scope_id IS NULL)) OR ((scope_type IS NOT NULL) AND (scope_id IS NOT NULL)))),
+    CONSTRAINT operator_role_assignments_time_window_check CHECK (((starts_at IS NULL) OR (ends_at IS NULL) OR (starts_at < ends_at)))
+);
+
+
+--
+-- Name: operator_role_assignments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.operator_role_assignments_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: operator_role_assignments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.operator_role_assignments_id_seq OWNED BY public.operator_role_assignments.id;
+
+
+--
 -- Name: operators; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -878,6 +955,75 @@ ALTER SEQUENCE public.posting_batches_id_seq OWNED BY public.posting_batches.id;
 
 
 --
+-- Name: role_capabilities; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.role_capabilities (
+    id bigint NOT NULL,
+    role_id bigint NOT NULL,
+    capability_id bigint NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: role_capabilities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.role_capabilities_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: role_capabilities_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.role_capabilities_id_seq OWNED BY public.role_capabilities.id;
+
+
+--
+-- Name: roles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.roles (
+    id bigint NOT NULL,
+    code character varying NOT NULL,
+    name character varying NOT NULL,
+    description text,
+    active boolean DEFAULT true NOT NULL,
+    system_role boolean DEFAULT true NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    CONSTRAINT roles_code_present_check CHECK ((btrim((code)::text) <> ''::text)),
+    CONSTRAINT roles_name_present_check CHECK ((btrim((name)::text) <> ''::text))
+);
+
+
+--
+-- Name: roles_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.roles_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: roles_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.roles_id_seq OWNED BY public.roles.id;
+
+
+--
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -924,6 +1070,13 @@ CREATE SEQUENCE public.teller_sessions_id_seq
 --
 
 ALTER SEQUENCE public.teller_sessions_id_seq OWNED BY public.teller_sessions.id;
+
+
+--
+-- Name: capabilities id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.capabilities ALTER COLUMN id SET DEFAULT nextval('public.capabilities_id_seq'::regclass);
 
 
 --
@@ -1039,6 +1192,13 @@ ALTER TABLE ONLY public.operator_credentials ALTER COLUMN id SET DEFAULT nextval
 
 
 --
+-- Name: operator_role_assignments id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.operator_role_assignments ALTER COLUMN id SET DEFAULT nextval('public.operator_role_assignments_id_seq'::regclass);
+
+
+--
 -- Name: operators id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1067,6 +1227,20 @@ ALTER TABLE ONLY public.posting_batches ALTER COLUMN id SET DEFAULT nextval('pub
 
 
 --
+-- Name: role_capabilities id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.role_capabilities ALTER COLUMN id SET DEFAULT nextval('public.role_capabilities_id_seq'::regclass);
+
+
+--
+-- Name: roles id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.roles ALTER COLUMN id SET DEFAULT nextval('public.roles_id_seq'::regclass);
+
+
+--
 -- Name: teller_sessions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1079,6 +1253,14 @@ ALTER TABLE ONLY public.teller_sessions ALTER COLUMN id SET DEFAULT nextval('pub
 
 ALTER TABLE ONLY public.ar_internal_metadata
     ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
+
+
+--
+-- Name: capabilities capabilities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.capabilities
+    ADD CONSTRAINT capabilities_pkey PRIMARY KEY (id);
 
 
 --
@@ -1210,6 +1392,14 @@ ALTER TABLE ONLY public.operator_credentials
 
 
 --
+-- Name: operator_role_assignments operator_role_assignments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.operator_role_assignments
+    ADD CONSTRAINT operator_role_assignments_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: operators operators_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1239,6 +1429,22 @@ ALTER TABLE ONLY public.party_records
 
 ALTER TABLE ONLY public.posting_batches
     ADD CONSTRAINT posting_batches_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: role_capabilities role_capabilities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.role_capabilities
+    ADD CONSTRAINT role_capabilities_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: roles roles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.roles
+    ADD CONSTRAINT roles_pkey PRIMARY KEY (id);
 
 
 --
@@ -1367,6 +1573,13 @@ CREATE INDEX idx_on_deposit_account_id_c32203628a ON public.deposit_account_part
 --
 
 CREATE INDEX idx_on_party_record_id_91aa95b618 ON public.deposit_account_party_maintenance_audits USING btree (party_record_id);
+
+
+--
+-- Name: index_capabilities_on_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_capabilities_on_code ON public.capabilities USING btree (code);
 
 
 --
@@ -1629,6 +1842,34 @@ CREATE UNIQUE INDEX index_operator_credentials_on_operator_id ON public.operator
 
 
 --
+-- Name: index_operator_role_assignments_on_global_role; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_operator_role_assignments_on_global_role ON public.operator_role_assignments USING btree (operator_id, role_id) WHERE ((scope_type IS NULL) AND (scope_id IS NULL));
+
+
+--
+-- Name: index_operator_role_assignments_on_operator_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_operator_role_assignments_on_operator_id ON public.operator_role_assignments USING btree (operator_id);
+
+
+--
+-- Name: index_operator_role_assignments_on_role_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_operator_role_assignments_on_role_id ON public.operator_role_assignments USING btree (role_id);
+
+
+--
+-- Name: index_operator_role_assignments_on_scoped_role; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_operator_role_assignments_on_scoped_role ON public.operator_role_assignments USING btree (operator_id, role_id, scope_type, scope_id) WHERE ((scope_type IS NOT NULL) AND (scope_id IS NOT NULL));
+
+
+--
 -- Name: index_party_individual_profiles_on_party_record_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1640,6 +1881,34 @@ CREATE UNIQUE INDEX index_party_individual_profiles_on_party_record_id ON public
 --
 
 CREATE INDEX index_posting_batches_on_operational_event_id ON public.posting_batches USING btree (operational_event_id);
+
+
+--
+-- Name: index_role_capabilities_on_capability_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_role_capabilities_on_capability_id ON public.role_capabilities USING btree (capability_id);
+
+
+--
+-- Name: index_role_capabilities_on_role_and_capability; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_role_capabilities_on_role_and_capability ON public.role_capabilities USING btree (role_id, capability_id);
+
+
+--
+-- Name: index_role_capabilities_on_role_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_role_capabilities_on_role_id ON public.role_capabilities USING btree (role_id);
+
+
+--
+-- Name: index_roles_on_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_roles_on_code ON public.roles USING btree (code);
 
 
 --
@@ -1719,6 +1988,14 @@ ALTER TABLE ONLY public.posting_batches
 
 
 --
+-- Name: operator_role_assignments fk_rails_2034e16c17; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.operator_role_assignments
+    ADD CONSTRAINT fk_rails_2034e16c17 FOREIGN KEY (role_id) REFERENCES public.roles(id);
+
+
+--
 -- Name: party_individual_profiles fk_rails_22a835d5da; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1783,11 +2060,27 @@ ALTER TABLE ONLY public.holds
 
 
 --
+-- Name: operator_role_assignments fk_rails_54957937ed; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.operator_role_assignments
+    ADD CONSTRAINT fk_rails_54957937ed FOREIGN KEY (operator_id) REFERENCES public.operators(id);
+
+
+--
 -- Name: operator_credentials fk_rails_580f3046fd; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.operator_credentials
     ADD CONSTRAINT fk_rails_580f3046fd FOREIGN KEY (operator_id) REFERENCES public.operators(id);
+
+
+--
+-- Name: role_capabilities fk_rails_5a0544a242; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.role_capabilities
+    ADD CONSTRAINT fk_rails_5a0544a242 FOREIGN KEY (role_id) REFERENCES public.roles(id);
 
 
 --
@@ -1887,6 +2180,14 @@ ALTER TABLE ONLY public.operational_events
 
 
 --
+-- Name: role_capabilities fk_rails_a6e4d08394; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.role_capabilities
+    ADD CONSTRAINT fk_rails_a6e4d08394 FOREIGN KEY (capability_id) REFERENCES public.capabilities(id);
+
+
+--
 -- Name: deposit_account_parties fk_rails_bf2b31365a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1957,6 +2258,7 @@ ALTER TABLE ONLY public.operational_events
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260424120016'),
 ('20260424120015'),
 ('20260424120014'),
 ('20260424120013'),

--- a/docs/adr/0029-capability-first-authorization-layer.md
+++ b/docs/adr/0029-capability-first-authorization-layer.md
@@ -83,15 +83,15 @@ May this internal staff operator attempt this category of action?
 
 Examples:
 
-- `txn.cash.deposit`
-- `txn.cash.withdrawal`
-- `txn.override.fee`
-- `approval.standard`
-- `approval.reversal`
+- `deposit.accept`
+- `withdrawal.post`
+- `transfer.complete`
+- `fee.waive`
+- `reversal.create`
 - `ops.exception.resolve`
-- `audit.operational_events.view`
+- `operational_event.view`
 - `audit.export`
-- `admin.role.manage`
+- `role.manage`
 
 Capabilities must not encode conditional controls.
 
@@ -231,8 +231,8 @@ role_id
 scope_type
 scope_id
 active
-starts_on
-ends_on
+starts_at
+ends_at
 created_at
 updated_at
 ```
@@ -243,6 +243,16 @@ Scope rules for this ADR:
 - null scope means institution-wide assignment for the current narrow implementation.
 - future ADRs may define scoped values such as `branch`, `location`, or `operating_unit`.
 - until those scope models exist, implementation must not invent branch resolution rules.
+- until ADR-0032 scope resolution is implemented, scoped assignment rows grant no capabilities.
+- `scope: nil` and `scope: <non-nil>` resolver calls both evaluate active global assignments only.
+
+Temporal rules:
+
+- `starts_at` and `ends_at` are nullable `datetime` columns.
+- `starts_at: nil` means the assignment is eligible immediately.
+- `ends_at: nil` means the assignment has no scheduled end.
+- an assignment is effective when `active = true`, `starts_at` is nil or `starts_at <= Time.current`, and `ends_at` is nil or `Time.current < ends_at`.
+- `ends_at` is exclusive.
 
 Uniqueness:
 
@@ -266,8 +276,21 @@ Rules:
 - code references in application code must be covered by tests or registry checks
 - deleting or renaming a capability requires an explicit migration plan
 - institution-specific role bundles may compose registered capabilities, but must not create undeclared codes at runtime
+- capability codes should use the pattern `<object>.<action>`
+- capability actions should be present-tense authority verbs, while operational events remain past-tense business facts
+- when a capability protects an action that records an operational event, prefer the same business object noun as the event type
 
-The initial implementation should favor seed-managed baseline capabilities and role bundles. Role-management UI is deferred.
+Examples:
+
+```text
+Operational event: deposit.accepted
+Capability:        deposit.accept
+
+Operational event: fee.waived
+Capability:        fee.waive
+```
+
+The initial implementation should favor a Ruby `Workspace::Authorization::CapabilityRegistry` as the source for baseline capability definitions and role bundles. Migrations and seeds may use the registry to create database rows, but the registry remains the code-reviewed source for baseline RBAC data. Role-management UI is deferred.
 
 ---
 
@@ -288,17 +311,33 @@ If scope is nil:
   return capabilities assigned through active, unexpired, globally scoped operator role assignments.
 
 If scope is present:
-  return globally scoped capabilities plus capabilities for matching scope_type/scope_id,
-  once a future scoped-RBAC ADR defines valid scope resolution.
+  return capabilities assigned through active, unexpired, globally scoped operator role assignments.
+  Ignore scoped assignment rows until ADR-0032 defines valid scope resolution.
 ```
 
 Operators may expose a convenience method:
 
 ```ruby
-current_operator.has_capability?("approval.standard", scope: current_authorization_scope)
+current_operator.has_capability?("reversal.create", scope: current_authorization_scope)
 ```
 
 Convenience methods must delegate to the resolver and must not duplicate role/capability traversal logic.
+
+### 6.1 Command-layer enforcement
+
+Controllers may perform capability checks for navigation, button visibility, redirects, and friendly `403` responses, but controller authorization is not sufficient for privileged writes.
+
+Control-sensitive commands must enforce required capabilities at the command boundary. This applies to commands that waive fees, place or release holds, create reversals, close the business date, approve teller-session variances, maintain authorized signers, or perform similarly privileged state changes.
+
+Commands should:
+
+- accept `actor_id` as the durable staff actor reference
+- resolve `actor_id` to an active `Workspace::Models::Operator`
+- call `Workspace::Authorization::CapabilityResolver`
+- fail closed when the actor is missing, inactive, or lacks the required capability
+- avoid direct traversal of role or capability tables outside the Workspace resolver
+
+Business rules and conditional controls remain in the owning command, policy, or domain service. For example, a command may require `reversal.create`, but reversal age, linked-hold guards, source-event status, idempotency replay, and no-self-approval checks remain explicit non-RBAC controls.
 
 ---
 
@@ -313,20 +352,20 @@ current_operator.operations?
 current_operator.admin?
 ```
 
-These helpers should remain legacy compatibility helpers during migration. They must not be redefined as aliases for one broad capability such as `approval.standard`, because a role and a capability are not equivalent.
+These helpers should remain legacy compatibility helpers during migration. They must not be redefined as aliases for one action-specific capability such as `business_date.close`, because a role and a capability are not equivalent.
 
 New control-sensitive checks should use capabilities directly:
 
 ```ruby
-current_operator.has_capability?("approval.standard")
-current_operator.has_capability?("txn.override.fee")
+current_operator.has_capability?("reversal.create")
+current_operator.has_capability?("fee.waive")
 ```
 
 The migration path is:
 
 1. create capability and role tables
-2. seed baseline capabilities and role bundles
-3. backfill role assignments from `operators.role`
+2. create baseline capabilities and role bundles through migration
+3. backfill role assignments from `operators.role` through migration
 4. keep `operators.role` temporarily for compatibility
 5. migrate one control-sensitive check at a time
 6. add regression tests before replacing each legacy role check
@@ -334,38 +373,55 @@ The migration path is:
 
 This avoids a big-bang authorization refactor.
 
+Production deploys must not depend on running seeds to preserve authorization behavior. The initial RBAC migrations must create the baseline capability rows, role rows, role-capability links, and global `operator_role_assignments` derived from existing `operators.role` values before any shipped role check is replaced by a capability check.
+
+Seeds remain useful for development, test, local rebuilds, and idempotent repair, but later role-management or institution-specific configuration must not rely on rerunning seeds. The compatibility backfill should create missing global assignments conservatively and preserve `operators.role` unchanged; it must not delete future assignments or reconcile institution-specific changes.
+
+Response contracts should remain stable during the migration. Existing Teller JSON errors and Branch redirect/flash behavior may continue to use legacy role-oriented wording such as "supervisor role required" while the underlying check moves to capabilities. Capability-neutral wording such as "Not authorized for this action" can be introduced later as a separate UI/API cleanup after compatibility role checks are retired.
+
+Role-management UI is deferred, but admin-managed RBAC must not ship without audit evidence. Future role assignment change records should capture, at minimum, actor, target operator, role, affected assignment, action, old and new active state, old and new `starts_at` / `ends_at`, reason, and timestamp.
+
 ---
 
 ## 8. Baseline Role Bundles
 
 Initial seeded role bundles must preserve existing behavior. The table below is a baseline, not an institution-specific final matrix.
 
-| Capability | Teller | Branch Supervisor | Operations | System Admin |
-| --- | ---: | ---: | ---: | ---: |
-| `txn.cash.deposit` | Yes | Yes | No | No |
-| `txn.cash.withdrawal` | Yes | Yes | No | No |
-| `txn.cash.check_cashing` | Yes | Yes | No | No |
-| `txn.cash.bank_draft.issue` | Yes | Yes | No | No |
-| `txn.transfer.internal` | Yes | Yes | No | No |
-| `teller.session.open` | Yes | Yes | No | No |
-| `teller.session.close` | Yes | Yes | No | No |
-| `teller.cash.manage_drawer` | Yes | Yes | No | No |
-| `txn.override.fee` | No | Yes | No | No |
-| `txn.override.hold` | No | Yes | No | No |
-| `approval.standard` | No | Yes | No | No |
-| `approval.reversal` | No | Yes | No | No |
-| `ops.exception.resolve` | No | No | Yes | No |
-| `ops.reconciliation.perform` | No | No | Yes | No |
-| `ops.batch.process` | No | No | Yes | No |
-| `audit.operational_events.view` | No | Limited | Yes | Yes |
-| `audit.posting.view` | No | No | Yes | Yes |
-| `audit.export` | No | No | Yes | No |
-| `reporting.view` | No | Limited | Yes | Yes |
-| `admin.user.manage` | No | No | No | Yes |
-| `admin.role.manage` | No | No | No | Yes |
-| `admin.system.configure` | No | No | No | Yes |
+| Capability | Teller | Branch Supervisor | CSR | Branch Manager | Operations | Auditor | System Admin |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `deposit.accept` | Yes | Yes | No | No | No | No | No |
+| `withdrawal.post` | Yes | Yes | No | No | No | No | No |
+| `transfer.complete` | Yes | Yes | No | No | No | No | No |
+| `teller_session.open` | Yes | Yes | No | No | No | No | No |
+| `teller_session.close` | Yes | Yes | No | No | No | No | No |
+| `cash_drawer.manage` | Yes | Yes | No | No | No | No | No |
+| `party.create` | Yes | Yes | Yes | Yes | No | No | No |
+| `account.open` | Yes | Yes | Yes | Yes | No | No | No |
+| `account.maintain` | No | Yes | Yes | Yes | No | No | No |
+| `hold.place` | Yes | Yes | Yes | Yes | No | No | No |
+| `fee.waive` | No | Yes | No | Yes | No | No | No |
+| `hold.release` | No | Yes | No | Yes | No | No | No |
+| `business_date.close` | No | Yes | No | No | Yes | No | No |
+| `teller_session_variance.approve` | No | Yes | No | No | Yes | No | No |
+| `reversal.create` | No | Yes | No | Yes | No | No | No |
+| `ops.batch.process` | No | No | No | No | Yes | No | No |
+| `ops.exception.resolve` | No | No | No | No | Yes | No | No |
+| `ops.reconciliation.perform` | No | No | No | No | Yes | No | No |
+| `operational_event.view` | No | Yes | Yes | Yes | Yes | Yes | Yes |
+| `journal_entry.view` | No | No | No | Yes | Yes | Yes | No |
+| `audit.export` | No | No | No | No | Yes | Yes | No |
+| `report.view` | Limited | Yes | Yes | Yes | Yes | Yes | Yes |
+| `user.manage` | No | No | No | No | No | No | Yes |
+| `role.manage` | No | No | No | No | No | No | Yes |
+| `system.configure` | No | No | No | No | No | No | Yes |
 
 System administrators do not receive financial approval capabilities by default. If a bank needs emergency financial authority for technology administrators, that must be modeled as a separate break-glass role with explicit audit and review requirements.
+
+`branch_supervisor` is the compatibility target for existing `operators.role = supervisor` records and should preserve today's migrated supervisor behavior. `csr`, `branch_manager`, and `auditor` are seeded future-facing bundles and existing operators are not backfilled into them unless development or test seed data explicitly creates those users.
+
+`operations` receives `business_date.close` and `teller_session_variance.approve` to preserve the shipped Ops control surfaces while Teller JSON remains supervisor-equivalent for those same actions.
+
+`system_admin` is a technology administration role, not a financial approval role. Support visibility through `operational_event.view` and `report.view` does not imply authority to waive fees, release holds, create reversals, close the business date, or approve teller-session variances.
 
 ---
 
@@ -387,7 +443,7 @@ Capabilities are necessary but not sufficient.
 Example:
 
 ```ruby
-return false unless operator.has_capability?("txn.cash.withdrawal")
+return false unless operator.has_capability?("withdrawal.post")
 return false unless teller_session.open?
 return false unless available_balance_minor_units >= amount_minor_units
 return approval_required if amount_minor_units > threshold_minor_units
@@ -405,19 +461,19 @@ Recommended targets:
 
 1. Standard approval
    - from: `current_operator.supervisor?`
-   - to: `current_operator.has_capability?("approval.standard")`
+   - to: action-specific capabilities such as `current_operator.has_capability?("teller_session_variance.approve")`
 
 2. Reversal approval
    - from: supervisor-only checks
-   - to: `current_operator.has_capability?("approval.reversal")`
+   - to: `current_operator.has_capability?("reversal.create")`
 
 3. Fee waiver
    - from: hardcoded supervisor check
-   - to: `current_operator.has_capability?("txn.override.fee")`
+   - to: `current_operator.has_capability?("fee.waive")`
 
 4. Admin role management, once role-management UI exists
    - from: `current_operator.admin?`
-   - to: `current_operator.has_capability?("admin.role.manage")`
+   - to: `current_operator.has_capability?("role.manage")`
 
 Broad workspace navigation should not be the first migration target. Domain controls are easier to test and carry clearer audit/control value.
 
@@ -468,7 +524,7 @@ Neutral:
 ## 13. Open Questions
 
 1. Should `operators.role` eventually be removed, retained as display-only, or retained as a default role-template hint?
-2. Should the canonical capability registry be database-first, YAML-first, or seed-managed with drift tests?
+2. Should the Ruby capability registry later be supplemented with institution-specific role configuration outside code?
 3. Should institution-specific role bundles be editable in the UI during MVP, or remain seed/config managed?
 4. Which scoped assignment types should be valid after branch/location modeling: `branch`, `location`, `operating_unit`, or something else?
 5. Should workspace navigation become capability-driven immediately, or only after control-sensitive domain gates are migrated?

--- a/docs/adr/0032-operating-units-and-branch-scope.md
+++ b/docs/adr/0032-operating-units-and-branch-scope.md
@@ -1,0 +1,409 @@
+# ADR-0032: Operating units and branch scope
+
+**Status:** Proposed  
+**Date:** 2026-04-27  
+**Decision Type:** Workspace / branch operating model architecture  
+**Aligns with:** [ADR-0018](0018-business-date-close-and-posting-invariant.md), [ADR-0025](0025-internal-workspace-ui.md), [ADR-0026](0026-branch-csr-servicing.md), [ADR-0029](0029-capability-first-authorization-layer.md), [ADR-0031](0031-cash-inventory-and-management.md), [module catalog](../architecture/bankcore-module-catalog.md)
+
+---
+
+## 1. Context and Problem Statement
+
+BankCORE currently uses `branch` in two different ways:
+
+- as an internal Rails HTML workspace namespace for teller-adjacent and CSR servicing screens
+- as a business concept in planning language, for example "Can we run a branch safely?"
+
+The application does not yet model branches, departments, regions, vault locations, or operating units as first-class records. That was acceptable while BankCORE had one conceptual branch and global staff roles, but several accepted and proposed ADRs now need a shared scope primitive:
+
+- ADR-0029 prepares capability assignments for future branch, location, or operating-unit scope.
+- ADR-0031 needs branch or operating-unit references for cash locations.
+- Teller sessions and cash drawer controls need to know where cash work happened.
+- Branch CSR servicing needs audit clarity beyond the HTTP workspace namespace.
+- Future reporting, EOD readiness, cash reconciliation, and audit review need to group activity by organizational place.
+
+BankCORE needs a model for operating units before it adds scoped authorization, branch cash custody, branch dashboards, or branch-aware audit reporting. That model must not accidentally introduce multi-branch business dates, branch-level GL ledgers, or multi-entity accounting before those concerns are explicitly designed.
+
+---
+
+## 2. Decision Drivers
+
+- Provide one canonical organizational scope model for staff, teller, cash, audit, and reporting use.
+- Preserve the current singleton business date and centralized financial kernel.
+- Avoid encoding branch behavior into workspace route names, role strings, or cash-location enums.
+- Support future branches, departments, regions, and centralized operations without redesigning scoped authorization.
+- Make branch/location context durable audit data for operator actions.
+- Keep the first implementation slice small enough to support current branch-safe MVP work.
+- Avoid treating operating-unit scope as a ledger segment, legal entity, or separate books model.
+
+---
+
+## 3. Considered Options
+
+| Option | Pros | Cons |
+| :--- | :--- | :--- |
+| **Keep branch as a UI namespace only** | No new persistence; matches the current Branch workspace. | Cannot scope authorization, cash locations, teller sessions, audit evidence, or reporting. |
+| **Add a `branches` table only** | Simple and intuitive for teller/cash workflows. | Too narrow for operations centers, regions, departments, centralized vaults, or future non-branch scopes. |
+| **Add a general `operating_units` model with branch as the first unit type** | Creates one reusable scope primitive for branch, cash, staff authority, audit, and reporting. | Requires clearer rules so teams do not treat it as multi-entity accounting or branch-level business date behavior. |
+| **Use GL segments or entities as branch scope** | Aligns with future financial reporting dimensions. | Prematurely couples operational scope to accounting structure and risks fragmenting the ledger model. |
+
+---
+
+## 4. Decision Outcome
+
+**Chosen Option: Add a general `operating_units` model with branch as the first unit type.**
+
+BankCORE will introduce operating units as the canonical organizational scope for internal operations. A branch is an operating unit with `unit_type: branch`.
+
+Operating units answer:
+
+```text
+Where is this internal work happening?
+Which organizational unit owns or supervises this operational resource?
+What scope applies to this staff authority assignment?
+```
+
+Operating units do not answer:
+
+```text
+Which ledger owns this money?
+Which business date is open?
+Which legal entity owns these books?
+```
+
+The first implementation should seed one institution-level operating unit and one branch-level operating unit so existing single-branch behavior can become explicit without changing financial outcomes.
+
+### 4.1 Core invariants
+
+- Operating-unit scope is operational and organizational; it is not a second ledger.
+- Posting, journal entries, journal lines, trial balance, and account balances remain owned by the existing financial kernel.
+- Business date remains the singleton model from ADR-0018 unless a future ADR introduces branch-scoped business dates.
+- Branch workspace routes do not imply branch scope by themselves; controllers must resolve scope from authenticated operator/session context or explicit persisted records.
+- Staff authority may be global or operating-unit scoped, but capabilities remain attempt authorization only. Conditional controls stay in policy, command, workflow, and domain validation layers.
+- Corrections to scope-sensitive operational records must be auditable. Posted financial history must not be silently rewritten to change operating-unit attribution.
+
+---
+
+## 5. Domain Ownership
+
+### 5.1 `Workspace`
+
+`Workspace` owns internal staff identity, session context, and operating-unit scope resolution.
+
+It should own:
+
+- `operating_units`
+- operator home or default operating-unit references
+- scoped operator role assignments when ADR-0029 is implemented
+- current internal authorization context resolution
+
+Representative services:
+
+- `Workspace::OperatingUnits::ResolveCurrentOperatingUnit`
+- `Workspace::Authorization::CapabilityResolver`
+- `Workspace::Queries::OperatingUnitTree`
+
+### 5.2 `Teller`
+
+`Teller` owns teller-session lifecycle and should record the operating unit where a session is opened.
+
+Teller sessions should eventually include:
+
+```text
+operating_unit_id
+cash_location_id
+operator_id
+business_date
+status
+```
+
+Teller commands must reject ambiguous scope once the first implementation requires operating-unit context for teller sessions.
+
+### 5.3 `Cash`
+
+`Cash` owns cash locations and custody movement. Cash locations should reference operating units once ADR-0031 is implemented.
+
+Examples:
+
+```text
+Main Branch Vault -> operating_unit: Main Branch
+Teller Drawer 3   -> operating_unit: Main Branch
+Central Vault     -> operating_unit: Central Operations
+```
+
+Cash commands must keep custody scope separate from GL ownership. Internal movement between two cash locations may change operating-unit custody without changing aggregate GL cash when both locations remain within institutional custody.
+
+### 5.4 Core domains
+
+`Core::OperationalEvents` should preserve actor, channel, business date, and, where applicable, operating-unit context for audit and support.
+
+`Core::Posting`, `Core::Ledger`, and `Core::BusinessDate` remain centralized in this ADR. They must not infer branch-level books or branch-level business dates from operating-unit records.
+
+---
+
+## 6. Data Model
+
+### 6.1 `operating_units`
+
+Stores the organizational units used for internal staff scope, branch operations, cash custody, and reporting.
+
+```text
+id
+code
+name
+unit_type
+parent_operating_unit_id
+status
+time_zone
+opened_on
+closed_on
+created_at
+updated_at
+```
+
+Initial `unit_type` values:
+
+```text
+institution
+branch
+operations
+department
+region
+```
+
+Initial `status` values:
+
+```text
+active
+inactive
+closed
+```
+
+Rules:
+
+- `code` is unique and stable enough for operator-facing configuration and seeded references.
+- `unit_type` is an operating model classification, not an authorization role.
+- `parent_operating_unit_id` supports a simple hierarchy such as institution -> region -> branch.
+- `time_zone` is operational metadata and does not create a separate business date.
+- `closed_on` prevents new routine assignment or location creation after closure, but historical records remain linked.
+
+### 6.2 Operator references
+
+The first implementation may add a default operating-unit reference to operators:
+
+```text
+operators.default_operating_unit_id
+```
+
+This is a convenience for current UI/session scope. It is not the full authority model. Actual authority should come from ADR-0029 role assignments once that layer is implemented.
+
+### 6.3 Scoped role assignments
+
+ADR-0029's scope fields should use operating units as the first concrete scope type:
+
+```text
+operator_role_assignments.scope_type = "operating_unit"
+operator_role_assignments.scope_id = operating_units.id
+```
+
+Global assignments remain represented by `scope_type: nil` and `scope_id: nil`.
+
+### 6.4 Operational records
+
+First-slice records that should carry operating-unit context:
+
+- `teller_sessions.operating_unit_id`
+- `cash_locations.operating_unit_id` once Cash is implemented
+- `cash_movements` via source and destination cash locations
+
+Future records that may carry operating-unit context directly:
+
+- `operational_events.operating_unit_id`
+- approval requests and approval decisions
+- reporting extracts or materialized branch dashboards
+
+The implementation should avoid duplicating operating-unit id on every table until there is a concrete query, audit, or integrity need. Derivation through teller session, cash location, operator assignment, or operational event may be sufficient for early slices.
+
+---
+
+## 7. Scope Resolution
+
+Internal requests should resolve operating-unit context explicitly.
+
+Initial resolution order for Branch HTML teller-adjacent workflows:
+
+1. Use the open teller session's `operating_unit_id` when the action depends on teller session state.
+2. Use the selected cash location's `operating_unit_id` for cash location workflows.
+3. Use the authenticated operator's default operating unit for read-only branch navigation and form defaults.
+4. Require an explicit operator-selected operating unit when an operator has authority in multiple active units and no session or location determines the scope.
+
+Controllers must not trust a hidden field or arbitrary param as proof of scope authority. If a form submits `operating_unit_id`, the controller or command must verify that the authenticated operator may act in that unit through the scoped authorization resolver or a temporary compatibility rule.
+
+---
+
+## 8. Worked Examples
+
+### 8.1 Teller opens a session at Main Branch
+
+Command:
+
+```text
+Teller::Commands::OpenSession
+  operator_id: 101
+  operating_unit_id: main_branch
+  business_date: current open day
+  opening_cash_minor_units: 100000
+```
+
+Operational result:
+
+- Create an open teller session linked to Main Branch.
+- Use the session operating unit for teller cash transactions during that session.
+- Keep transaction posting behavior unchanged.
+
+Posting outline:
+
+```text
+No journal entry for opening the session.
+Future deposits and withdrawals post through existing operational events and posting rules.
+```
+
+### 8.2 Branch supervisor authority is scoped to one branch
+
+Assignment:
+
+```text
+Operator 202
+  role: branch_supervisor
+  scope_type: operating_unit
+  scope_id: main_branch
+```
+
+Behavior:
+
+- The operator may approve branch-supervisor actions in Main Branch.
+- The same operator has no supervisor authority in another branch unless granted globally or assigned there too.
+- No-self-approval, thresholds, active session, and business-date checks still run outside capability resolution.
+
+### 8.3 Vault-to-drawer cash movement
+
+Command:
+
+```text
+Cash::Commands::TransferCash
+  source_location: Main Branch Vault
+  destination_location: Teller Drawer 3
+  amount_minor_units: 100000
+  currency: USD
+  actor_id: 101
+  approval_actor_id: 202
+```
+
+Operational result:
+
+- Both locations carry `operating_unit_id: main_branch`.
+- Cash custody moves from vault to drawer.
+- No GL posting occurs for an internal custody transfer within institutional cash.
+
+Posting outline:
+
+```text
+No journal entry.
+Cash subledger:
+  Main Branch Vault -100000
+  Teller Drawer 3   +100000
+```
+
+---
+
+## 9. MVP Boundary and Phasing
+
+### First operating-unit slice
+
+The first implementation slice should include:
+
+- `operating_units` with seeded institution and branch records
+- `operators.default_operating_unit_id` or equivalent session-default support
+- `teller_sessions.operating_unit_id`
+- operating-unit scope object support for ADR-0029 capability resolution
+- Branch UI/session defaults that make the current branch explicit
+- tests proving existing single-branch teller and Branch CSR behavior remains unchanged
+
+### Follow-up slices
+
+Likely follow-up work:
+
+- `cash_locations.operating_unit_id` with ADR-0031 Cash implementation
+- scoped role assignment backfill and enforcement
+- branch-aware operational event search filters
+- branch cash position and reconciliation reports
+- branch dashboards for open sessions, pending approvals, and cash exceptions
+
+### Deferred
+
+The following are post-MVP unless a selected branch story requires them earlier:
+
+- branch-scoped business dates
+- day close by branch or region
+- branch GL segments or branch-level financial statements
+- multi-entity accounting
+- interbranch settlement accounting
+- customer/account home-branch ownership rules
+- branch transfer, consolidation, merger, and closure workflows
+- branch holiday calendars and cutoff policies
+
+---
+
+## 10. Technical Consequences
+
+Positive:
+
+- Gives BankCORE one reusable scope primitive for staff authority, teller sessions, cash custody, audit, and reporting.
+- Lets ADR-0029 scoped authorization become concrete without inventing branch-specific role logic.
+- Supports ADR-0031 cash locations without overloading cash-location type values.
+- Improves audit evidence for where internal staff work happened.
+
+Negative:
+
+- Adds organizational reference data and scope-resolution code.
+- Requires migration and seed discipline even in the current single-branch implementation.
+- Creates risk that teams accidentally infer financial segmentation from operational scope.
+- Requires authorization tests for multi-unit staff scenarios once scoped roles are enforced.
+
+Neutral:
+
+- Existing Branch HTML routes remain the same.
+- Existing teller JSON routes can preserve current behavior while defaulting to the seeded branch during migration.
+- Operating-unit hierarchy can remain shallow until regional or centralized operations workflows need it.
+
+---
+
+## 11. Risks and Mitigations
+
+| Risk | Mitigation |
+| :--- | :--- |
+| Operating units become a second ledger segmentation model | State explicitly that ledger and posting remain centralized; require a future GL ADR for branch financial statements or segment accounting. |
+| Branch routes are mistaken for branch authority | Resolve scope from session, cash location, operator context, or explicit authorized selection, not route namespace alone. |
+| Default branch masks missing scope in multi-branch scenarios | Allow defaulting only while the system has one seeded branch or for read-only navigation; require explicit scope once multiple units are active. |
+| Scoped authorization bypasses conditional controls | Keep capabilities as attempt authorization only; enforce thresholds, no-self-approval, dual control, business date, and session rules in commands and workflow. |
+| Historical records lose branch context after organizational changes | Keep operating-unit rows stable and historical links intact; close or inactivate units rather than deleting them. |
+| Operating-unit hierarchy gets over-modeled | Start with institution and branch; add region, department, and operations usage only when a workflow needs them. |
+
+---
+
+## 12. Open Questions
+
+1. Should `operating_units` live physically under a `Workspace` namespace, or should BankCORE introduce a small `Organization` domain later if the model grows beyond internal staff scope?
+2. Should `operational_events` carry `operating_unit_id` directly in the first slice, or derive it from teller session, cash location, and actor context until branch-aware event search is implemented?
+3. Should account opening record an account home operating unit, or should customer/account home-branch ownership remain deferred?
+4. What compatibility behavior should teller JSON APIs use before clients send explicit operating-unit context?
+5. Should inactive and closed operating units remain selectable for historical reporting but blocked for new sessions, locations, and role assignments?
+6. Should branch-aware EOD readiness be a filtered view over the singleton business date, or should it wait until branch-scoped business dates are designed?
+
+---
+
+## 13. Decision Summary
+
+BankCORE will model branches as operating units rather than treating branch as only a UI namespace or a special-purpose teller/cash field.
+
+Operating units provide durable organizational scope for staff authority, teller sessions, cash locations, audit evidence, and branch reporting. They do not create branch-level business dates, branch ledgers, or separate financial truth. The first slice should seed one institution and one branch, attach teller sessions and staff defaults to that scope, and prepare scoped authorization while preserving the current singleton business date and centralized posting/ledger model.

--- a/docs/architecture/bankcore-module-catalog.md
+++ b/docs/architecture/bankcore-module-catalog.md
@@ -856,7 +856,7 @@ Each table family should have **one owning domain** even if all tables live in o
 | `holds`                                                      | `Accounts`                |
 | `deposit_statements`                                         | `Deposits`                |
 | `authorization_decisions`                                    | `Limits`                  |
-| `operators`                                                  | `Workspace`               |
+| `operators`, `operator_credentials`, `capabilities`, `roles`, `role_capabilities`, `operator_role_assignments`, future `operator_role_assignment_audits` | `Workspace`               |
 | `teller_sessions`, `teller_transactions`                     | `Teller`                  |
 | `cash_locations`, `vault_transfers`, `cash_counts`           | `Cash`                    |
 | `approval_requests`, `approval_decisions`                    | `Workflow`                |

--- a/docs/rbac-plan.md
+++ b/docs/rbac-plan.md
@@ -1,0 +1,575 @@
+# RBAC implementation plan
+
+**Status:** Draft  
+**Last reviewed:** 2026-04-27  
+**Primary ADR:** [ADR-0029: Capability-first authorization layer](adr/0029-capability-first-authorization-layer.md)
+
+This plan uses "RBAC" as shorthand for BankCORE's capability-first staff authorization model. Roles are bundles of capabilities; capabilities are the authorization primitive.
+
+The first implementation must preserve existing behavior while creating a path away from hardcoded checks such as `operator.supervisor?`, `operator.operations?`, and `operator.admin?`.
+
+---
+
+## 1. Goals
+
+- Preserve `Workspace::Models::Operator` as the canonical internal staff actor.
+- Keep `operators.role` during migration as compatibility data.
+- Add role bundles and capability checks without changing financial outcomes.
+- Migrate high-control gates incrementally, with regression tests before each replacement.
+- Keep internal staff authorization separate from customer, partner, fintech, ACH participant, wire, card, or external API authorization.
+
+RBAC answers only:
+
+```text
+May this internal staff operator attempt this category of action?
+```
+
+RBAC must not encode conditional controls.
+
+Examples of rules that remain outside RBAC:
+
+- transaction limits
+- approval thresholds
+- active teller session checks
+- available-balance and hold rules
+- account restrictions
+- no-self-approval
+- dual control
+- business-date rules
+- reversal age, amount, and source-event status rules
+- operating-unit scope rules until ADR-0032 is implemented
+
+---
+
+## 2. Ownership and boundaries
+
+Module owner: `Workspace`.
+
+Workspace owns:
+
+- staff operator identity
+- RBAC persistence
+- role bundle resolution
+- capability resolution
+- future scoped staff authority integration
+
+Other domains may ask authorization questions through the Workspace resolver, but they must not own separate role or capability tables.
+
+RBAC does not change `Core::OperationalEvents`, `Core::Posting`, `Core::Ledger`, or `Core::BusinessDate` invariants. It does not introduce new money movement, new posting rules, new reversal semantics, branch-level business dates, or branch-level ledgers.
+
+---
+
+## 3. Role model
+
+Target seeded role bundles:
+
+- `teller`
+- `branch_supervisor`
+- `csr`
+- `branch_manager`
+- `operations`
+- `auditor`
+- `system_admin`
+
+Compatibility mapping from existing roles:
+
+| Existing `operators.role` | Initial role assignment |
+| --- | --- |
+| `teller` | `teller` |
+| `supervisor` | `branch_supervisor` |
+| `operations` | `operations` |
+| `admin` | `system_admin` |
+
+Seed `csr`, `branch_manager`, and `auditor` roles in the first slice, but do not assign existing operators to them unless a dev/test seed explicitly needs those users.
+
+System administrators must not receive financial approval capabilities by default. If a bank needs emergency financial authority for technology administrators, model it later as a separate break-glass role with explicit audit and review requirements.
+
+---
+
+## 4. Data foundation
+
+Add Workspace-owned tables:
+
+### `capabilities`
+
+Purpose: canonical atomic permission codes.
+
+Columns:
+
+- `code`
+- `name`
+- `description`
+- `category`
+- `active`
+- timestamps
+
+Constraints:
+
+- unique `code`
+- `code` must be stable
+- inactive capabilities grant nothing
+
+### `roles`
+
+Purpose: named role bundles.
+
+Columns:
+
+- `code`
+- `name`
+- `description`
+- `active`
+- `system_role`
+- timestamps
+
+Constraints:
+
+- unique `code`
+- inactive roles grant nothing
+- `system_role` seeded roles are protected from routine deletion once role management exists
+
+### `role_capabilities`
+
+Purpose: join table between roles and capabilities.
+
+Columns:
+
+- `role_id`
+- `capability_id`
+- timestamps
+
+Constraints:
+
+- unique pair of `role_id`, `capability_id`
+
+### `operator_role_assignments`
+
+Purpose: assigns role bundles to operators.
+
+Columns:
+
+- `operator_id`
+- `role_id`
+- `scope_type`
+- `scope_id`
+- `active`
+- `starts_at`
+- `ends_at`
+- timestamps
+
+Constraints:
+
+- global assignments use `scope_type: nil` and `scope_id: nil`
+- add a uniqueness rule for global assignments by `operator_id` and `role_id`
+- reserve `scope_type` and `scope_id` for ADR-0032 operating-unit scope, but do not activate scoped resolution in the first RBAC slice
+- `starts_at` and `ends_at` are nullable `datetime` columns
+- `starts_at: nil` means active immediately
+- `ends_at: nil` means no scheduled end
+- assignment windows use `starts_at <= Time.current` and `Time.current < ends_at`
+- `ends_at` is exclusive
+
+---
+
+## 5. Models and services
+
+Add models:
+
+- `Workspace::Models::Capability`
+- `Workspace::Models::Role`
+- `Workspace::Models::RoleCapability`
+- `Workspace::Models::OperatorRoleAssignment`
+
+Add authorization services:
+
+- `Workspace::Authorization::CapabilityRegistry`
+- `Workspace::Authorization::CapabilityResolver`
+
+Add operator convenience methods:
+
+```ruby
+operator.capabilities(scope: nil)
+operator.has_capability?("reversal.create", scope: nil)
+```
+
+The operator methods must delegate to `Workspace::Authorization::CapabilityResolver`. They must not duplicate role traversal logic.
+
+Initial resolver contract:
+
+```ruby
+Workspace::Authorization::CapabilityResolver.capabilities_for(operator:, scope: nil)
+Workspace::Authorization::CapabilityResolver.has_capability?(operator:, capability_code:, scope: nil)
+```
+
+Initial resolver rules:
+
+- inactive operators receive no capabilities
+- inactive assignments grant nothing
+- assignments outside `starts_at` / `ends_at` grant nothing
+- inactive roles grant nothing
+- inactive capabilities grant nothing
+- unknown capability codes fail closed
+- first slice supports global assignments only
+- `scope: nil` checks active global assignments only
+- `scope: <non-nil>` also checks active global assignments only
+- scoped assignment rows grant nothing until ADR-0032 scope resolution is implemented
+
+### Command-layer authorization
+
+Controllers may perform capability checks for workspace navigation, button visibility, redirects, and friendly `403` responses, but controller checks are not sufficient for privileged writes.
+
+Control-sensitive commands must enforce required capabilities at the command boundary. Commands should accept `actor_id`, resolve it to an active `Workspace::Models::Operator`, call `Workspace::Authorization::CapabilityResolver`, and fail closed if the actor is missing, inactive, or lacks the required capability.
+
+Commands must not traverse role or capability tables directly. Other domains may ask authorization questions only through the Workspace resolver.
+
+Business rules and conditional controls remain outside RBAC. For example, a command may require `reversal.create`, but reversal age, linked-hold guards, source-event status, idempotency replay, account status, no-self-approval, and business-date readiness remain explicit domain rules.
+
+---
+
+## 6. Seed and backfill
+
+Add `BankCore::Seeds::Rbac.seed!`.
+
+Production baseline RBAC data and the initial compatibility backfill must be created by migration, not only by seeds. The migration must run before any production code path depends on capability checks and should:
+
+1. Upsert baseline capabilities from the canonical registry.
+2. Upsert baseline roles.
+3. Upsert role-capability links.
+4. Backfill global `operator_role_assignments` from existing `operators.role`.
+5. Preserve `operators.role` unchanged.
+
+The compatibility backfill should be conservative: create missing global assignments from known legacy role values, but do not delete role assignments or attempt to reconcile future institution-specific changes.
+
+`BankCore::Seeds::Rbac.seed!` remains useful for development, test, local rebuilds, and idempotent repair. Call RBAC seeds from `db/seeds.rb`, but do not rely on seeds as the production deploy contract.
+
+Development and test seeds should still create the existing sample operators. RBAC backfill must run after those operators exist.
+
+Existing response contracts should remain stable during the migration. Teller JSON responses may keep legacy messages such as `{ "error": "forbidden", "message": "supervisor role required" }`, and Branch controllers may keep current redirect/flash wording while their underlying checks move to capabilities. Capability-neutral wording can be handled later as a separate UI/API cleanup.
+
+---
+
+## 7. Initial capability set
+
+Seed the capabilities needed for existing workflows and near-term migrations first.
+
+Capability codes follow the pattern `<object>.<action>`. Use the same business object vocabulary as operational events, but use present-tense authority verbs instead of past-tense event facts.
+
+Examples:
+
+```text
+Operational event: deposit.accepted
+Capability:        deposit.accept
+
+Operational event: hold.released
+Capability:        hold.release
+```
+
+### Transaction and teller capabilities
+
+- `deposit.accept`
+- `withdrawal.post`
+- `transfer.complete`
+- `teller_session.open`
+- `teller_session.close`
+- `cash_drawer.manage`
+
+### Control and approval capabilities
+
+- `hold.place`
+- `fee.waive`
+- `hold.release`
+- `reversal.create`
+- `teller_session_variance.approve`
+- `business_date.close`
+
+### Party and account capabilities
+
+- `party.create`
+- `account.open`
+- `account.maintain`
+
+### Ops, audit, and reporting capabilities
+
+- `ops.batch.process`
+- `ops.exception.resolve`
+- `ops.reconciliation.perform`
+- `operational_event.view`
+- `journal_entry.view`
+- `audit.export`
+- `report.view`
+
+### Admin capabilities
+
+- `user.manage`
+- `role.manage`
+- `system.configure`
+
+Capabilities from the broader matrix that do not have shipped workflows yet may be added later when the workflow is implemented. Examples include check cashing, bank draft issuance, external transfers, identity overrides, vault access, vault transfers, high-value approvals, account close, account restrictions, and audit export if export remains unimplemented.
+
+---
+
+## 8. Baseline role-to-capability matrix
+
+The initial matrix is conservative and behavior-preserving. `branch_supervisor` is the compatibility target for existing `operators.role = supervisor` records. `csr`, `branch_manager`, and `auditor` are seeded future-facing bundles, but existing operators are not backfilled into them unless development or test seed data explicitly creates those users.
+
+| Capability | Teller | Branch Supervisor | CSR | Branch Manager | Operations | Auditor | System Admin |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `deposit.accept` | Yes | Yes | No | No | No | No | No |
+| `withdrawal.post` | Yes | Yes | No | No | No | No | No |
+| `transfer.complete` | Yes | Yes | No | No | No | No | No |
+| `teller_session.open` | Yes | Yes | No | No | No | No | No |
+| `teller_session.close` | Yes | Yes | No | No | No | No | No |
+| `cash_drawer.manage` | Yes | Yes | No | No | No | No | No |
+| `party.create` | Yes | Yes | Yes | Yes | No | No | No |
+| `account.open` | Yes | Yes | Yes | Yes | No | No | No |
+| `account.maintain` | No | Yes | Yes | Yes | No | No | No |
+| `hold.place` | Yes | Yes | Yes | Yes | No | No | No |
+| `fee.waive` | No | Yes | No | Yes | No | No | No |
+| `hold.release` | No | Yes | No | Yes | No | No | No |
+| `business_date.close` | No | Yes | No | No | Yes | No | No |
+| `teller_session_variance.approve` | No | Yes | No | No | Yes | No | No |
+| `reversal.create` | No | Yes | No | Yes | No | No | No |
+| `ops.batch.process` | No | No | No | No | Yes | No | No |
+| `ops.exception.resolve` | No | No | No | No | Yes | No | No |
+| `ops.reconciliation.perform` | No | No | No | No | Yes | No | No |
+| `operational_event.view` | No | Yes | Yes | Yes | Yes | Yes | Yes |
+| `journal_entry.view` | No | No | No | Yes | Yes | Yes | No |
+| `audit.export` | No | No | No | No | Yes | Yes | No |
+| `report.view` | Limited | Yes | Yes | Yes | Yes | Yes | Yes |
+| `user.manage` | No | No | No | No | No | No | Yes |
+| `role.manage` | No | No | No | No | No | No | Yes |
+| `system.configure` | No | No | No | No | No | No | Yes |
+
+`operations` receives `business_date.close` and `teller_session_variance.approve` to preserve the shipped Ops control surfaces while Teller JSON remains supervisor-equivalent for those same actions.
+
+`system_admin` is a technology administration role, not a financial approval role. Support visibility through `operational_event.view` and `report.view` does not imply authority to waive fees, release holds, create reversals, close the business date, or approve teller-session variances.
+
+---
+
+## 9. Migration order
+
+Migrate one gate group at a time.
+
+### Step 1: Add data and resolver foundation
+
+- Add migrations, models, registry, seeds, and resolver.
+- Create baseline RBAC data in migration.
+- Backfill role assignments from existing operators in migration.
+- Keep all current role checks in place.
+- Add safety tests.
+
+Exit criteria:
+
+- Existing tests still pass.
+- Existing operators have equivalent RBAC assignments.
+- Production deploys do not depend on seeds to preserve existing authorization behavior.
+- No production code path depends on RBAC yet.
+
+### Step 2: Reversal approval
+
+Replace supervisor-only reversal checks with:
+
+```ruby
+current_operator.has_capability?("reversal.create")
+```
+
+Targets:
+
+- Teller reversal create
+- Branch reversal create
+
+Regression expectations:
+
+- teller cannot create reversal
+- branch supervisor can create reversal
+- system admin cannot create reversal by default
+
+### Step 3: Standard approval
+
+Replace selected supervisor approval gates with:
+
+```ruby
+current_operator.has_capability?("teller_session_variance.approve")
+current_operator.has_capability?("business_date.close")
+```
+
+Initial targets:
+
+- teller session variance approval
+- business date close, if it remains supervisor-equivalent for the first migration
+
+Do not move no-self-approval, thresholds, or EOD readiness into RBAC.
+
+### Step 4: Fee and hold overrides
+
+Replace fee and hold supervisor gates with:
+
+```ruby
+current_operator.has_capability?("fee.waive")
+current_operator.has_capability?("hold.release")
+```
+
+Initial targets:
+
+- Branch fee waiver
+- Branch account hold release
+
+### Step 5: Account maintenance
+
+Replace authorized-signer maintenance supervisor gates with:
+
+```ruby
+current_operator.has_capability?("account.maintain")
+```
+
+Initial targets:
+
+- authorized signer add
+- authorized signer end
+
+If account maintenance becomes too broad, split it later into more specific capability codes such as `account.party.maintain`.
+
+These checks must be enforced inside the Accounts commands, not only in Branch controllers, because the commands are the durable write boundary for authorized-signer maintenance.
+
+### Step 6: Workspace navigation
+
+Only after control-sensitive gates are stable, migrate workspace navigation checks:
+
+- Branch workspace access
+- Ops workspace access
+- Admin workspace access
+
+Do not make workspace navigation the first migration target. It is broad and easier to over-grant.
+
+---
+
+## 10. Tests
+
+Add focused tests before replacing any role gate.
+
+Foundation tests:
+
+- seeded capability codes are unique
+- seeded role codes are unique
+- every role-capability link points to a registered capability
+- every capability literal used by migrated authorization code exists in `CapabilityRegistry`
+- no migrated code references deprecated capability names
+- backfill creates expected assignments from existing `operators.role`
+- inactive role assignment grants no capabilities
+- expired role assignment grants no capabilities
+- inactive role grants no capabilities
+- inactive capability grants no capabilities
+- unknown capability checks fail closed
+- `system_admin` does not receive financial approval capabilities by default
+
+Migration tests:
+
+- teller cannot approve reversals
+- branch supervisor can approve reversals
+- system admin cannot approve reversals by default
+- teller cannot approve session variance
+- branch supervisor can approve session variance
+- branch fee waiver requires `fee.waive`
+- branch hold release requires `hold.release`
+- authorized-signer maintenance requires `account.maintain`
+- privileged command tests prove command-level enforcement even when called without a controller preflight check
+
+Regression stance:
+
+- Each migrated gate must prove the same allow/deny behavior as the old role check unless the change is explicitly called out in the test name and implementation notes.
+
+---
+
+## 11. Deferred work
+
+Defer until after the first RBAC foundation is stable:
+
+- role-management UI
+- audit records for role assignment changes
+- operating-unit scoped assignments
+- branch/location authority resolution
+- capability-driven menus and workspace navigation polish
+- break-glass financial authority for system administrators
+- customer, partner, fintech, ACH participant, wire, card, or external API authorization
+- threshold engines, approval queues, or generalized Workflow tables
+
+Before role-management UI ships, role and capability assignment changes must have audit evidence. At minimum, record actor, changed operator, old assignment, new assignment, timestamp, and reason.
+
+Future admin-managed RBAC audit records should capture actor, target operator, role, affected assignment, action, old and new active state, old and new `starts_at` / `ends_at`, reason, and timestamp. Phase 1 may defer the audit table while RBAC changes remain migration/seed-managed.
+
+---
+
+## 12. Implementation plan and checklist
+
+### Implementation plan
+
+Implement RBAC as small vertical slices.
+
+#### Slice 1A: Foundation only
+
+Scope:
+
+- migrations for RBAC tables, indexes, baseline data, and compatibility backfill
+- `Workspace::Models::*` RBAC models and associations
+- `Workspace::Authorization::CapabilityRegistry` as the code-reviewed source for baseline capability and role-bundle data
+- `Workspace::Authorization::CapabilityResolver`
+- `Operator#capabilities` and `Operator#has_capability?`
+- `BankCore::Seeds::Rbac.seed!` for development, test, local rebuilds, and repair
+- foundation, temporal-window, scope, backfill, matrix, and drift tests
+
+Do not replace any production role checks in Slice 1A. The exit condition is that RBAC data exists, resolver behavior is proven, existing operators have equivalent assignments, and no shipped code path depends on RBAC yet.
+
+#### Slice 1B: Reversal creation
+
+Replace reversal authorization with `reversal.create` in the Teller and Branch entry points, with command-level enforcement where the reversal write is performed. Preserve existing JSON and redirect response contracts.
+
+#### Slice 1C: Standard approvals
+
+Replace teller-session variance approval with `teller_session_variance.approve` and business-date close with `business_date.close`, keeping EOD readiness, no-self-approval, variance threshold, and business-date rules outside RBAC.
+
+#### Slice 1D: Fee and hold controls
+
+Replace fee waiver and hold release gates with `fee.waive` and `hold.release`. Keep hold eligibility, linked-deposit constraints, and posting/reversal guards in the owning domain commands.
+
+#### Slice 1E: Account maintenance
+
+Replace authorized-signer maintenance supervisor checks with `account.maintain` inside the Accounts commands. Keep account status, party validity, idempotency replay, and audit writes in Accounts.
+
+#### Slice 1F: Workspace navigation
+
+Only after control-sensitive writes are stable, migrate Branch, Ops, and Admin navigation helpers to capability checks. This should be a UI/navigation cleanup, not a control replacement for privileged writes.
+
+### Ordered checklist
+
+1. Add RBAC migrations.
+2. Add RBAC models and associations.
+3. Add `CapabilityRegistry`.
+4. Add `CapabilityResolver`.
+5. Add `Operator#capabilities` and `Operator#has_capability?`.
+6. Create baseline RBAC data and compatibility assignments in migration.
+7. Add `BankCore::Seeds::Rbac.seed!`.
+8. Call RBAC seeds from `db/seeds.rb`.
+9. Add foundation tests and capability drift tests.
+10. Stop after the foundation slice and verify no production code path depends on RBAC yet.
+11. Migrate reversal approval checks.
+12. Add reversal authorization regression tests.
+13. Migrate standard approval checks.
+14. Add standard approval regression tests.
+15. Migrate fee and hold override checks.
+16. Add override regression tests.
+17. Migrate account maintenance checks.
+18. Add account maintenance regression tests.
+19. Revisit workspace navigation checks after control gates are stable.
+
+---
+
+## 13. Success criteria
+
+RBAC Phase 1 is complete when:
+
+- baseline capabilities and role bundles are registry-managed and created by migration
+- existing operators are backfilled into equivalent role assignments
+- high-control supervisor gates are capability-based
+- existing behavior is preserved by tests
+- system administrators do not accidentally gain financial approval authority
+- `operators.role` remains available for compatibility
+- no financial posting, ledger, business-date, or reversal invariant changes are introduced

--- a/lib/bank_core/seeds/rbac.rb
+++ b/lib/bank_core/seeds/rbac.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module BankCore
+  module Seeds
+    module Rbac
+      def self.seed!
+        now = Time.current
+
+        Workspace::Authorization::CapabilityRegistry::CAPABILITIES.each do |attrs|
+          capability = Workspace::Models::Capability.find_or_initialize_by(code: attrs.fetch(:code))
+          capability.assign_attributes(
+            name: attrs.fetch(:name),
+            description: attrs[:description],
+            category: attrs.fetch(:category),
+            active: true
+          )
+          capability.save!
+        end
+
+        Workspace::Authorization::CapabilityRegistry::ROLES.each do |attrs|
+          role = Workspace::Models::Role.find_or_initialize_by(code: attrs.fetch(:code))
+          role.assign_attributes(
+            name: attrs.fetch(:name),
+            description: attrs[:description],
+            active: true,
+            system_role: true
+          )
+          role.save!
+        end
+
+        capabilities_by_code = Workspace::Models::Capability.where(
+          code: Workspace::Authorization::CapabilityRegistry.capability_codes
+        ).index_by(&:code)
+        roles_by_code = Workspace::Models::Role.where(
+          code: Workspace::Authorization::CapabilityRegistry.role_codes
+        ).index_by(&:code)
+
+        Workspace::Authorization::CapabilityRegistry.role_capability_pairs.each do |pair|
+          Workspace::Models::RoleCapability.find_or_create_by!(
+            role: roles_by_code.fetch(pair.fetch(:role_code)),
+            capability: capabilities_by_code.fetch(pair.fetch(:capability_code))
+          )
+        end
+
+        Workspace::Models::Operator.find_each do |operator|
+          role_code = Workspace::Authorization::CapabilityRegistry::LEGACY_ROLE_MAPPING[operator.role]
+          next if role_code.blank?
+
+          Workspace::Models::OperatorRoleAssignment.find_or_create_by!(
+            operator: operator,
+            role: roles_by_code.fetch(role_code),
+            scope_type: nil,
+            scope_id: nil
+          ) do |assignment|
+            assignment.active = true
+            assignment.starts_at = nil
+            assignment.ends_at = nil
+            assignment.created_at = now
+            assignment.updated_at = now
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/domains/accounts/queries/list_holds_for_account_test.rb
+++ b/test/domains/accounts/queries/list_holds_for_account_test.rb
@@ -7,6 +7,7 @@ class ListHoldsForAccountTest < ActiveSupport::TestCase
     Core::BusinessDate::Models::BusinessDateSetting.delete_all
     Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.new(2026, 9, 3))
     @operator = Workspace::Models::Operator.create!(role: "teller", display_name: "Hold Teller", active: true)
+    @supervisor = Workspace::Models::Operator.create!(role: "supervisor", display_name: "Hold Supervisor", active: true)
   end
 
   test "lists holds and active total for an account" do
@@ -31,7 +32,7 @@ class ListHoldsForAccountTest < ActiveSupport::TestCase
       hold_id: released.id,
       channel: "branch",
       idempotency_key: "release-hold",
-      actor_id: @operator.id
+      actor_id: @supervisor.id
     )
 
     result = Accounts::Queries::ListHoldsForAccount.call(deposit_account_id: account.id)

--- a/test/domains/core/business_date/close_business_date_test.rb
+++ b/test/domains/core/business_date/close_business_date_test.rb
@@ -6,28 +6,31 @@ class CoreBusinessDateCloseBusinessDateTest < ActiveSupport::TestCase
   setup do
     Core::BusinessDate::Models::BusinessDateSetting.delete_all
     Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.new(2026, 3, 1))
+    @operator = Workspace::Models::Operator.create!(role: "supervisor", display_name: "Business Date Supervisor", active: true)
   end
 
   test "close advances when institution is eod_ready" do
-    op = Workspace::Models::Operator.create!(role: "supervisor", display_name: "S", active: true)
-    result = Core::BusinessDate::Commands::CloseBusinessDate.call(closed_by_operator_id: op.id)
+    result = Core::BusinessDate::Commands::CloseBusinessDate.call(closed_by_operator_id: @operator.id)
     assert_equal Date.new(2026, 3, 2), result[:setting].current_business_on
     assert_equal Date.new(2026, 3, 1), result[:closed_on]
     ev = Core::BusinessDate::Models::BusinessDateCloseEvent.sole
-    assert_equal op.id, ev.closed_by_operator_id
+    assert_equal @operator.id, ev.closed_by_operator_id
   end
 
   test "close raises when a teller session is still open" do
     Teller::Commands::OpenSession.call(drawer_code: "close-block-#{SecureRandom.hex(4)}")
     err = assert_raises(Core::BusinessDate::Errors::EodNotReady) do
-      Core::BusinessDate::Commands::CloseBusinessDate.call
+      Core::BusinessDate::Commands::CloseBusinessDate.call(closed_by_operator_id: @operator.id)
     end
     assert_equal false, err.readiness[:eod_ready]
   end
 
   test "close raises when business_date param does not match current" do
     assert_raises(ArgumentError) do
-      Core::BusinessDate::Commands::CloseBusinessDate.call(business_date: Date.new(2026, 2, 1))
+      Core::BusinessDate::Commands::CloseBusinessDate.call(
+        closed_by_operator_id: @operator.id,
+        business_date: Date.new(2026, 2, 1)
+      )
     end
   end
 end

--- a/test/domains/core/operational_events/record_reversal_deposit_hold_guard_test.rb
+++ b/test/domains/core/operational_events/record_reversal_deposit_hold_guard_test.rb
@@ -12,6 +12,7 @@ class RecordReversalDepositHoldGuardTest < ActiveSupport::TestCase
     @account = Accounts::Commands::OpenAccount.call(party_record_id: @party.id)
     @cash_session_id = Teller::Commands::OpenSession.call(drawer_code: "rev-hold-#{SecureRandom.hex(4)}").id
     @supervisor = Workspace::Models::Operator.create!(role: "supervisor", display_name: "Rev Supervisor", active: true)
+    @teller = Workspace::Models::Operator.create!(role: "teller", display_name: "Rev Teller", active: true)
   end
 
   test "rejects reversal of deposit while active deposit-linked hold exists" do
@@ -52,7 +53,8 @@ class RecordReversalDepositHoldGuardTest < ActiveSupport::TestCase
     Accounts::Commands::ReleaseHold.call(
       hold_id: hold_r[:hold].id,
       channel: "teller",
-      idempotency_key: "rel-rev2-#{SecureRandom.hex(4)}"
+      idempotency_key: "rel-rev2-#{SecureRandom.hex(4)}",
+      actor_id: @supervisor.id
     )
 
     r = Core::OperationalEvents::Commands::RecordReversal.call(
@@ -63,6 +65,19 @@ class RecordReversalDepositHoldGuardTest < ActiveSupport::TestCase
     )
     assert_equal :created, r[:outcome]
     assert_equal "posting.reversal", r[:event].event_type
+  end
+
+  test "teller channel reversal requires reversal capability in command" do
+    dep = record_and_post_deposit!(10_000, "dep-rev-denied-#{SecureRandom.hex(4)}")
+
+    assert_raises(Workspace::Authorization::Forbidden) do
+      Core::OperationalEvents::Commands::RecordReversal.call(
+        original_operational_event_id: dep.id,
+        channel: "teller",
+        idempotency_key: "rev-denied-#{SecureRandom.hex(4)}",
+        actor_id: @teller.id
+      )
+    end
   end
 
   private

--- a/test/domains/workspace/capability_registry_test.rb
+++ b/test/domains/workspace/capability_registry_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "set"
+
+module Workspace
+  module Authorization
+    class CapabilityRegistryTest < ActiveSupport::TestCase
+      test "baseline capability codes are unique" do
+        codes = CapabilityRegistry.capability_codes
+
+        assert_equal codes.size, codes.uniq.size
+      end
+
+      test "baseline role codes are unique" do
+        codes = CapabilityRegistry.role_codes
+
+        assert_equal codes.size, codes.uniq.size
+      end
+
+      test "every role capability points to a registered capability" do
+        registered = CapabilityRegistry.capability_codes.to_set
+
+        CapabilityRegistry.role_capability_pairs.each do |pair|
+          assert_includes registered, pair.fetch(:capability_code)
+        end
+      end
+
+      test "every registry capability is present in database seed rows" do
+        BankCore::Seeds::Rbac.seed!
+
+        persisted_codes = Workspace::Models::Capability.pluck(:code).to_set
+
+        CapabilityRegistry.capability_codes.each do |code|
+          assert_includes persisted_codes, code
+        end
+      end
+
+      test "system admin does not receive financial approval capabilities" do
+        financial_codes = [
+          CapabilityRegistry::FEE_WAIVE,
+          CapabilityRegistry::HOLD_RELEASE,
+          CapabilityRegistry::REVERSAL_CREATE,
+          CapabilityRegistry::BUSINESS_DATE_CLOSE,
+          CapabilityRegistry::TELLER_SESSION_VARIANCE_APPROVE
+        ]
+
+        system_admin_codes = CapabilityRegistry::ROLE_CAPABILITIES.fetch(CapabilityRegistry::SYSTEM_ADMIN)
+
+        financial_codes.each do |code|
+          assert_not_includes system_admin_codes, code
+        end
+      end
+    end
+  end
+end

--- a/test/domains/workspace/capability_resolver_test.rb
+++ b/test/domains/workspace/capability_resolver_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Workspace
+  module Authorization
+    class CapabilityResolverTest < ActiveSupport::TestCase
+      setup do
+        BankCore::Seeds::Rbac.seed!
+      end
+
+      test "backfill creates expected assignment from legacy operator role" do
+        operator = Models::Operator.create!(role: "supervisor", display_name: "RBAC Supervisor", active: true)
+        operator.operator_role_assignments.delete_all
+
+        BankCore::Seeds::Rbac.seed!
+
+        assignment = operator.operator_role_assignments.joins(:role).find_by!(roles: { code: CapabilityRegistry::BRANCH_SUPERVISOR })
+        assert assignment.active?
+        assert_nil assignment.scope_type
+        assert_nil assignment.scope_id
+      end
+
+      test "operator capabilities come from active global assignments" do
+        operator = Models::Operator.create!(role: "supervisor", display_name: "RBAC Supervisor", active: true)
+
+        assert operator.has_capability?(CapabilityRegistry::REVERSAL_CREATE)
+        assert operator.has_capability?(CapabilityRegistry::FEE_WAIVE)
+      end
+
+      test "inactive operators receive no capabilities" do
+        operator = Models::Operator.create!(role: "supervisor", display_name: "Inactive Supervisor", active: false)
+
+        assert_empty CapabilityResolver.capabilities_for(operator: operator)
+        assert_not operator.has_capability?(CapabilityRegistry::REVERSAL_CREATE)
+      end
+
+      test "inactive role assignment grants no capabilities" do
+        operator = Models::Operator.create!(role: "supervisor", display_name: "Inactive Assignment Supervisor", active: true)
+        operator.operator_role_assignments.update_all(active: false)
+
+        assert_not operator.has_capability?(CapabilityRegistry::REVERSAL_CREATE)
+      end
+
+      test "inactive role grants no capabilities" do
+        operator = Models::Operator.create!(role: "supervisor", display_name: "Inactive Role Supervisor", active: true)
+        role = Models::Role.find_by!(code: CapabilityRegistry::BRANCH_SUPERVISOR)
+
+        role.update!(active: false)
+        assert_not operator.has_capability?(CapabilityRegistry::REVERSAL_CREATE)
+      ensure
+        role&.update!(active: true)
+      end
+
+      test "inactive capability grants nothing" do
+        operator = Models::Operator.create!(role: "supervisor", display_name: "Inactive Capability Supervisor", active: true)
+        capability = Models::Capability.find_by!(code: CapabilityRegistry::REVERSAL_CREATE)
+
+        capability.update!(active: false)
+        assert_not operator.has_capability?(CapabilityRegistry::REVERSAL_CREATE)
+      ensure
+        capability&.update!(active: true)
+      end
+
+      test "future assignment grants no capabilities until starts_at" do
+        operator = Models::Operator.create!(role: "supervisor", display_name: "Future Supervisor", active: true)
+        operator.operator_role_assignments.update_all(starts_at: 1.hour.from_now)
+
+        assert_not operator.has_capability?(CapabilityRegistry::REVERSAL_CREATE)
+      end
+
+      test "expired assignment grants no capabilities at exclusive ends_at" do
+        operator = Models::Operator.create!(role: "supervisor", display_name: "Expired Supervisor", active: true)
+        operator.operator_role_assignments.update_all(ends_at: Time.current)
+
+        assert_not operator.has_capability?(CapabilityRegistry::REVERSAL_CREATE)
+      end
+
+      test "scope argument still resolves global capabilities only" do
+        operator = Models::Operator.create!(role: "teller", display_name: "Scoped Teller", active: true)
+
+        assert operator.has_capability?(CapabilityRegistry::DEPOSIT_ACCEPT, scope: { branch_id: 1 })
+      end
+
+      test "scoped assignment rows grant nothing until scoped RBAC exists" do
+        operator = Models::Operator.create!(role: "teller", display_name: "Scoped Assignment Teller", active: true)
+        auditor = Models::Role.find_by!(code: CapabilityRegistry::AUDITOR)
+        Models::OperatorRoleAssignment.create!(
+          operator: operator,
+          role: auditor,
+          scope_type: "branch",
+          scope_id: 1,
+          active: true
+        )
+
+        assert_not operator.has_capability?(CapabilityRegistry::JOURNAL_ENTRY_VIEW, scope: { branch_id: 1 })
+      end
+
+      test "unknown capability fails closed" do
+        operator = Models::Operator.create!(role: "supervisor", display_name: "Unknown Capability Supervisor", active: true)
+
+        assert_not operator.has_capability?("not.real")
+      end
+    end
+  end
+end

--- a/test/integration/operational_events_money_flows_test.rb
+++ b/test/integration/operational_events_money_flows_test.rb
@@ -72,7 +72,7 @@ class OperationalEventsMoneyFlowsTest < ActionDispatch::IntegrationTest
           reference_id: fee_id.to_s
         }
       }.to_json,
-      headers: teller_json_headers(@teller_operator)
+      headers: teller_json_headers(@supervisor_operator)
     assert_response :created
     waive_id = response.parsed_body["id"]
     post "/teller/operational_events/#{waive_id}/post", headers: teller_json_headers(@teller_operator)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require_relative "../lib/bank_core/seeds/gl_coa"
 require_relative "../lib/bank_core/seeds/deposit_products"
+require_relative "../lib/bank_core/seeds/rbac"
 require "rails/test_help"
 
 module ActiveSupport
@@ -9,12 +10,14 @@ module ActiveSupport
     # `parallelize_setup` runs in forked workers only; below the parallelization threshold the suite
     # runs in the parent process, so seed here too (structure.sql has empty `deposit_products`).
     BankCore::Seeds::DepositProducts.seed!
+    BankCore::Seeds::Rbac.seed! if ActiveRecord::Base.connection.table_exists?(:capabilities)
 
     # Run tests in parallel with specified workers
     parallelize(workers: :number_of_processors)
 
     parallelize_setup do |_worker|
       BankCore::Seeds::DepositProducts.seed!
+      BankCore::Seeds::Rbac.seed! if ActiveRecord::Base.connection.table_exists?(:capabilities)
     end
 
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
@@ -35,6 +38,7 @@ class ActionDispatch::IntegrationTest
   def create_workspace_operators!
     teller = Workspace::Models::Operator.create!(role: "teller", display_name: "Test Teller", active: true)
     supervisor = Workspace::Models::Operator.create!(role: "supervisor", display_name: "Test Supervisor", active: true)
+    BankCore::Seeds::Rbac.seed!
     [ teller, supervisor ]
   end
 
@@ -49,6 +53,7 @@ class ActionDispatch::IntegrationTest
       password: password,
       password_changed_at: Time.current
     )
+    BankCore::Seeds::Rbac.seed!
     operator
   end
 


### PR DESCRIPTION
## Summary
- Add ADR-0032 operating-unit and branch-scope documentation already present on this branch.
- Add Workspace-owned RBAC tables, registry, resolver, seeds, and compatibility backfill from legacy operator roles.
- Migrate high-control staff gates and workspace navigation to capability checks while preserving existing response contracts.

## Test plan
- [x] docker compose run --rm web bin/rails test
- [x] docker compose run --rm web bin/rubocop


Made with [Cursor](https://cursor.com)