### PR TITLE
Harden operating-unit cash authorization

### DIFF
--- a/app/controllers/internal/application_controller.rb
+++ b/app/controllers/internal/application_controller.rb
@@ -52,6 +52,12 @@ module Internal
       render plain: "Forbidden", status: :forbidden
     end
 
+    def require_current_operating_unit!
+      return if current_operating_unit.present?
+
+      render plain: "Operating unit required", status: :forbidden
+    end
+
     def branch_access?
       has_any_capability?(
         Workspace::Authorization::CapabilityRegistry::DEPOSIT_ACCEPT,
@@ -79,6 +85,8 @@ module Internal
     end
 
     def has_any_capability?(*capability_codes)
+      return false if current_operating_unit.blank?
+
       capability_codes.any? { |code| current_operator&.has_capability?(code, scope: current_operating_unit) }
     end
   end

--- a/app/controllers/ops/cash_controller.rb
+++ b/app/controllers/ops/cash_controller.rb
@@ -2,6 +2,11 @@
 
 module Ops
   class CashController < ApplicationController
+    before_action :require_current_operating_unit!
+    before_action :require_cash_position_view!, only: %i[index reconciliation]
+    before_action :require_cash_movement_approval!, only: :approve_movement
+    before_action :require_cash_variance_approval!, only: :approve_variance
+
     def index
       @approvals = Cash::Queries::PendingCashApprovals.call(operating_unit_id: current_operating_unit&.id)
       @summary = Cash::Queries::ReconciliationSummary.call(operating_unit_id: current_operating_unit&.id)
@@ -33,6 +38,41 @@ module Ops
         operating_unit_id: current_operating_unit&.id,
         business_date: params[:business_date].presence
       )
+    end
+
+    private
+
+    def require_cash_position_view!
+      require_cash_capability!(
+        Workspace::Authorization::CapabilityRegistry::CASH_POSITION_VIEW,
+        current_operating_unit
+      )
+    end
+
+    def require_cash_movement_approval!
+      movement = Cash::Models::CashMovement.find_by(id: params[:id].to_i)
+      return if movement.nil?
+
+      require_cash_capability!(
+        Workspace::Authorization::CapabilityRegistry::CASH_MOVEMENT_APPROVE,
+        movement.operating_unit
+      )
+    end
+
+    def require_cash_variance_approval!
+      variance = Cash::Models::CashVariance.find_by(id: params[:id].to_i)
+      return if variance.nil?
+
+      require_cash_capability!(
+        Workspace::Authorization::CapabilityRegistry::CASH_VARIANCE_APPROVE,
+        variance.operating_unit
+      )
+    end
+
+    def require_cash_capability!(capability_code, operating_unit)
+      return if current_operator&.has_capability?(capability_code, scope: operating_unit)
+
+      render plain: "Forbidden", status: :forbidden
     end
   end
 end

--- a/app/domains/cash/commands/approve_cash_movement.rb
+++ b/app/domains/cash/commands/approve_cash_movement.rb
@@ -8,15 +8,15 @@ module Cash
       class InvalidState < Error; end
 
       def self.call(cash_movement_id:, approving_actor_id:, channel: "branch")
-        Workspace::Authorization::Authorizer.require_capability!(
-          actor_id: approving_actor_id,
-          capability_code: Workspace::Authorization::CapabilityRegistry::CASH_MOVEMENT_APPROVE,
-          scope: nil
-        )
-
         Cash::Models::CashMovement.transaction do
           movement = Cash::Models::CashMovement.lock.find_by(id: cash_movement_id)
           raise NotFound, "cash_movement_id=#{cash_movement_id}" if movement.nil?
+          Workspace::Authorization::Authorizer.require_capability!(
+            actor_id: approving_actor_id,
+            capability_code: Workspace::Authorization::CapabilityRegistry::CASH_MOVEMENT_APPROVE,
+            scope: movement.operating_unit
+          )
+
           return movement if movement.completed?
           unless movement.pending_approval?
             raise InvalidState, "movement must be pending_approval, was #{movement.status.inspect}"

--- a/app/domains/cash/commands/approve_cash_variance.rb
+++ b/app/domains/cash/commands/approve_cash_variance.rb
@@ -8,15 +8,15 @@ module Cash
       class InvalidState < Error; end
 
       def self.call(cash_variance_id:, approving_actor_id:)
-        Workspace::Authorization::Authorizer.require_capability!(
-          actor_id: approving_actor_id,
-          capability_code: Workspace::Authorization::CapabilityRegistry::CASH_VARIANCE_APPROVE,
-          scope: nil
-        )
-
         Cash::Models::CashVariance.transaction do
           variance = Cash::Models::CashVariance.lock.find_by(id: cash_variance_id)
           raise NotFound, "cash_variance_id=#{cash_variance_id}" if variance.nil?
+          Workspace::Authorization::Authorizer.require_capability!(
+            actor_id: approving_actor_id,
+            capability_code: Workspace::Authorization::CapabilityRegistry::CASH_VARIANCE_APPROVE,
+            scope: variance.operating_unit
+          )
+
           return variance if variance.status == Cash::Models::CashVariance::STATUS_POSTED
           unless variance.status == Cash::Models::CashVariance::STATUS_PENDING_APPROVAL ||
               variance.status == Cash::Models::CashVariance::STATUS_APPROVED

--- a/docs/adr/0032-operating-units-and-branch-scope.md
+++ b/docs/adr/0032-operating-units-and-branch-scope.md
@@ -1,6 +1,6 @@
 # ADR-0032: Operating units and branch scope
 
-**Status:** Proposed  
+**Status:** Accepted - first slice implemented  
 **Date:** 2026-04-27  
 **Decision Type:** Workspace / branch operating model architecture  
 **Aligns with:** [ADR-0018](0018-business-date-close-and-posting-invariant.md), [ADR-0025](0025-internal-workspace-ui.md), [ADR-0026](0026-branch-csr-servicing.md), [ADR-0029](0029-capability-first-authorization-layer.md), [ADR-0031](0031-cash-inventory-and-management.md), [module catalog](../architecture/bankcore-module-catalog.md)
@@ -331,7 +331,7 @@ Cash subledger:
 
 ### First operating-unit slice
 
-The first implementation slice should include:
+The first implementation slice is implemented with:
 
 - `operating_units` with seeded institution and branch records
 - `operators.default_operating_unit_id` or equivalent session-default support
@@ -341,12 +341,13 @@ The first implementation slice should include:
 - Branch UI/session defaults that make the current branch explicit
 - tests proving existing single-branch teller and Branch CSR behavior remains unchanged
 
+Implementation caveat: branch/cash workflows must continue to authorize against the resolved operating unit that owns the session, cash location, movement, or variance. Global role assignments remain valid, but operating-unit-scoped assignments are exact-match only.
+
 ### Follow-up slices
 
 Likely follow-up work:
 
-- `cash_locations.operating_unit_id` with ADR-0031 Cash implementation
-- scoped role assignment backfill and enforcement
+- broader scoped role assignment backfill and administration screens
 - branch-aware operational event search filters
 - branch cash position and reconciliation reports
 - branch dashboards for open sessions, pending approvals, and cash exceptions

--- a/test/domains/cash/cash_inventory_test.rb
+++ b/test/domains/cash/cash_inventory_test.rb
@@ -56,6 +56,41 @@ class CashInventoryTest < ActiveSupport::TestCase
     assert_empty movement.operational_event.journal_entries
   end
 
+  test "cash movement approval requires authority in the movement operating unit" do
+    vault = vault!
+    drawer = drawer!("B2")
+    Cash::Commands::RecordCashCount.call(
+      cash_location_id: vault.id,
+      counted_amount_minor_units: 10_000,
+      expected_amount_minor_units: 0,
+      actor_id: @teller.id,
+      idempotency_key: "fund-vault-scoped-approval"
+    )
+    movement = Cash::Commands::TransferCash.call(
+      source_cash_location_id: vault.id,
+      destination_cash_location_id: drawer.id,
+      amount_minor_units: 2_500,
+      actor_id: @teller.id,
+      idempotency_key: "vault-to-drawer-scoped-approval"
+    )
+    scoped_supervisor = scoped_operator!("supervisor", "Other Branch Supervisor", other_branch!)
+
+    assert_raises(Cash::Commands::ApproveCashMovement::InvalidState) do
+      Cash::Commands::ApproveCashMovement.call(
+        cash_movement_id: movement.id,
+        approving_actor_id: scoped_supervisor.id
+      )
+    end
+
+    grant_scoped_role!(scoped_supervisor, @operating_unit)
+    approved = Cash::Commands::ApproveCashMovement.call(
+      cash_movement_id: movement.id,
+      approving_actor_id: scoped_supervisor.id
+    )
+
+    assert_equal "completed", approved.status
+  end
+
   test "cash count variance approval posts cash variance to GL once" do
     drawer = drawer!("C1")
     Cash::Commands::RecordCashCount.call(
@@ -93,6 +128,40 @@ class CashInventoryTest < ActiveSupport::TestCase
     assert_equal 1, Core::OperationalEvents::Models::OperationalEvent.where(event_type: "cash.variance.posted", reference_id: variance.id.to_s).count
   end
 
+  test "cash variance approval requires authority in the variance operating unit" do
+    drawer = drawer!("C2")
+    Cash::Commands::RecordCashCount.call(
+      cash_location_id: drawer.id,
+      counted_amount_minor_units: 1_000,
+      expected_amount_minor_units: 0,
+      actor_id: @teller.id,
+      idempotency_key: "drawer-start-scoped-variance"
+    )
+    count = Cash::Commands::RecordCashCount.call(
+      cash_location_id: drawer.id,
+      counted_amount_minor_units: 900,
+      expected_amount_minor_units: 1_000,
+      actor_id: @teller.id,
+      idempotency_key: "drawer-count-scoped-variance"
+    )
+    scoped_supervisor = scoped_operator!("supervisor", "Other Branch Variance Supervisor", other_branch!)
+
+    assert_raises(Cash::Commands::ApproveCashVariance::InvalidState) do
+      Cash::Commands::ApproveCashVariance.call(
+        cash_variance_id: count.cash_variance.id,
+        approving_actor_id: scoped_supervisor.id
+      )
+    end
+
+    grant_scoped_role!(scoped_supervisor, @operating_unit)
+    variance = Cash::Commands::ApproveCashVariance.call(
+      cash_variance_id: count.cash_variance.id,
+      approving_actor_id: scoped_supervisor.id
+    )
+
+    assert_equal "posted", variance.status
+  end
+
   private
 
   def operator!(role, name)
@@ -101,6 +170,42 @@ class CashInventoryTest < ActiveSupport::TestCase
       display_name: name,
       active: true,
       default_operating_unit: @operating_unit
+    )
+  end
+
+  def scoped_operator!(role, name, operating_unit)
+    operator = operator!(role, name)
+    operator.operator_role_assignments.delete_all
+    operator.update!(default_operating_unit: operating_unit)
+    grant_scoped_role!(operator, operating_unit)
+    operator
+  end
+
+  def grant_scoped_role!(operator, operating_unit)
+    Workspace::Models::OperatorRoleAssignment.find_or_create_by!(
+      operator: operator,
+      role: role_for(operator.role),
+      scope_type: "operating_unit",
+      scope_id: operating_unit.id
+    ) do |assignment|
+      assignment.active = true
+    end
+  end
+
+  def role_for(legacy_role)
+    role_code = Workspace::Authorization::CapabilityRegistry::LEGACY_ROLE_MAPPING.fetch(legacy_role)
+    Workspace::Models::Role.find_by!(code: role_code)
+  end
+
+  def other_branch!
+    Organization::Models::OperatingUnit.create!(
+      code: "OTHER-#{SecureRandom.hex(4)}",
+      name: "Other Branch",
+      unit_type: "branch",
+      parent_operating_unit: Organization::Services::DefaultOperatingUnit.institution,
+      status: "active",
+      time_zone: "Eastern Time (US & Canada)",
+      opened_on: Date.current
     )
   end
 

--- a/test/domains/workspace/capability_resolver_test.rb
+++ b/test/domains/workspace/capability_resolver_test.rb
@@ -84,6 +84,21 @@ module Workspace
         assert operator.has_capability?(CapabilityRegistry::DEPOSIT_ACCEPT, scope: operating_unit)
       end
 
+      test "global assignments authorize in any operating unit scope" do
+        operator = Models::Operator.create!(role: "supervisor", display_name: "Global Supervisor", active: true)
+        other_branch = Organization::Models::OperatingUnit.create!(
+          code: "GLOBAL-#{SecureRandom.hex(4)}",
+          name: "Global Test Branch",
+          unit_type: "branch",
+          parent_operating_unit: Organization::Services::DefaultOperatingUnit.institution,
+          status: "active",
+          time_zone: "Eastern Time (US & Canada)",
+          opened_on: Date.current
+        )
+
+        assert operator.has_capability?(CapabilityRegistry::CASH_MOVEMENT_APPROVE, scope: other_branch)
+      end
+
       test "operating unit scoped assignments grant capabilities in exact scope" do
         operator = Models::Operator.create!(role: "teller", display_name: "Scoped Assignment Teller", active: true)
         auditor = Models::Role.find_by!(code: CapabilityRegistry::AUDITOR)


### PR DESCRIPTION
## Summary
- Mark ADR-0032's first operating-unit slice as implemented and clarify remaining follow-up work.
- Require resolved operating-unit context for internal workspace access and Ops cash screens.
- Authorize cash movement and variance approvals against the resource operating unit, with multi-unit tests for global and scoped roles.

## Test plan
- `docker compose run --rm web bin/rails test test/domains/workspace/capability_resolver_test.rb test/domains/organization/operating_unit_test.rb test/domains/cash/cash_inventory_test.rb test/integration/teller/teller_session_cash_policy_test.rb test/integration/branch_transaction_forms_test.rb`
- `docker compose run --rm web bin/rails test`

Made with [Cursor](https://cursor.com)