### PR TITLE
Add admin maintenance workspaces

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -6,6 +6,13 @@ module Admin
 
     private
 
+    def require_admin_capability!(capability_code)
+      return if current_operating_unit.present? &&
+        current_operator&.has_capability?(capability_code, scope: current_operating_unit)
+
+      render plain: "Forbidden", status: :forbidden
+    end
+
     def parse_optional_date_param(name)
       raw = params[name].presence
       return nil if raw.blank?

--- a/app/controllers/admin/capabilities_controller.rb
+++ b/app/controllers/admin/capabilities_controller.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Admin
+  class CapabilitiesController < ApplicationController
+    before_action -> { require_admin_capability!(Workspace::Authorization::CapabilityRegistry::SYSTEM_CONFIGURE) }
+    before_action :load_capability, only: %i[show edit update deactivate]
+
+    def index
+      @capabilities = Workspace::Queries::RbacCatalog.capabilities.group_by(&:category)
+    end
+
+    def show; end
+
+    def new
+      @capability = Workspace::Models::Capability.new(active: true)
+    end
+
+    def create
+      @capability = Workspace::Commands::CreateCapability.call(attributes: capability_params)
+      redirect_to admin_capability_path(@capability), notice: "Created capability #{@capability.code}."
+    rescue Workspace::Commands::CreateCapability::InvalidRequest => e
+      @capability = Workspace::Models::Capability.new(capability_params)
+      @error_message = e.message
+      render :new, status: :unprocessable_entity
+    end
+
+    def edit; end
+
+    def update
+      @capability = Workspace::Commands::UpdateCapability.call(
+        capability_id: @capability.id,
+        attributes: capability_params
+      )
+      redirect_to admin_capability_path(@capability), notice: "Updated capability #{@capability.code}."
+    rescue Workspace::Commands::UpdateCapability::InvalidRequest => e
+      @error_message = e.message
+      render :edit, status: :unprocessable_entity
+    end
+
+    def deactivate
+      Workspace::Commands::DeactivateCapability.call(capability_id: @capability.id)
+      redirect_to admin_capabilities_path, notice: "Deactivated capability #{@capability.code}."
+    rescue Workspace::Commands::DeactivateCapability::InvalidRequest => e
+      redirect_to admin_capability_path(@capability), alert: e.message
+    end
+
+    private
+
+    def load_capability
+      @capability = Workspace::Models::Capability.includes(:roles).find(params[:id])
+    end
+
+    def capability_params
+      params.require(:capability).permit(:code, :name, :category, :description, :active).to_h
+    end
+  end
+end

--- a/app/controllers/admin/cash_locations_controller.rb
+++ b/app/controllers/admin/cash_locations_controller.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module Admin
+  class CashLocationsController < ApplicationController
+    before_action -> { require_admin_capability!(Workspace::Authorization::CapabilityRegistry::SYSTEM_CONFIGURE) }
+    before_action :load_cash_location, only: %i[show edit update deactivate]
+    before_action :load_form_options, only: %i[new create edit update show]
+
+    def index
+      @operating_unit_id = params[:operating_unit_id].presence
+      @location_type = params[:location_type].presence
+      @status = params[:status].presence
+      @cash_locations = Cash::Queries::LocationDirectory.call(
+        operating_unit_id: @operating_unit_id,
+        location_type: @location_type,
+        status: @status
+      )
+      @operating_units = Organization::Models::OperatingUnit.order(:code)
+    end
+
+    def show
+      @activity = Cash::Queries::LocationActivity.call(cash_location_id: @cash_location.id)
+    end
+
+    def new
+      @cash_location = Cash::Models::CashLocation.new(
+        status: Cash::Models::CashLocation::STATUS_ACTIVE,
+        currency: "USD",
+        balancing_required: true
+      )
+    end
+
+    def create
+      operating_unit = Organization::Models::OperatingUnit.find(cash_location_params.fetch(:operating_unit_id))
+      attrs = cash_location_params
+      @cash_location = Cash::Commands::CreateLocation.call(
+        location_type: attrs[:location_type],
+        operating_unit: operating_unit,
+        responsible_operator_id: attrs[:responsible_operator_id],
+        drawer_code: attrs[:drawer_code],
+        name: attrs[:name],
+        parent_cash_location_id: attrs[:parent_cash_location_id],
+        currency: attrs[:currency].presence || "USD",
+        balancing_required: attrs[:balancing_required],
+        external_reference: attrs[:external_reference]
+      )
+      redirect_to admin_cash_location_path(@cash_location), notice: "Created cash location #{@cash_location.name}."
+    rescue Cash::Commands::CreateLocation::InvalidRequest, ActiveRecord::RecordNotFound, KeyError => e
+      @cash_location = Cash::Models::CashLocation.new(cash_location_params)
+      @error_message = e.message
+      render :new, status: :unprocessable_entity
+    end
+
+    def edit; end
+
+    def update
+      @cash_location = Cash::Commands::UpdateLocation.call(
+        cash_location_id: @cash_location.id,
+        attributes: cash_location_params.except(:operating_unit_id, :location_type, :currency)
+      )
+      redirect_to admin_cash_location_path(@cash_location), notice: "Updated cash location #{@cash_location.name}."
+    rescue Cash::Commands::UpdateLocation::InvalidRequest => e
+      @error_message = e.message
+      render :edit, status: :unprocessable_entity
+    end
+
+    def deactivate
+      Cash::Commands::DeactivateLocation.call(cash_location_id: @cash_location.id)
+      redirect_to admin_cash_location_path(@cash_location), notice: "Deactivated cash location #{@cash_location.name}."
+    rescue Cash::Commands::DeactivateLocation::InvalidRequest => e
+      redirect_to admin_cash_location_path(@cash_location), alert: e.message
+    end
+
+    private
+
+    def load_cash_location
+      @cash_location = Cash::Models::CashLocation
+        .includes(:operating_unit, :responsible_operator, :parent_cash_location, :cash_balance)
+        .find(params[:id])
+    end
+
+    def load_form_options
+      @operating_units = Organization::Models::OperatingUnit.order(:code)
+      @operators = Workspace::Models::Operator.where(active: true).order(:display_name)
+      @parent_cash_locations = Cash::Models::CashLocation.order(:operating_unit_id, :location_type, :drawer_code, :name)
+      @location_types = Cash::Models::CashLocation::LOCATION_TYPES
+      @statuses = Cash::Models::CashLocation::STATUSES
+    end
+
+    def cash_location_params
+      permitted = params.require(:cash_location).permit(
+        :location_type,
+        :operating_unit_id,
+        :responsible_operator_id,
+        :parent_cash_location_id,
+        :drawer_code,
+        :name,
+        :status,
+        :currency,
+        :balancing_required,
+        :external_reference
+      ).to_h.symbolize_keys
+      permitted[:responsible_operator_id] = nil if permitted[:responsible_operator_id].blank?
+      permitted[:parent_cash_location_id] = nil if permitted[:parent_cash_location_id].blank?
+      permitted[:drawer_code] = nil if permitted[:drawer_code].blank?
+      permitted[:balancing_required] = ActiveModel::Type::Boolean.new.cast(permitted[:balancing_required]) if permitted.key?(:balancing_required)
+      permitted
+    end
+  end
+end

--- a/app/controllers/admin/operating_units_controller.rb
+++ b/app/controllers/admin/operating_units_controller.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Admin
+  class OperatingUnitsController < ApplicationController
+    before_action -> { require_admin_capability!(Workspace::Authorization::CapabilityRegistry::SYSTEM_CONFIGURE) }
+    before_action :load_operating_unit, only: %i[show edit update close]
+    before_action :load_form_options, only: %i[new create edit update show]
+
+    def index
+      @status = params[:status].presence
+      @unit_type = params[:unit_type].presence
+      @operating_units = Organization::Queries::OperatingUnitDirectory.call(status: @status, unit_type: @unit_type)
+      @child_counts = Organization::Models::OperatingUnit.group(:parent_operating_unit_id).count
+      @cash_location_counts = Cash::Models::CashLocation.group(:operating_unit_id).count
+    end
+
+    def show
+      @child_units = @operating_unit.child_operating_units.order(:code)
+      @defaulting_operators = Workspace::Models::Operator
+        .where(default_operating_unit_id: @operating_unit.id)
+        .order(:display_name)
+      @scoped_assignments = Workspace::Models::OperatorRoleAssignment
+        .includes(:operator, :role)
+        .where(scope_type: "operating_unit", scope_id: @operating_unit.id)
+        .order(active: :desc, id: :desc)
+      @cash_locations = Cash::Models::CashLocation
+        .includes(:cash_balance)
+        .where(operating_unit_id: @operating_unit.id)
+        .order(:location_type, :drawer_code, :name)
+    end
+
+    def new
+      @operating_unit = Organization::Models::OperatingUnit.new(
+        status: Organization::Models::OperatingUnit::STATUS_ACTIVE,
+        time_zone: "Eastern Time (US & Canada)"
+      )
+    end
+
+    def create
+      @operating_unit = Organization::Commands::CreateOperatingUnit.call(attributes: operating_unit_params)
+      redirect_to admin_operating_unit_path(@operating_unit), notice: "Created operating unit #{@operating_unit.code}."
+    rescue Organization::Commands::CreateOperatingUnit::InvalidRequest => e
+      @operating_unit = Organization::Models::OperatingUnit.new(operating_unit_params)
+      @error_message = e.message
+      render :new, status: :unprocessable_entity
+    end
+
+    def edit; end
+
+    def update
+      @operating_unit = Organization::Commands::UpdateOperatingUnit.call(
+        operating_unit_id: @operating_unit.id,
+        attributes: operating_unit_params
+      )
+      redirect_to admin_operating_unit_path(@operating_unit), notice: "Updated operating unit #{@operating_unit.code}."
+    rescue Organization::Commands::UpdateOperatingUnit::InvalidRequest => e
+      @error_message = e.message
+      render :edit, status: :unprocessable_entity
+    end
+
+    def close
+      Organization::Commands::CloseOperatingUnit.call(
+        operating_unit_id: @operating_unit.id,
+        closed_on: params.dig(:operating_unit, :closed_on)
+      )
+      redirect_to admin_operating_unit_path(@operating_unit), notice: "Closed operating unit #{@operating_unit.code}."
+    rescue Organization::Commands::CloseOperatingUnit::InvalidRequest => e
+      redirect_to admin_operating_unit_path(@operating_unit), alert: e.message
+    end
+
+    private
+
+    def load_operating_unit
+      @operating_unit = Organization::Models::OperatingUnit.includes(:parent_operating_unit).find(params[:id])
+    end
+
+    def load_form_options
+      @parent_operating_units = Organization::Models::OperatingUnit.order(:code)
+      @unit_types = Organization::Models::OperatingUnit::UNIT_TYPES
+      @statuses = Organization::Models::OperatingUnit::STATUSES
+    end
+
+    def operating_unit_params
+      params.require(:operating_unit).permit(
+        :code, :name, :unit_type, :status, :parent_operating_unit_id, :time_zone, :opened_on, :closed_on
+      ).to_h
+    end
+  end
+end

--- a/app/controllers/admin/operator_role_assignments_controller.rb
+++ b/app/controllers/admin/operator_role_assignments_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Admin
+  class OperatorRoleAssignmentsController < ApplicationController
+    before_action -> { require_admin_capability!(Workspace::Authorization::CapabilityRegistry::ROLE_MANAGE) }
+    before_action :load_operator
+    before_action :load_assignment, only: %i[edit update deactivate]
+    before_action :load_form_options, only: %i[new edit create update]
+
+    def new
+      @assignment = @operator.operator_role_assignments.build(active: true, scope_type: "operating_unit")
+    end
+
+    def create
+      @assignment = Workspace::Commands::AssignOperatorRole.call(attributes: assignment_params.merge(operator_id: @operator.id))
+      redirect_to admin_operator_path(@operator), notice: "Assigned role #{@assignment.role.code}."
+    rescue Workspace::Commands::AssignOperatorRole::InvalidRequest => e
+      @assignment = @operator.operator_role_assignments.build(assignment_params)
+      @error_message = e.message
+      render :new, status: :unprocessable_entity
+    end
+
+    def edit; end
+
+    def update
+      @assignment = Workspace::Commands::UpdateOperatorRoleAssignment.call(
+        assignment_id: @assignment.id,
+        attributes: assignment_params
+      )
+      redirect_to admin_operator_path(@operator), notice: "Updated role assignment."
+    rescue Workspace::Commands::UpdateOperatorRoleAssignment::InvalidRequest => e
+      @error_message = e.message
+      render :edit, status: :unprocessable_entity
+    end
+
+    def deactivate
+      Workspace::Commands::DeactivateOperatorRoleAssignment.call(assignment_id: @assignment.id)
+      redirect_to admin_operator_path(@operator), notice: "Deactivated role assignment."
+    rescue Workspace::Commands::DeactivateOperatorRoleAssignment::InvalidRequest => e
+      redirect_to admin_operator_path(@operator), alert: e.message
+    end
+
+    private
+
+    def load_operator
+      @operator = Workspace::Models::Operator.find(params[:operator_id])
+    end
+
+    def load_assignment
+      @assignment = @operator.operator_role_assignments.find(params[:id])
+    end
+
+    def load_form_options
+      @roles = Workspace::Queries::RbacCatalog.active_roles
+      @operating_units = Workspace::Queries::RbacCatalog.operating_units
+    end
+
+    def assignment_params
+      params.require(:operator_role_assignment).permit(
+        :role_id, :scope_type, :scope_id, :active, :starts_at, :ends_at
+      ).to_h
+    end
+  end
+end

--- a/app/controllers/admin/operators_controller.rb
+++ b/app/controllers/admin/operators_controller.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Admin
+  class OperatorsController < ApplicationController
+    before_action -> { require_admin_capability!(Workspace::Authorization::CapabilityRegistry::USER_MANAGE) }
+    before_action :load_operator, only: %i[show edit update deactivate reset_credential]
+    before_action :load_form_options, only: %i[new create edit update show]
+
+    def index
+      @status = params[:status].presence
+      @search = params[:search].presence
+      @operators = Workspace::Queries::OperatorDirectory.call(search: @search, status: @status)
+    end
+
+    def show
+      @assignments = @operator.operator_role_assignments.includes(:role).order(:active, :id)
+      @effective_capabilities = current_scope_capabilities(@operator)
+    end
+
+    def new
+      @operator = Workspace::Models::Operator.new(active: true)
+    end
+
+    def create
+      @operator = Workspace::Commands::CreateOperator.call(attributes: operator_params)
+      redirect_to admin_operator_path(@operator), notice: "Created operator #{@operator.display_name}."
+    rescue Workspace::Commands::CreateOperator::InvalidRequest => e
+      @operator = Workspace::Models::Operator.new(operator_params.except(:username, :password))
+      @error_message = e.message
+      render :new, status: :unprocessable_entity
+    end
+
+    def edit; end
+
+    def update
+      @operator = Workspace::Commands::UpdateOperator.call(operator_id: @operator.id, attributes: operator_params)
+      redirect_to admin_operator_path(@operator), notice: "Updated operator #{@operator.display_name}."
+    rescue Workspace::Commands::UpdateOperator::InvalidRequest => e
+      @error_message = e.message
+      render :edit, status: :unprocessable_entity
+    end
+
+    def deactivate
+      Workspace::Commands::DeactivateOperator.call(operator_id: @operator.id)
+      redirect_to admin_operator_path(@operator), notice: "Deactivated operator #{@operator.display_name}."
+    rescue Workspace::Commands::DeactivateOperator::InvalidRequest => e
+      redirect_to admin_operator_path(@operator), alert: e.message
+    end
+
+    def reset_credential
+      Workspace::Commands::ResetOperatorCredential.call(
+        operator_id: @operator.id,
+        username: params.dig(:credential, :username),
+        password: params.dig(:credential, :password)
+      )
+      redirect_to admin_operator_path(@operator), notice: "Reset credentials for #{@operator.display_name}."
+    rescue Workspace::Commands::ResetOperatorCredential::InvalidRequest => e
+      redirect_to admin_operator_path(@operator), alert: e.message
+    end
+
+    private
+
+    def load_operator
+      @operator = Workspace::Models::Operator.includes(:credential, :default_operating_unit).find(params[:id])
+    end
+
+    def load_form_options
+      @operating_units = Workspace::Queries::RbacCatalog.operating_units
+      @legacy_roles = Workspace::Models::Operator::ROLES
+    end
+
+    def operator_params
+      permitted = params.require(:operator).permit(
+        :display_name, :role, :active, :default_operating_unit_id, :username, :password
+      ).to_h
+      permitted[:active] = ActiveModel::Type::Boolean.new.cast(permitted[:active]) if permitted.key?(:active)
+      permitted[:default_operating_unit_id] = nil if permitted[:default_operating_unit_id].blank?
+      permitted
+    end
+
+    def current_scope_capabilities(operator)
+      return [] if operator.default_operating_unit.blank?
+
+      operator.capabilities(scope: operator.default_operating_unit)
+    end
+  end
+end

--- a/app/controllers/admin/roles_controller.rb
+++ b/app/controllers/admin/roles_controller.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Admin
+  class RolesController < ApplicationController
+    before_action -> { require_admin_capability!(Workspace::Authorization::CapabilityRegistry::ROLE_MANAGE) }
+    before_action :load_role, only: %i[show edit update deactivate update_capabilities]
+    before_action :load_capabilities, only: %i[show new create edit update]
+
+    def index
+      @roles = Workspace::Queries::RbacCatalog.roles
+    end
+
+    def show
+      @assignments = @role.operator_role_assignments.includes(:operator).order(active: :desc, id: :desc)
+    end
+
+    def new
+      @role = Workspace::Models::Role.new(active: true)
+    end
+
+    def create
+      @role = Workspace::Commands::CreateRole.call(attributes: role_params)
+      Workspace::Commands::UpdateRoleCapabilities.call(role_id: @role.id, capability_ids: params[:capability_ids])
+      redirect_to admin_role_path(@role), notice: "Created role #{@role.code}."
+    rescue Workspace::Commands::CreateRole::InvalidRequest, Workspace::Commands::UpdateRoleCapabilities::InvalidRequest => e
+      @role = Workspace::Models::Role.new(role_params)
+      @error_message = e.message
+      render :new, status: :unprocessable_entity
+    end
+
+    def edit; end
+
+    def update
+      @role = Workspace::Commands::UpdateRole.call(role_id: @role.id, attributes: role_params)
+      redirect_to admin_role_path(@role), notice: "Updated role #{@role.code}."
+    rescue Workspace::Commands::UpdateRole::InvalidRequest => e
+      @error_message = e.message
+      render :edit, status: :unprocessable_entity
+    end
+
+    def update_capabilities
+      Workspace::Commands::UpdateRoleCapabilities.call(role_id: @role.id, capability_ids: params[:capability_ids])
+      redirect_to admin_role_path(@role), notice: "Updated role capabilities for #{@role.code}."
+    rescue Workspace::Commands::UpdateRoleCapabilities::InvalidRequest => e
+      redirect_to admin_role_path(@role), alert: e.message
+    end
+
+    def deactivate
+      Workspace::Commands::DeactivateRole.call(role_id: @role.id)
+      redirect_to admin_roles_path, notice: "Deactivated role #{@role.code}."
+    rescue Workspace::Commands::DeactivateRole::InvalidRequest => e
+      redirect_to admin_role_path(@role), alert: e.message
+    end
+
+    private
+
+    def load_role
+      @role = Workspace::Models::Role.includes(:capabilities).find(params[:id])
+    end
+
+    def load_capabilities
+      @capabilities = Workspace::Queries::RbacCatalog.capabilities.group_by(&:category)
+    end
+
+    def role_params
+      params.require(:role).permit(:code, :name, :description, :active).to_h
+    end
+  end
+end

--- a/app/domains/cash/commands/deactivate_location.rb
+++ b/app/domains/cash/commands/deactivate_location.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Cash
+  module Commands
+    class DeactivateLocation
+      class InvalidRequest < StandardError; end
+
+      def self.call(cash_location_id:)
+        location = Models::CashLocation.includes(:cash_balance).find(cash_location_id)
+        raise InvalidRequest, "cash balance must be zero before deactivation" unless zero_balance?(location)
+        raise InvalidRequest, "open teller session references this location" if open_teller_session?(location)
+        raise InvalidRequest, "pending cash movement references this location" if pending_movement?(location)
+        raise InvalidRequest, "pending cash variance references this location" if pending_variance?(location)
+
+        location.update!(status: Models::CashLocation::STATUS_INACTIVE)
+        location
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
+        raise InvalidRequest, e.message
+      end
+
+      def self.zero_balance?(location)
+        location.cash_balance.nil? || location.cash_balance.amount_minor_units.to_i.zero?
+      end
+      private_class_method :zero_balance?
+
+      def self.open_teller_session?(location)
+        Teller::Models::TellerSession.where(
+          cash_location_id: location.id,
+          status: Teller::Models::TellerSession::STATUS_OPEN
+        ).exists?
+      end
+      private_class_method :open_teller_session?
+
+      def self.pending_movement?(location)
+        Models::CashMovement.where(status: Models::CashMovement::STATUS_PENDING_APPROVAL)
+          .where("source_cash_location_id = :id OR destination_cash_location_id = :id", id: location.id)
+          .exists?
+      end
+      private_class_method :pending_movement?
+
+      def self.pending_variance?(location)
+        Models::CashVariance.where(
+          cash_location_id: location.id,
+          status: Models::CashVariance::STATUS_PENDING_APPROVAL
+        ).exists?
+      end
+      private_class_method :pending_variance?
+    end
+  end
+end

--- a/app/domains/cash/commands/update_location.rb
+++ b/app/domains/cash/commands/update_location.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Cash
+  module Commands
+    class UpdateLocation
+      class InvalidRequest < StandardError; end
+
+      def self.call(cash_location_id:, attributes:)
+        location = Models::CashLocation.find(cash_location_id)
+        attrs = normalized_attributes(attributes)
+        validate_parent!(location, attrs[:parent_cash_location_id]) if attrs.key?(:parent_cash_location_id)
+        location.update!(attrs)
+        location
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound, ActiveRecord::RecordNotUnique => e
+        raise InvalidRequest, e.message
+      end
+
+      def self.normalized_attributes(attributes)
+        attrs = attributes.to_h.symbolize_keys
+        attrs[:responsible_operator_id] = attrs[:responsible_operator_id].presence if attrs.key?(:responsible_operator_id)
+        attrs[:parent_cash_location_id] = attrs[:parent_cash_location_id].presence if attrs.key?(:parent_cash_location_id)
+        attrs[:drawer_code] = attrs[:drawer_code].presence if attrs.key?(:drawer_code)
+        attrs[:balancing_required] = ActiveModel::Type::Boolean.new.cast(attrs[:balancing_required]) if attrs.key?(:balancing_required)
+        attrs.slice(
+          :name,
+          :status,
+          :responsible_operator_id,
+          :parent_cash_location_id,
+          :drawer_code,
+          :balancing_required,
+          :external_reference
+        )
+      end
+      private_class_method :normalized_attributes
+
+      def self.validate_parent!(location, parent_id)
+        return if parent_id.blank?
+        raise InvalidRequest, "parent cash location cannot reference itself" if parent_id.to_i == location.id
+
+        parent = Models::CashLocation.find(parent_id)
+        unless parent.operating_unit_id == location.operating_unit_id
+          raise InvalidRequest, "parent cash location must be in the same operating unit"
+        end
+      end
+      private_class_method :validate_parent!
+    end
+  end
+end

--- a/app/domains/cash/queries/location_directory.rb
+++ b/app/domains/cash/queries/location_directory.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Cash
+  module Queries
+    class LocationDirectory
+      def self.call(operating_unit_id: nil, location_type: nil, status: nil)
+        scope = Models::CashLocation
+          .includes(:operating_unit, :responsible_operator, :parent_cash_location, :cash_balance)
+          .order(:operating_unit_id, :location_type, :drawer_code, :name)
+        scope = scope.where(operating_unit_id: operating_unit_id) if operating_unit_id.present?
+        scope = scope.where(location_type: location_type) if location_type.present?
+        scope = scope.where(status: status) if status.present?
+        scope
+      end
+    end
+  end
+end

--- a/app/domains/organization/commands/close_operating_unit.rb
+++ b/app/domains/organization/commands/close_operating_unit.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Organization
+  module Commands
+    class CloseOperatingUnit
+      class InvalidRequest < StandardError; end
+
+      def self.call(operating_unit_id:, closed_on:)
+        unit = Models::OperatingUnit.find(operating_unit_id)
+        date = parse_date(closed_on)
+        raise InvalidRequest, "closed_on is required" if date.blank?
+        raise InvalidRequest, "active child operating units must be closed first" if active_children?(unit)
+        raise InvalidRequest, "active cash locations must be deactivated first" if active_cash_locations?(unit)
+
+        unit.update!(status: Models::OperatingUnit::STATUS_CLOSED, closed_on: date)
+        unit
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
+        raise InvalidRequest, e.message
+      end
+
+      def self.active_children?(unit)
+        unit.child_operating_units.where(status: Models::OperatingUnit::STATUS_ACTIVE).exists?
+      end
+      private_class_method :active_children?
+
+      def self.active_cash_locations?(unit)
+        Cash::Models::CashLocation.where(
+          operating_unit_id: unit.id,
+          status: Cash::Models::CashLocation::STATUS_ACTIVE
+        ).exists?
+      end
+      private_class_method :active_cash_locations?
+
+      def self.parse_date(value)
+        return nil if value.blank?
+
+        Date.iso8601(value.to_s)
+      rescue ArgumentError, TypeError
+        raise InvalidRequest, "closed_on must be a valid ISO 8601 date"
+      end
+      private_class_method :parse_date
+    end
+  end
+end

--- a/app/domains/organization/commands/create_operating_unit.rb
+++ b/app/domains/organization/commands/create_operating_unit.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Organization
+  module Commands
+    class CreateOperatingUnit
+      class InvalidRequest < StandardError; end
+
+      def self.call(attributes:)
+        attrs = normalized_attributes(attributes)
+        Models::OperatingUnit.create!(attrs)
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e
+        raise InvalidRequest, e.message
+      end
+
+      def self.normalized_attributes(attributes)
+        attrs = attributes.to_h.symbolize_keys
+        attrs[:code] = attrs[:code].to_s.strip.upcase
+        attrs[:name] = attrs[:name].to_s.strip
+        attrs[:parent_operating_unit_id] = attrs[:parent_operating_unit_id].presence
+        attrs[:opened_on] = parse_date(attrs[:opened_on])
+        attrs[:closed_on] = parse_date(attrs[:closed_on])
+        attrs.slice(:code, :name, :unit_type, :status, :parent_operating_unit_id, :time_zone, :opened_on, :closed_on)
+      end
+      private_class_method :normalized_attributes
+
+      def self.parse_date(value)
+        return nil if value.blank?
+
+        Date.iso8601(value.to_s)
+      rescue ArgumentError, TypeError
+        raise InvalidRequest, "Dates must be valid ISO 8601 values"
+      end
+      private_class_method :parse_date
+    end
+  end
+end

--- a/app/domains/organization/commands/update_operating_unit.rb
+++ b/app/domains/organization/commands/update_operating_unit.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Organization
+  module Commands
+    class UpdateOperatingUnit
+      PROTECTED_CODES = [
+        Services::DefaultOperatingUnit::INSTITUTION_CODE,
+        Services::DefaultOperatingUnit::BRANCH_CODE
+      ].freeze
+
+      class InvalidRequest < StandardError; end
+
+      def self.call(operating_unit_id:, attributes:)
+        unit = Models::OperatingUnit.find(operating_unit_id)
+        attrs = normalized_attributes(attributes)
+        validate_code_change!(unit, attrs)
+        validate_parent!(unit, attrs[:parent_operating_unit_id])
+        validate_close_transition!(unit, attrs)
+        unit.update!(attrs)
+        unit
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound, ActiveRecord::RecordNotUnique => e
+        raise InvalidRequest, e.message
+      end
+
+      def self.normalized_attributes(attributes)
+        attrs = attributes.to_h.symbolize_keys
+        attrs[:code] = attrs[:code].to_s.strip.upcase if attrs.key?(:code)
+        attrs[:name] = attrs[:name].to_s.strip if attrs.key?(:name)
+        attrs[:parent_operating_unit_id] = attrs[:parent_operating_unit_id].presence if attrs.key?(:parent_operating_unit_id)
+        attrs[:opened_on] = parse_date(attrs[:opened_on]) if attrs.key?(:opened_on)
+        attrs[:closed_on] = parse_date(attrs[:closed_on]) if attrs.key?(:closed_on)
+        attrs.slice(:code, :name, :unit_type, :status, :parent_operating_unit_id, :time_zone, :opened_on, :closed_on)
+      end
+      private_class_method :normalized_attributes
+
+      def self.validate_code_change!(unit, attrs)
+        return unless attrs.key?(:code)
+        return if attrs[:code] == unit.code
+        return unless PROTECTED_CODES.include?(unit.code)
+
+        raise InvalidRequest, "Seeded operating unit code #{unit.code} cannot be changed"
+      end
+      private_class_method :validate_code_change!
+
+      def self.validate_parent!(unit, parent_id)
+        return if parent_id.blank?
+
+        parent = Models::OperatingUnit.find(parent_id)
+        current = parent
+        while current
+          if current.id == unit.id
+            raise InvalidRequest, "parent operating unit cannot be a descendant of this unit"
+          end
+          current = current.parent_operating_unit
+        end
+      end
+      private_class_method :validate_parent!
+
+      def self.validate_close_transition!(unit, attrs)
+        return unless attrs[:status] == Models::OperatingUnit::STATUS_CLOSED
+        return if unit.status == Models::OperatingUnit::STATUS_CLOSED
+        raise InvalidRequest, "closed_on is required" if attrs[:closed_on].blank?
+        if unit.child_operating_units.where(status: Models::OperatingUnit::STATUS_ACTIVE).exists?
+          raise InvalidRequest, "active child operating units must be closed first"
+        end
+        if Cash::Models::CashLocation.where(
+          operating_unit_id: unit.id,
+          status: Cash::Models::CashLocation::STATUS_ACTIVE
+        ).exists?
+          raise InvalidRequest, "active cash locations must be deactivated first"
+        end
+      end
+      private_class_method :validate_close_transition!
+
+      def self.parse_date(value)
+        return nil if value.blank?
+
+        Date.iso8601(value.to_s)
+      rescue ArgumentError, TypeError
+        raise InvalidRequest, "Dates must be valid ISO 8601 values"
+      end
+      private_class_method :parse_date
+    end
+  end
+end

--- a/app/domains/organization/queries/operating_unit_directory.rb
+++ b/app/domains/organization/queries/operating_unit_directory.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Organization
+  module Queries
+    class OperatingUnitDirectory
+      def self.call(status: nil, unit_type: nil)
+        scope = Models::OperatingUnit.includes(:parent_operating_unit).order(:parent_operating_unit_id, :code)
+        scope = scope.where(status: status) if status.present?
+        scope = scope.where(unit_type: unit_type) if unit_type.present?
+        scope
+      end
+    end
+  end
+end

--- a/app/domains/workspace/commands/assign_operator_role.rb
+++ b/app/domains/workspace/commands/assign_operator_role.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Commands
+    class AssignOperatorRole
+      class InvalidRequest < StandardError; end
+
+      def self.call(attributes:)
+        attrs = attributes.to_h.symbolize_keys
+        assignment_attrs = normalized_assignment_attrs(attrs)
+        finder = assignment_attrs.slice(:operator_id, :role_id, :scope_type, :scope_id)
+
+        assignment = Models::OperatorRoleAssignment.find_or_initialize_by(finder)
+        assignment.assign_attributes(assignment_attrs.slice(:active, :starts_at, :ends_at))
+        assignment.save!
+        assignment
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound, ActiveRecord::RecordNotUnique => e
+        raise InvalidRequest, e.message
+      end
+
+      def self.normalized_assignment_attrs(attrs)
+        scope_type = attrs[:scope_type].presence
+        scope_id = attrs[:scope_id].presence
+        scope_type = nil if scope_id.blank?
+
+        {
+          operator_id: attrs.fetch(:operator_id),
+          role_id: attrs.fetch(:role_id),
+          scope_type: scope_type,
+          scope_id: scope_id,
+          active: ActiveModel::Type::Boolean.new.cast(attrs.fetch(:active, true)),
+          starts_at: parse_time(attrs[:starts_at]),
+          ends_at: parse_time(attrs[:ends_at])
+        }
+      end
+      private_class_method :normalized_assignment_attrs
+
+      def self.parse_time(value)
+        return nil if value.blank?
+
+        Time.zone.parse(value.to_s)
+      rescue ArgumentError, TypeError
+        raise InvalidRequest, "Time windows must be valid date/time values"
+      end
+      private_class_method :parse_time
+    end
+  end
+end

--- a/app/domains/workspace/commands/create_capability.rb
+++ b/app/domains/workspace/commands/create_capability.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Commands
+    class CreateCapability
+      class InvalidRequest < StandardError; end
+
+      def self.call(attributes:)
+        attrs = attributes.to_h.symbolize_keys
+        Models::Capability.create!(
+          code: attrs.fetch(:code).to_s.strip.downcase,
+          name: attrs.fetch(:name).to_s.strip,
+          category: attrs.fetch(:category).to_s.strip,
+          description: attrs[:description],
+          active: ActiveModel::Type::Boolean.new.cast(attrs.fetch(:active, true))
+        )
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique, KeyError => e
+        raise InvalidRequest, e.message
+      end
+    end
+  end
+end

--- a/app/domains/workspace/commands/create_operator.rb
+++ b/app/domains/workspace/commands/create_operator.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Commands
+    class CreateOperator
+      class InvalidRequest < StandardError; end
+
+      def self.call(attributes:)
+        attrs = attributes.to_h.symbolize_keys
+        credential_attrs = attrs.slice(:username, :password)
+        operator_attrs = attrs.slice(:display_name, :role, :active, :default_operating_unit_id)
+
+        Models::Operator.transaction do
+          operator = Models::Operator.create!(operator_attrs)
+          create_credential!(operator, credential_attrs) if credential_attrs[:username].present?
+          operator
+        end
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e
+        raise InvalidRequest, e.message
+      end
+
+      def self.create_credential!(operator, credential_attrs)
+        if credential_attrs[:password].blank?
+          raise InvalidRequest, "Password is required when creating credentials"
+        end
+
+        operator.create_credential!(
+          username: credential_attrs[:username],
+          password: credential_attrs[:password],
+          password_changed_at: Time.current,
+          failed_login_attempts: 0,
+          locked_at: nil
+        )
+      end
+      private_class_method :create_credential!
+    end
+  end
+end

--- a/app/domains/workspace/commands/create_role.rb
+++ b/app/domains/workspace/commands/create_role.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Commands
+    class CreateRole
+      class InvalidRequest < StandardError; end
+
+      def self.call(attributes:)
+        attrs = attributes.to_h.symbolize_keys
+        Models::Role.create!(
+          code: attrs.fetch(:code).to_s.strip.downcase,
+          name: attrs.fetch(:name).to_s.strip,
+          description: attrs[:description],
+          active: boolean_value(attrs.fetch(:active, true)),
+          system_role: false
+        )
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique, KeyError => e
+        raise InvalidRequest, e.message
+      end
+
+      def self.boolean_value(value)
+        ActiveModel::Type::Boolean.new.cast(value)
+      end
+      private_class_method :boolean_value
+    end
+  end
+end

--- a/app/domains/workspace/commands/deactivate_capability.rb
+++ b/app/domains/workspace/commands/deactivate_capability.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Commands
+    class DeactivateCapability
+      class InvalidRequest < StandardError; end
+
+      def self.call(capability_id:)
+        capability = Models::Capability.find(capability_id)
+        capability.update!(active: false)
+        capability
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
+        raise InvalidRequest, e.message
+      end
+    end
+  end
+end

--- a/app/domains/workspace/commands/deactivate_operator.rb
+++ b/app/domains/workspace/commands/deactivate_operator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Commands
+    class DeactivateOperator
+      class InvalidRequest < StandardError; end
+
+      def self.call(operator_id:)
+        operator = Models::Operator.find(operator_id)
+        operator.update!(active: false)
+        operator
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
+        raise InvalidRequest, e.message
+      end
+    end
+  end
+end

--- a/app/domains/workspace/commands/deactivate_operator_role_assignment.rb
+++ b/app/domains/workspace/commands/deactivate_operator_role_assignment.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Commands
+    class DeactivateOperatorRoleAssignment
+      class InvalidRequest < StandardError; end
+
+      def self.call(assignment_id:)
+        assignment = Models::OperatorRoleAssignment.find(assignment_id)
+        assignment.update!(active: false)
+        assignment
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
+        raise InvalidRequest, e.message
+      end
+    end
+  end
+end

--- a/app/domains/workspace/commands/deactivate_role.rb
+++ b/app/domains/workspace/commands/deactivate_role.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Commands
+    class DeactivateRole
+      class InvalidRequest < StandardError; end
+
+      def self.call(role_id:)
+        role = Models::Role.find(role_id)
+        raise InvalidRequest, "System roles cannot be deactivated" if role.system_role?
+
+        role.update!(active: false)
+        role
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
+        raise InvalidRequest, e.message
+      end
+    end
+  end
+end

--- a/app/domains/workspace/commands/reset_operator_credential.rb
+++ b/app/domains/workspace/commands/reset_operator_credential.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Commands
+    class ResetOperatorCredential
+      class InvalidRequest < StandardError; end
+
+      def self.call(operator_id:, username:, password:)
+        raise InvalidRequest, "Password is required" if password.blank?
+
+        operator = Models::Operator.find(operator_id)
+        credential = operator.credential || operator.build_credential
+        credential.assign_attributes(
+          username: username.presence || credential.username,
+          password: password,
+          password_changed_at: Time.current,
+          failed_login_attempts: 0,
+          locked_at: nil
+        )
+        credential.save!
+        credential
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique, ActiveRecord::RecordNotFound => e
+        raise InvalidRequest, e.message
+      end
+    end
+  end
+end

--- a/app/domains/workspace/commands/update_capability.rb
+++ b/app/domains/workspace/commands/update_capability.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Commands
+    class UpdateCapability
+      class InvalidRequest < StandardError; end
+
+      def self.call(capability_id:, attributes:)
+        capability = Models::Capability.find(capability_id)
+        attrs = attributes.to_h.symbolize_keys.slice(:name, :category, :description, :active)
+        attrs[:active] = ActiveModel::Type::Boolean.new.cast(attrs[:active]) if attrs.key?(:active)
+        capability.update!(attrs)
+        capability
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
+        raise InvalidRequest, e.message
+      end
+    end
+  end
+end

--- a/app/domains/workspace/commands/update_operator.rb
+++ b/app/domains/workspace/commands/update_operator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Commands
+    class UpdateOperator
+      class InvalidRequest < StandardError; end
+
+      def self.call(operator_id:, attributes:)
+        operator = Models::Operator.find(operator_id)
+        attrs = attributes.to_h.symbolize_keys.slice(:display_name, :role, :active, :default_operating_unit_id)
+        operator.update!(attrs)
+        operator
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
+        raise InvalidRequest, e.message
+      end
+    end
+  end
+end

--- a/app/domains/workspace/commands/update_operator_role_assignment.rb
+++ b/app/domains/workspace/commands/update_operator_role_assignment.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Commands
+    class UpdateOperatorRoleAssignment
+      class InvalidRequest < StandardError; end
+
+      def self.call(assignment_id:, attributes:)
+        assignment = Models::OperatorRoleAssignment.find(assignment_id)
+        attrs = attributes.to_h.symbolize_keys
+        scope_id = attrs[:scope_id].presence
+        scope_type = scope_id.present? ? attrs[:scope_type].presence : nil
+        assignment.update!(
+          role_id: attrs[:role_id],
+          scope_type: scope_type,
+          scope_id: scope_id,
+          active: ActiveModel::Type::Boolean.new.cast(attrs.fetch(:active, true)),
+          starts_at: parse_time(attrs[:starts_at]),
+          ends_at: parse_time(attrs[:ends_at])
+        )
+        assignment
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound, ActiveRecord::RecordNotUnique => e
+        raise InvalidRequest, e.message
+      end
+
+      def self.parse_time(value)
+        return nil if value.blank?
+
+        Time.zone.parse(value.to_s)
+      rescue ArgumentError, TypeError
+        raise InvalidRequest, "Time windows must be valid date/time values"
+      end
+      private_class_method :parse_time
+    end
+  end
+end

--- a/app/domains/workspace/commands/update_role.rb
+++ b/app/domains/workspace/commands/update_role.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Commands
+    class UpdateRole
+      class InvalidRequest < StandardError; end
+
+      def self.call(role_id:, attributes:)
+        role = Models::Role.find(role_id)
+        attrs = attributes.to_h.symbolize_keys.slice(:name, :description, :active)
+        attrs[:active] = ActiveModel::Type::Boolean.new.cast(attrs[:active]) if attrs.key?(:active)
+        role.update!(attrs)
+        role
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
+        raise InvalidRequest, e.message
+      end
+    end
+  end
+end

--- a/app/domains/workspace/commands/update_role_capabilities.rb
+++ b/app/domains/workspace/commands/update_role_capabilities.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Commands
+    class UpdateRoleCapabilities
+      class InvalidRequest < StandardError; end
+
+      def self.call(role_id:, capability_ids:)
+        role = Models::Role.find(role_id)
+        ids = Array(capability_ids).reject(&:blank?).map(&:to_i).uniq
+        capabilities = Models::Capability.where(id: ids).to_a
+        raise InvalidRequest, "Unknown capability selected" unless capabilities.size == ids.size
+
+        Models::RoleCapability.transaction do
+          role.role_capabilities.where.not(capability_id: ids).delete_all
+          ids.each do |capability_id|
+            role.role_capabilities.find_or_create_by!(capability_id: capability_id)
+          end
+        end
+
+        role.reload
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
+        raise InvalidRequest, e.message
+      end
+    end
+  end
+end

--- a/app/domains/workspace/queries/operator_directory.rb
+++ b/app/domains/workspace/queries/operator_directory.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Queries
+    class OperatorDirectory
+      def self.call(search: nil, status: nil)
+        scope = Models::Operator
+          .includes(:credential, :default_operating_unit, operator_role_assignments: :role)
+          .order(:display_name, :id)
+
+        case status.to_s
+        when "active"
+          scope = scope.where(active: true)
+        when "inactive"
+          scope = scope.where(active: false)
+        end
+
+        if search.present?
+          term = "%#{search.to_s.strip.downcase}%"
+          scope = scope.left_joins(:credential).where(
+            "lower(operators.display_name) LIKE :term OR lower(operator_credentials.username) LIKE :term",
+            term: term
+          )
+        end
+
+        scope
+      end
+    end
+  end
+end

--- a/app/domains/workspace/queries/rbac_catalog.rb
+++ b/app/domains/workspace/queries/rbac_catalog.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Workspace
+  module Queries
+    class RbacCatalog
+      def self.roles
+        Models::Role.includes(:capabilities).order(:code)
+      end
+
+      def self.capabilities
+        Models::Capability.includes(:roles).order(:category, :code)
+      end
+
+      def self.active_roles
+        Models::Role.where(active: true).order(:code)
+      end
+
+      def self.active_capabilities
+        Models::Capability.where(active: true).order(:category, :code)
+      end
+
+      def self.operating_units
+        Organization::Models::OperatingUnit.order(:code)
+      end
+    end
+  end
+end

--- a/app/helpers/admin/application_helper.rb
+++ b/app/helpers/admin/application_helper.rb
@@ -14,6 +14,12 @@ module Admin
       value.iso8601
     end
 
+    def admin_datetime(value)
+      return "Not recorded" if value.blank?
+
+      value.in_time_zone.strftime("%Y-%m-%d %H:%M")
+    end
+
     def admin_status_badge(value)
       classes = case value.to_s
       when "active"
@@ -30,6 +36,19 @@ module Admin
       return "Unknown product" if product.nil?
 
       "#{product.product_code} - #{product.name}"
+    end
+
+    def admin_operating_unit_label(unit)
+      return "Global" if unit.nil?
+
+      "#{unit.code} - #{unit.name}"
+    end
+
+    def admin_assignment_scope_label(assignment)
+      return "Global" if assignment.global_scope?
+
+      unit = Organization::Models::OperatingUnit.find_by(id: assignment.scope_id)
+      admin_operating_unit_label(unit)
     end
 
     def admin_rule_type(row)

--- a/app/helpers/admin/application_helper.rb
+++ b/app/helpers/admin/application_helper.rb
@@ -44,6 +44,12 @@ module Admin
       "#{unit.code} - #{unit.name}"
     end
 
+    def admin_cash_location_label(location)
+      return "No cash location" if location.nil?
+
+      [ location.name, location.drawer_code.presence ].compact.join(" - ")
+    end
+
     def admin_assignment_scope_label(assignment)
       return "Global" if assignment.global_scope?
 

--- a/app/views/admin/capabilities/_form.html.erb
+++ b/app/views/admin/capabilities/_form.html.erb
@@ -1,0 +1,37 @@
+<% if @error_message.present? %>
+  <div class="mb-4 rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800"><%= @error_message %></div>
+<% end %>
+
+<%= form_with model: @capability,
+  scope: :capability,
+  url: @capability.persisted? ? admin_capability_path(@capability) : admin_capabilities_path,
+  method: @capability.persisted? ? :patch : :post,
+  local: true,
+  class: "rounded border border-slate-200 bg-white p-5 shadow-sm" do |form| %>
+  <div class="grid gap-4 md:grid-cols-2">
+    <div>
+      <%= form.label :code, class: "text-sm font-medium text-slate-700" %>
+      <%= form.text_field :code, disabled: @capability.persisted?, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2 disabled:bg-slate-100" %>
+    </div>
+    <div>
+      <%= form.label :category, class: "text-sm font-medium text-slate-700" %>
+      <%= form.text_field :category, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div class="md:col-span-2">
+      <%= form.label :name, class: "text-sm font-medium text-slate-700" %>
+      <%= form.text_field :name, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div class="md:col-span-2">
+      <%= form.label :description, class: "text-sm font-medium text-slate-700" %>
+      <%= form.text_area :description, rows: 3, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div class="flex items-center gap-2">
+      <%= form.check_box :active, checked: @capability.active.nil? ? true : @capability.active %>
+      <%= form.label :active, "Active", class: "text-sm font-medium text-slate-700" %>
+    </div>
+  </div>
+  <div class="mt-6 flex gap-2">
+    <%= form.submit class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+    <%= link_to "Cancel", @capability.persisted? ? admin_capability_path(@capability) : admin_capabilities_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+  </div>
+<% end %>

--- a/app/views/admin/capabilities/edit.html.erb
+++ b/app/views/admin/capabilities/edit.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "Edit Capability - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">Edit capability</h1>
+    <p class="mt-2 text-slate-600"><%= @capability.code %></p>
+  </div>
+  <%= link_to "Capability detail", admin_capability_path(@capability), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+</section>
+
+<section class="mt-8">
+  <%= render "form" %>
+</section>

--- a/app/views/admin/capabilities/index.html.erb
+++ b/app/views/admin/capabilities/index.html.erb
@@ -1,0 +1,43 @@
+<% content_for :title, "Capabilities - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">Capabilities</h1>
+    <p class="mt-2 text-slate-600">Database capability catalog used by runtime authorization.</p>
+  </div>
+  <div class="flex gap-2">
+    <%= link_to "Admin dashboard", admin_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+    <%= link_to "New capability", new_admin_capability_path, class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+  </div>
+</section>
+
+<% @capabilities.each do |category, capabilities| %>
+  <section class="mt-8 rounded border border-slate-200 bg-white shadow-sm">
+    <div class="border-b border-slate-200 px-5 py-4">
+      <h2 class="text-xl font-semibold"><%= category.to_s.humanize %></h2>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-slate-200 text-sm">
+        <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+          <tr>
+            <th class="px-5 py-3">Capability</th>
+            <th class="px-5 py-3">Status</th>
+            <th class="px-5 py-3 text-right">Roles</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100">
+          <% capabilities.each do |capability| %>
+            <tr>
+              <td class="px-5 py-4">
+                <%= link_to capability.code, admin_capability_path(capability), class: "font-medium text-slate-950 underline" %>
+                <div class="text-xs text-slate-500"><%= capability.name %></div>
+              </td>
+              <td class="px-5 py-4"><%= admin_status_badge(capability.active? ? "active" : "inactive") %></td>
+              <td class="px-5 py-4 text-right"><%= capability.roles.size %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </section>
+<% end %>

--- a/app/views/admin/capabilities/new.html.erb
+++ b/app/views/admin/capabilities/new.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "New Capability - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">New capability</h1>
+    <p class="mt-2 text-slate-600">Create a database capability record for role mapping.</p>
+  </div>
+  <%= link_to "All capabilities", admin_capabilities_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+</section>
+
+<section class="mt-8">
+  <%= render "form" %>
+</section>

--- a/app/views/admin/capabilities/show.html.erb
+++ b/app/views/admin/capabilities/show.html.erb
@@ -1,0 +1,63 @@
+<% content_for :title, "#{@capability.code} - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold"><%= @capability.code %></h1>
+    <p class="mt-2 text-slate-600"><%= @capability.name %></p>
+  </div>
+  <div class="flex flex-wrap gap-2">
+    <%= link_to "All capabilities", admin_capabilities_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+    <%= link_to "Edit", edit_admin_capability_path(@capability), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+  </div>
+</section>
+
+<section class="mt-8 grid gap-4 md:grid-cols-3">
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Status</p>
+    <div class="mt-3"><%= admin_status_badge(@capability.active? ? "active" : "inactive") %></div>
+  </div>
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Category</p>
+    <p class="mt-2 text-2xl font-semibold"><%= @capability.category %></p>
+  </div>
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Roles</p>
+    <p class="mt-2 text-2xl font-semibold"><%= @capability.roles.size %></p>
+  </div>
+</section>
+
+<section class="mt-8 rounded border border-slate-200 bg-white p-5 shadow-sm">
+  <h2 class="text-xl font-semibold">Description</h2>
+  <p class="mt-2 text-sm text-slate-600"><%= @capability.description.presence || "No description recorded." %></p>
+</section>
+
+<section class="mt-8 rounded border border-slate-200 bg-white shadow-sm">
+  <div class="border-b border-slate-200 px-5 py-4">
+    <h2 class="text-xl font-semibold">Roles using this capability</h2>
+  </div>
+  <% if @capability.roles.any? %>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-slate-200 text-sm">
+        <tbody class="divide-y divide-slate-100">
+          <% @capability.roles.order(:code).each do |role| %>
+            <tr>
+              <td class="px-5 py-4"><%= link_to role.code, admin_role_path(role), class: "font-medium underline" %></td>
+              <td class="px-5 py-4"><%= role.name %></td>
+              <td class="px-5 py-4 text-right"><%= admin_status_badge(role.active? ? "active" : "inactive") %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <div class="px-5 py-8 text-sm text-slate-600">No roles currently include this capability.</div>
+  <% end %>
+</section>
+
+<% if @capability.active? %>
+  <section class="mt-8 rounded border border-amber-200 bg-amber-50 p-5">
+    <h2 class="font-semibold text-amber-950">Deactivate capability</h2>
+    <p class="mt-2 text-sm text-amber-900">Deactivation removes this capability from runtime authorization without deleting historical mappings.</p>
+    <%= button_to "Deactivate #{@capability.code}", deactivate_admin_capability_path(@capability), method: :post, class: "mt-4 rounded border border-amber-300 px-4 py-2 font-medium text-amber-950" %>
+  </section>
+<% end %>

--- a/app/views/admin/cash_locations/_form.html.erb
+++ b/app/views/admin/cash_locations/_form.html.erb
@@ -1,0 +1,60 @@
+<% if @error_message.present? %>
+  <div class="mb-4 rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800"><%= @error_message %></div>
+<% end %>
+
+<%= form_with model: @cash_location,
+  scope: :cash_location,
+  url: @cash_location.persisted? ? admin_cash_location_path(@cash_location) : admin_cash_locations_path,
+  method: @cash_location.persisted? ? :patch : :post,
+  local: true,
+  class: "rounded border border-slate-200 bg-white p-5 shadow-sm" do |form| %>
+  <div class="grid gap-4 md:grid-cols-2">
+    <div>
+      <%= form.label :name, class: "text-sm font-medium text-slate-700" %>
+      <%= form.text_field :name, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :location_type, "Type", class: "text-sm font-medium text-slate-700" %>
+      <%= form.select :location_type, options_for_select(@location_types.map { |type| [type.humanize, type] }, @cash_location.location_type), {}, disabled: @cash_location.persisted?, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2 disabled:bg-slate-100" %>
+    </div>
+    <div>
+      <%= form.label :operating_unit_id, "Operating unit", class: "text-sm font-medium text-slate-700" %>
+      <%= form.select :operating_unit_id, options_from_collection_for_select(@operating_units, :id, :code, @cash_location.operating_unit_id), {}, disabled: @cash_location.persisted?, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2 disabled:bg-slate-100" %>
+    </div>
+    <div>
+      <%= form.label :status, class: "text-sm font-medium text-slate-700" %>
+      <%= form.select :status, options_for_select(@statuses.map { |status| [status.humanize, status] }, @cash_location.status), {}, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :drawer_code, class: "text-sm font-medium text-slate-700" %>
+      <%= form.text_field :drawer_code, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :responsible_operator_id, "Responsible operator", class: "text-sm font-medium text-slate-700" %>
+      <%= form.select :responsible_operator_id, options_from_collection_for_select(@operators, :id, :display_name, @cash_location.responsible_operator_id), { include_blank: "Unassigned" }, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :parent_cash_location_id, "Parent cash location", class: "text-sm font-medium text-slate-700" %>
+      <%= form.select :parent_cash_location_id,
+        options_from_collection_for_select(@parent_cash_locations.reject { |location| location.id == @cash_location.id }, :id, :name, @cash_location.parent_cash_location_id),
+        { include_blank: "None" },
+        class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :currency, class: "text-sm font-medium text-slate-700" %>
+      <%= form.text_field :currency, value: @cash_location.currency || "USD", readonly: true, class: "mt-1 w-full rounded border border-slate-300 bg-slate-100 px-3 py-2" %>
+    </div>
+    <div class="flex items-center gap-2 pt-6">
+      <%= form.check_box :balancing_required, checked: @cash_location.balancing_required.nil? ? true : @cash_location.balancing_required %>
+      <%= form.label :balancing_required, "Balancing required", class: "text-sm font-medium text-slate-700" %>
+    </div>
+    <div>
+      <%= form.label :external_reference, class: "text-sm font-medium text-slate-700" %>
+      <%= form.text_field :external_reference, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+  </div>
+  <div class="mt-6 flex gap-2">
+    <%= form.submit class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+    <%= link_to "Cancel", @cash_location.persisted? ? admin_cash_location_path(@cash_location) : admin_cash_locations_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+  </div>
+<% end %>

--- a/app/views/admin/cash_locations/edit.html.erb
+++ b/app/views/admin/cash_locations/edit.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "Edit Cash Location - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">Edit cash location</h1>
+    <p class="mt-2 text-slate-600"><%= @cash_location.name %></p>
+  </div>
+  <%= link_to "Cash location detail", admin_cash_location_path(@cash_location), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+</section>
+
+<section class="mt-8">
+  <%= render "form" %>
+</section>

--- a/app/views/admin/cash_locations/index.html.erb
+++ b/app/views/admin/cash_locations/index.html.erb
@@ -1,0 +1,66 @@
+<% content_for :title, "Cash Locations - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">Cash locations</h1>
+    <p class="mt-2 text-slate-600">Vault, drawer, and internal transit custody locations.</p>
+  </div>
+  <div class="flex gap-2">
+    <%= link_to "Admin dashboard", admin_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+    <%= link_to "New cash location", new_admin_cash_location_path, class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+  </div>
+</section>
+
+<section class="mt-6 rounded border border-slate-200 bg-white p-4 shadow-sm">
+  <%= form_with url: admin_cash_locations_path, method: :get, local: true, class: "grid gap-3 md:grid-cols-4" do |form| %>
+    <div>
+      <%= form.label :operating_unit_id, "Operating unit", class: "text-sm font-medium text-slate-700" %>
+      <%= form.select :operating_unit_id, options_from_collection_for_select(@operating_units, :id, :code, @operating_unit_id), { include_blank: "All" }, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :location_type, "Type", class: "text-sm font-medium text-slate-700" %>
+      <%= form.select :location_type, options_for_select([["All", ""]] + Cash::Models::CashLocation::LOCATION_TYPES.map { |type| [type.humanize, type] }, @location_type), {}, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :status, class: "text-sm font-medium text-slate-700" %>
+      <%= form.select :status, options_for_select([["All", ""]] + Cash::Models::CashLocation::STATUSES.map { |status| [status.humanize, status] }, @status), {}, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div class="flex items-end">
+      <%= form.submit "Filter", class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+    </div>
+  <% end %>
+</section>
+
+<section class="mt-8 rounded border border-slate-200 bg-white shadow-sm">
+  <% if @cash_locations.any? %>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-slate-200 text-sm">
+        <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+          <tr>
+            <th class="px-5 py-3">Location</th>
+            <th class="px-5 py-3">Operating unit</th>
+            <th class="px-5 py-3">Responsible operator</th>
+            <th class="px-5 py-3">Status</th>
+            <th class="px-5 py-3 text-right">Balance</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100">
+          <% @cash_locations.each do |location| %>
+            <tr>
+              <td class="px-5 py-4">
+                <%= link_to admin_cash_location_label(location), admin_cash_location_path(location), class: "font-medium text-slate-950 underline" %>
+                <div class="text-xs text-slate-500"><%= location.location_type.humanize %></div>
+              </td>
+              <td class="px-5 py-4"><%= admin_operating_unit_label(location.operating_unit) %></td>
+              <td class="px-5 py-4"><%= location.responsible_operator&.display_name || "Unassigned" %></td>
+              <td class="px-5 py-4"><%= admin_status_badge(location.status) %></td>
+              <td class="px-5 py-4 text-right"><%= admin_money(location.cash_balance&.amount_minor_units) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <div class="px-5 py-8 text-sm text-slate-600">No cash locations match the current filters.</div>
+  <% end %>
+</section>

--- a/app/views/admin/cash_locations/new.html.erb
+++ b/app/views/admin/cash_locations/new.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "New Cash Location - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">New cash location</h1>
+    <p class="mt-2 text-slate-600">Create a vault, teller drawer, or internal transit location.</p>
+  </div>
+  <%= link_to "All cash locations", admin_cash_locations_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+</section>
+
+<section class="mt-8">
+  <%= render "form" %>
+</section>

--- a/app/views/admin/cash_locations/show.html.erb
+++ b/app/views/admin/cash_locations/show.html.erb
@@ -1,0 +1,110 @@
+<% content_for :title, "#{@cash_location.name} - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold"><%= @cash_location.name %></h1>
+    <p class="mt-2 text-slate-600"><%= @cash_location.location_type.humanize %></p>
+  </div>
+  <div class="flex flex-wrap gap-2">
+    <%= link_to "All cash locations", admin_cash_locations_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+    <%= link_to "Edit", edit_admin_cash_location_path(@cash_location), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+  </div>
+</section>
+
+<section class="mt-8 grid gap-4 md:grid-cols-4">
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Status</p>
+    <div class="mt-3"><%= admin_status_badge(@cash_location.status) %></div>
+  </div>
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Balance</p>
+    <p class="mt-2 text-2xl font-semibold"><%= admin_money(@cash_location.cash_balance&.amount_minor_units) %></p>
+  </div>
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Operating unit</p>
+    <p class="mt-2 text-lg font-semibold"><%= link_to @cash_location.operating_unit.code, admin_operating_unit_path(@cash_location.operating_unit), class: "underline" %></p>
+  </div>
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Responsible operator</p>
+    <p class="mt-2 text-lg font-semibold"><%= @cash_location.responsible_operator&.display_name || "Unassigned" %></p>
+  </div>
+</section>
+
+<section class="mt-8 grid gap-4 md:grid-cols-3">
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Drawer code</p>
+    <p class="mt-2 text-lg font-semibold"><%= @cash_location.drawer_code.presence || "Not applicable" %></p>
+  </div>
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Parent location</p>
+    <p class="mt-2 text-lg font-semibold"><%= admin_cash_location_label(@cash_location.parent_cash_location) %></p>
+  </div>
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">External reference</p>
+    <p class="mt-2 text-lg font-semibold"><%= @cash_location.external_reference.presence || "Not recorded" %></p>
+  </div>
+</section>
+
+<section class="mt-8 grid gap-4 md:grid-cols-3">
+  <div class="rounded border border-slate-200 bg-white shadow-sm">
+    <div class="border-b border-slate-200 px-5 py-4">
+      <h2 class="text-xl font-semibold">Recent movements</h2>
+    </div>
+    <% if @activity.fetch(:movements).any? %>
+      <div class="divide-y divide-slate-100">
+        <% @activity.fetch(:movements).each do |movement| %>
+          <div class="px-5 py-4 text-sm">
+            <div class="font-medium"><%= movement.movement_type.humanize %> - <%= admin_money(movement.amount_minor_units) %></div>
+            <div class="text-xs text-slate-500"><%= movement.status.humanize %> on <%= admin_date(movement.business_date) %></div>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="px-5 py-8 text-sm text-slate-600">No movements recorded.</div>
+    <% end %>
+  </div>
+
+  <div class="rounded border border-slate-200 bg-white shadow-sm">
+    <div class="border-b border-slate-200 px-5 py-4">
+      <h2 class="text-xl font-semibold">Recent counts</h2>
+    </div>
+    <% if @activity.fetch(:counts).any? %>
+      <div class="divide-y divide-slate-100">
+        <% @activity.fetch(:counts).each do |count| %>
+          <div class="px-5 py-4 text-sm">
+            <div class="font-medium"><%= admin_money(count.counted_amount_minor_units) %></div>
+            <div class="text-xs text-slate-500">Expected <%= admin_money(count.expected_amount_minor_units) %> on <%= admin_date(count.business_date) %></div>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="px-5 py-8 text-sm text-slate-600">No counts recorded.</div>
+    <% end %>
+  </div>
+
+  <div class="rounded border border-slate-200 bg-white shadow-sm">
+    <div class="border-b border-slate-200 px-5 py-4">
+      <h2 class="text-xl font-semibold">Variances</h2>
+    </div>
+    <% if @activity.fetch(:variances).any? %>
+      <div class="divide-y divide-slate-100">
+        <% @activity.fetch(:variances).each do |variance| %>
+          <div class="px-5 py-4 text-sm">
+            <div class="font-medium"><%= admin_money(variance.amount_minor_units) %></div>
+            <div class="text-xs text-slate-500"><%= variance.status.humanize %> on <%= admin_date(variance.business_date) %></div>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="px-5 py-8 text-sm text-slate-600">No variances recorded.</div>
+    <% end %>
+  </div>
+</section>
+
+<% if @cash_location.active? %>
+  <section class="mt-8 rounded border border-amber-200 bg-amber-50 p-5">
+    <h2 class="font-semibold text-amber-950">Deactivate cash location</h2>
+    <p class="mt-2 text-sm text-amber-900">Deactivation requires zero balance, no open teller session, and no pending movements or variances.</p>
+    <%= button_to "Deactivate #{@cash_location.name}", deactivate_admin_cash_location_path(@cash_location), method: :post, class: "mt-4 rounded border border-amber-300 px-4 py-2 font-medium text-amber-950" %>
+  </section>
+<% end %>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -3,11 +3,26 @@
 <section>
   <h1 class="text-3xl font-semibold">Admin workspace</h1>
   <p class="mt-2 text-slate-600">
-    Review deposit products and active product configuration.
+    Maintain internal operators, authorization, deposit products, and active product configuration.
   </p>
 </section>
 
 <section class="mt-8 grid gap-4 md:grid-cols-2">
+  <%= link_to admin_operators_path, class: "rounded border border-slate-200 bg-white p-5 shadow-sm hover:border-slate-400" do %>
+    <h2 class="font-semibold">Operators</h2>
+    <p class="mt-2 text-sm text-slate-600">Create operators, reset credentials, and manage active status.</p>
+  <% end %>
+
+  <%= link_to admin_roles_path, class: "rounded border border-slate-200 bg-white p-5 shadow-sm hover:border-slate-400" do %>
+    <h2 class="font-semibold">Roles and assignments</h2>
+    <p class="mt-2 text-sm text-slate-600">Review roles, capability mappings, and operating-unit scoped access.</p>
+  <% end %>
+
+  <%= link_to admin_capabilities_path, class: "rounded border border-slate-200 bg-white p-5 shadow-sm hover:border-slate-400" do %>
+    <h2 class="font-semibold">Capabilities</h2>
+    <p class="mt-2 text-sm text-slate-600">Maintain the database capability catalog used by runtime authorization.</p>
+  <% end %>
+
   <%= link_to admin_deposit_products_path, class: "rounded border border-slate-200 bg-white p-5 shadow-sm hover:border-slate-400" do %>
     <h2 class="font-semibold">Deposit products</h2>
     <p class="mt-2 text-sm text-slate-600">Browse products and related fee, overdraft, and statement configuration.</p>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -23,6 +23,16 @@
     <p class="mt-2 text-sm text-slate-600">Maintain the database capability catalog used by runtime authorization.</p>
   <% end %>
 
+  <%= link_to admin_operating_units_path, class: "rounded border border-slate-200 bg-white p-5 shadow-sm hover:border-slate-400" do %>
+    <h2 class="font-semibold">Operating units</h2>
+    <p class="mt-2 text-sm text-slate-600">Maintain institution, branch, operations, department, and region scope records.</p>
+  <% end %>
+
+  <%= link_to admin_cash_locations_path, class: "rounded border border-slate-200 bg-white p-5 shadow-sm hover:border-slate-400" do %>
+    <h2 class="font-semibold">Cash locations</h2>
+    <p class="mt-2 text-sm text-slate-600">Configure vaults, drawers, and internal transit custody locations.</p>
+  <% end %>
+
   <%= link_to admin_deposit_products_path, class: "rounded border border-slate-200 bg-white p-5 shadow-sm hover:border-slate-400" do %>
     <h2 class="font-semibold">Deposit products</h2>
     <p class="mt-2 text-sm text-slate-600">Browse products and related fee, overdraft, and statement configuration.</p>

--- a/app/views/admin/operating_units/_form.html.erb
+++ b/app/views/admin/operating_units/_form.html.erb
@@ -1,0 +1,52 @@
+<% if @error_message.present? %>
+  <div class="mb-4 rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800"><%= @error_message %></div>
+<% end %>
+
+<%= form_with model: @operating_unit,
+  scope: :operating_unit,
+  url: @operating_unit.persisted? ? admin_operating_unit_path(@operating_unit) : admin_operating_units_path,
+  method: @operating_unit.persisted? ? :patch : :post,
+  local: true,
+  class: "rounded border border-slate-200 bg-white p-5 shadow-sm" do |form| %>
+  <div class="grid gap-4 md:grid-cols-2">
+    <div>
+      <%= form.label :code, class: "text-sm font-medium text-slate-700" %>
+      <%= form.text_field :code, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :name, class: "text-sm font-medium text-slate-700" %>
+      <%= form.text_field :name, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :unit_type, "Type", class: "text-sm font-medium text-slate-700" %>
+      <%= form.select :unit_type, options_for_select(@unit_types.map { |type| [type.humanize, type] }, @operating_unit.unit_type), {}, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :status, class: "text-sm font-medium text-slate-700" %>
+      <%= form.select :status, options_for_select(@statuses.map { |status| [status.humanize, status] }, @operating_unit.status), {}, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :parent_operating_unit_id, "Parent", class: "text-sm font-medium text-slate-700" %>
+      <%= form.select :parent_operating_unit_id,
+        options_from_collection_for_select(@parent_operating_units.reject { |unit| unit.id == @operating_unit.id }, :id, :code, @operating_unit.parent_operating_unit_id),
+        { include_blank: "None" },
+        class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :time_zone, class: "text-sm font-medium text-slate-700" %>
+      <%= form.text_field :time_zone, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :opened_on, class: "text-sm font-medium text-slate-700" %>
+      <%= form.date_field :opened_on, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :closed_on, class: "text-sm font-medium text-slate-700" %>
+      <%= form.date_field :closed_on, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+  </div>
+  <div class="mt-6 flex gap-2">
+    <%= form.submit class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+    <%= link_to "Cancel", @operating_unit.persisted? ? admin_operating_unit_path(@operating_unit) : admin_operating_units_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+  </div>
+<% end %>

--- a/app/views/admin/operating_units/edit.html.erb
+++ b/app/views/admin/operating_units/edit.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "Edit Operating Unit - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">Edit operating unit</h1>
+    <p class="mt-2 text-slate-600"><%= @operating_unit.code %></p>
+  </div>
+  <%= link_to "Operating unit detail", admin_operating_unit_path(@operating_unit), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+</section>
+
+<section class="mt-8">
+  <%= render "form" %>
+</section>

--- a/app/views/admin/operating_units/index.html.erb
+++ b/app/views/admin/operating_units/index.html.erb
@@ -1,0 +1,64 @@
+<% content_for :title, "Operating Units - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">Operating units</h1>
+    <p class="mt-2 text-slate-600">Organization scope records for branches, departments, regions, operations, and institution units.</p>
+  </div>
+  <div class="flex gap-2">
+    <%= link_to "Admin dashboard", admin_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+    <%= link_to "New operating unit", new_admin_operating_unit_path, class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+  </div>
+</section>
+
+<section class="mt-6 rounded border border-slate-200 bg-white p-4 shadow-sm">
+  <%= form_with url: admin_operating_units_path, method: :get, local: true, class: "grid gap-3 md:grid-cols-3" do |form| %>
+    <div>
+      <%= form.label :unit_type, "Type", class: "text-sm font-medium text-slate-700" %>
+      <%= form.select :unit_type, options_for_select([["All", ""]] + Organization::Models::OperatingUnit::UNIT_TYPES.map { |type| [type.humanize, type] }, @unit_type), {}, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :status, class: "text-sm font-medium text-slate-700" %>
+      <%= form.select :status, options_for_select([["All", ""]] + Organization::Models::OperatingUnit::STATUSES.map { |status| [status.humanize, status] }, @status), {}, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div class="flex items-end">
+      <%= form.submit "Filter", class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+    </div>
+  <% end %>
+</section>
+
+<section class="mt-8 rounded border border-slate-200 bg-white shadow-sm">
+  <% if @operating_units.any? %>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-slate-200 text-sm">
+        <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+          <tr>
+            <th class="px-5 py-3">Operating unit</th>
+            <th class="px-5 py-3">Type</th>
+            <th class="px-5 py-3">Parent</th>
+            <th class="px-5 py-3">Status</th>
+            <th class="px-5 py-3 text-right">Children</th>
+            <th class="px-5 py-3 text-right">Cash locations</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100">
+          <% @operating_units.each do |unit| %>
+            <tr>
+              <td class="px-5 py-4">
+                <%= link_to unit.code, admin_operating_unit_path(unit), class: "font-medium text-slate-950 underline" %>
+                <div class="text-xs text-slate-500"><%= unit.name %></div>
+              </td>
+              <td class="px-5 py-4"><%= unit.unit_type.humanize %></td>
+              <td class="px-5 py-4"><%= admin_operating_unit_label(unit.parent_operating_unit) %></td>
+              <td class="px-5 py-4"><%= admin_status_badge(unit.status) %></td>
+              <td class="px-5 py-4 text-right"><%= @child_counts.fetch(unit.id, 0) %></td>
+              <td class="px-5 py-4 text-right"><%= @cash_location_counts.fetch(unit.id, 0) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <div class="px-5 py-8 text-sm text-slate-600">No operating units match the current filters.</div>
+  <% end %>
+</section>

--- a/app/views/admin/operating_units/new.html.erb
+++ b/app/views/admin/operating_units/new.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "New Operating Unit - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">New operating unit</h1>
+    <p class="mt-2 text-slate-600">Create an organizational scope record.</p>
+  </div>
+  <%= link_to "All operating units", admin_operating_units_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+</section>
+
+<section class="mt-8">
+  <%= render "form" %>
+</section>

--- a/app/views/admin/operating_units/show.html.erb
+++ b/app/views/admin/operating_units/show.html.erb
@@ -1,0 +1,118 @@
+<% content_for :title, "#{@operating_unit.code} - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold"><%= @operating_unit.code %></h1>
+    <p class="mt-2 text-slate-600"><%= @operating_unit.name %></p>
+  </div>
+  <div class="flex flex-wrap gap-2">
+    <%= link_to "All operating units", admin_operating_units_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+    <%= link_to "Edit", edit_admin_operating_unit_path(@operating_unit), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+  </div>
+</section>
+
+<section class="mt-8 grid gap-4 md:grid-cols-4">
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Status</p>
+    <div class="mt-3"><%= admin_status_badge(@operating_unit.status) %></div>
+  </div>
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Type</p>
+    <p class="mt-2 text-2xl font-semibold"><%= @operating_unit.unit_type.humanize %></p>
+  </div>
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Parent</p>
+    <p class="mt-2 text-lg font-semibold"><%= admin_operating_unit_label(@operating_unit.parent_operating_unit) %></p>
+  </div>
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Time zone</p>
+    <p class="mt-2 text-lg font-semibold"><%= @operating_unit.time_zone %></p>
+  </div>
+</section>
+
+<section class="mt-8 grid gap-4 md:grid-cols-2">
+  <div class="rounded border border-slate-200 bg-white shadow-sm">
+    <div class="border-b border-slate-200 px-5 py-4">
+      <h2 class="text-xl font-semibold">Child units</h2>
+    </div>
+    <% if @child_units.any? %>
+      <div class="divide-y divide-slate-100">
+        <% @child_units.each do |unit| %>
+          <div class="px-5 py-4 text-sm">
+            <%= link_to unit.code, admin_operating_unit_path(unit), class: "font-medium underline" %>
+            <span class="text-slate-500"><%= unit.name %></span>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="px-5 py-8 text-sm text-slate-600">No child operating units.</div>
+    <% end %>
+  </div>
+
+  <div class="rounded border border-slate-200 bg-white shadow-sm">
+    <div class="border-b border-slate-200 px-5 py-4">
+      <h2 class="text-xl font-semibold">Cash locations</h2>
+    </div>
+    <% if @cash_locations.any? %>
+      <div class="divide-y divide-slate-100">
+        <% @cash_locations.each do |location| %>
+          <div class="px-5 py-4 text-sm">
+            <%= link_to admin_cash_location_label(location), admin_cash_location_path(location), class: "font-medium underline" %>
+            <span class="text-slate-500"><%= location.location_type.humanize %></span>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="px-5 py-8 text-sm text-slate-600">No cash locations in this operating unit.</div>
+    <% end %>
+  </div>
+</section>
+
+<section class="mt-8 grid gap-4 md:grid-cols-2">
+  <div class="rounded border border-slate-200 bg-white shadow-sm">
+    <div class="border-b border-slate-200 px-5 py-4">
+      <h2 class="text-xl font-semibold">Defaulting operators</h2>
+    </div>
+    <% if @defaulting_operators.any? %>
+      <div class="divide-y divide-slate-100">
+        <% @defaulting_operators.each do |operator| %>
+          <div class="px-5 py-4 text-sm"><%= link_to operator.display_name, admin_operator_path(operator), class: "font-medium underline" %></div>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="px-5 py-8 text-sm text-slate-600">No operators default to this unit.</div>
+    <% end %>
+  </div>
+
+  <div class="rounded border border-slate-200 bg-white shadow-sm">
+    <div class="border-b border-slate-200 px-5 py-4">
+      <h2 class="text-xl font-semibold">Scoped role assignments</h2>
+    </div>
+    <% if @scoped_assignments.any? %>
+      <div class="divide-y divide-slate-100">
+        <% @scoped_assignments.each do |assignment| %>
+          <div class="px-5 py-4 text-sm">
+            <%= link_to assignment.operator.display_name, admin_operator_path(assignment.operator), class: "font-medium underline" %>
+            <span class="text-slate-500"><%= assignment.role.code %></span>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="px-5 py-8 text-sm text-slate-600">No scoped role assignments for this unit.</div>
+    <% end %>
+  </div>
+</section>
+
+<% unless @operating_unit.status == Organization::Models::OperatingUnit::STATUS_CLOSED %>
+  <section class="mt-8 rounded border border-amber-200 bg-amber-50 p-5">
+    <h2 class="font-semibold text-amber-950">Close operating unit</h2>
+    <p class="mt-2 text-sm text-amber-900">Closing is blocked while active child units or active cash locations remain.</p>
+    <%= form_with url: close_admin_operating_unit_path(@operating_unit), scope: :operating_unit, method: :post, local: true, class: "mt-4 flex flex-col gap-3 md:flex-row md:items-end" do |form| %>
+      <div>
+        <%= form.label :closed_on, class: "text-sm font-medium text-amber-950" %>
+        <%= form.date_field :closed_on, value: Date.current, class: "mt-1 rounded border border-amber-300 px-3 py-2" %>
+      </div>
+      <%= form.submit "Close operating unit", class: "rounded border border-amber-300 px-4 py-2 font-medium text-amber-950" %>
+    <% end %>
+  </section>
+<% end %>

--- a/app/views/admin/operator_role_assignments/_form.html.erb
+++ b/app/views/admin/operator_role_assignments/_form.html.erb
@@ -1,0 +1,38 @@
+<% if @error_message.present? %>
+  <div class="mb-4 rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800"><%= @error_message %></div>
+<% end %>
+
+<%= form_with model: @assignment,
+  scope: :operator_role_assignment,
+  url: @assignment.persisted? ? admin_operator_operator_role_assignment_path(@operator, @assignment) : admin_operator_operator_role_assignments_path(@operator),
+  method: @assignment.persisted? ? :patch : :post,
+  local: true,
+  class: "rounded border border-slate-200 bg-white p-5 shadow-sm" do |form| %>
+  <div class="grid gap-4 md:grid-cols-2">
+    <div>
+      <%= form.label :role_id, "Role", class: "text-sm font-medium text-slate-700" %>
+      <%= form.select :role_id, options_from_collection_for_select(@roles, :id, :code, @assignment.role_id), {}, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :scope_id, "Operating unit scope", class: "text-sm font-medium text-slate-700" %>
+      <%= form.hidden_field :scope_type, value: "operating_unit" %>
+      <%= form.select :scope_id, options_from_collection_for_select(@operating_units, :id, :code, @assignment.scope_id), { include_blank: "Global" }, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :starts_at, class: "text-sm font-medium text-slate-700" %>
+      <%= form.datetime_local_field :starts_at, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :ends_at, class: "text-sm font-medium text-slate-700" %>
+      <%= form.datetime_local_field :ends_at, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div class="flex items-center gap-2 pt-6">
+      <%= form.check_box :active, checked: @assignment.active.nil? ? true : @assignment.active %>
+      <%= form.label :active, "Active", class: "text-sm font-medium text-slate-700" %>
+    </div>
+  </div>
+  <div class="mt-6 flex gap-2">
+    <%= form.submit class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+    <%= link_to "Cancel", admin_operator_path(@operator), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+  </div>
+<% end %>

--- a/app/views/admin/operator_role_assignments/edit.html.erb
+++ b/app/views/admin/operator_role_assignments/edit.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "Edit Role Assignment - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">Edit role assignment</h1>
+    <p class="mt-2 text-slate-600"><%= @operator.display_name %></p>
+  </div>
+  <%= link_to "Operator detail", admin_operator_path(@operator), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+</section>
+
+<section class="mt-8">
+  <%= render "form" %>
+</section>

--- a/app/views/admin/operator_role_assignments/new.html.erb
+++ b/app/views/admin/operator_role_assignments/new.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "Assign Role - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">Assign role</h1>
+    <p class="mt-2 text-slate-600"><%= @operator.display_name %></p>
+  </div>
+  <%= link_to "Operator detail", admin_operator_path(@operator), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+</section>
+
+<section class="mt-8">
+  <%= render "form" %>
+</section>

--- a/app/views/admin/operators/_form.html.erb
+++ b/app/views/admin/operators/_form.html.erb
@@ -1,0 +1,50 @@
+<% if @error_message.present? %>
+  <div class="mb-4 rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800"><%= @error_message %></div>
+<% end %>
+
+<%= form_with model: @operator,
+  scope: :operator,
+  url: @operator.persisted? ? admin_operator_path(@operator) : admin_operators_path,
+  method: @operator.persisted? ? :patch : :post,
+  local: true,
+  class: "rounded border border-slate-200 bg-white p-5 shadow-sm" do |form| %>
+  <div class="grid gap-4 md:grid-cols-2">
+    <div>
+      <%= form.label :display_name, class: "text-sm font-medium text-slate-700" %>
+      <%= form.text_field :display_name, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :role, "Legacy role", class: "text-sm font-medium text-slate-700" %>
+      <%= form.select :role, options_for_select(@legacy_roles.map { |role| [role.humanize, role] }, @operator.role), {}, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :default_operating_unit_id, "Default operating unit", class: "text-sm font-medium text-slate-700" %>
+      <%= form.select :default_operating_unit_id, options_from_collection_for_select(@operating_units, :id, :code, @operator.default_operating_unit_id), { include_blank: "None" }, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div class="flex items-center gap-2 pt-6">
+      <%= form.check_box :active, checked: @operator.active.nil? ? true : @operator.active %>
+      <%= form.label :active, "Active", class: "text-sm font-medium text-slate-700" %>
+    </div>
+  </div>
+
+  <% if @operator.new_record? %>
+    <div class="mt-6 border-t border-slate-200 pt-5">
+      <h2 class="font-semibold">Initial credential</h2>
+      <div class="mt-4 grid gap-4 md:grid-cols-2">
+        <div>
+          <%= label_tag "operator_username", "Username", class: "text-sm font-medium text-slate-700" %>
+          <%= text_field_tag "operator[username]", params.dig(:operator, :username), class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+        </div>
+        <div>
+          <%= label_tag "operator_password", "Password", class: "text-sm font-medium text-slate-700" %>
+          <%= password_field_tag "operator[password]", nil, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="mt-6 flex gap-2">
+    <%= form.submit class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+    <%= link_to "Cancel", @operator.persisted? ? admin_operator_path(@operator) : admin_operators_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+  </div>
+<% end %>

--- a/app/views/admin/operators/edit.html.erb
+++ b/app/views/admin/operators/edit.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "Edit Operator - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">Edit operator</h1>
+    <p class="mt-2 text-slate-600"><%= @operator.display_name %></p>
+  </div>
+  <%= link_to "Operator detail", admin_operator_path(@operator), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+</section>
+
+<section class="mt-8">
+  <%= render "form" %>
+</section>

--- a/app/views/admin/operators/index.html.erb
+++ b/app/views/admin/operators/index.html.erb
@@ -1,0 +1,64 @@
+<% content_for :title, "Operators - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">Operators</h1>
+    <p class="mt-2 text-slate-600">Internal users, credentials, and effective role assignments.</p>
+  </div>
+  <div class="flex gap-2">
+    <%= link_to "Admin dashboard", admin_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+    <%= link_to "New operator", new_admin_operator_path, class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+  </div>
+</section>
+
+<section class="mt-6 rounded border border-slate-200 bg-white p-4 shadow-sm">
+  <%= form_with url: admin_operators_path, method: :get, local: true, class: "grid gap-3 md:grid-cols-3" do |form| %>
+    <div>
+      <%= form.label :search, "Search", class: "text-sm font-medium text-slate-700" %>
+      <%= form.text_field :search, value: @search, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :status, "Status", class: "text-sm font-medium text-slate-700" %>
+      <%= form.select :status, options_for_select([["All", ""], ["Active", "active"], ["Inactive", "inactive"]], @status), {}, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div class="flex items-end">
+      <%= form.submit "Filter", class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+    </div>
+  <% end %>
+</section>
+
+<section class="mt-8 rounded border border-slate-200 bg-white shadow-sm">
+  <% if @operators.any? %>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-slate-200 text-sm">
+        <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+          <tr>
+            <th class="px-5 py-3">Operator</th>
+            <th class="px-5 py-3">Username</th>
+            <th class="px-5 py-3">Legacy role</th>
+            <th class="px-5 py-3">Default OU</th>
+            <th class="px-5 py-3">Status</th>
+            <th class="px-5 py-3 text-right">Assignments</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100">
+          <% @operators.each do |operator| %>
+            <tr>
+              <td class="px-5 py-4">
+                <%= link_to operator.display_name, admin_operator_path(operator), class: "font-medium text-slate-950 underline" %>
+                <div class="text-xs text-slate-500">#<%= operator.id %></div>
+              </td>
+              <td class="px-5 py-4"><%= operator.credential&.username || "No credential" %></td>
+              <td class="px-5 py-4"><%= operator.role.humanize %></td>
+              <td class="px-5 py-4"><%= admin_operating_unit_label(operator.default_operating_unit) %></td>
+              <td class="px-5 py-4"><%= admin_status_badge(operator.active? ? "active" : "inactive") %></td>
+              <td class="px-5 py-4 text-right"><%= operator.operator_role_assignments.size %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <div class="px-5 py-8 text-sm text-slate-600">No operators match the current filters.</div>
+  <% end %>
+</section>

--- a/app/views/admin/operators/new.html.erb
+++ b/app/views/admin/operators/new.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "New Operator - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">New operator</h1>
+    <p class="mt-2 text-slate-600">Create an internal operator and optional first credential.</p>
+  </div>
+  <%= link_to "All operators", admin_operators_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+</section>
+
+<section class="mt-8">
+  <%= render "form" %>
+</section>

--- a/app/views/admin/operators/show.html.erb
+++ b/app/views/admin/operators/show.html.erb
@@ -1,0 +1,111 @@
+<% content_for :title, "#{@operator.display_name} - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold"><%= @operator.display_name %></h1>
+    <p class="mt-2 text-slate-600">Operator #<%= @operator.id %></p>
+  </div>
+  <div class="flex flex-wrap gap-2">
+    <%= link_to "All operators", admin_operators_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+    <%= link_to "Edit", edit_admin_operator_path(@operator), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+    <%= link_to "Assign role", new_admin_operator_operator_role_assignment_path(@operator), class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+  </div>
+</section>
+
+<section class="mt-8 grid gap-4 md:grid-cols-4">
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Status</p>
+    <div class="mt-3"><%= admin_status_badge(@operator.active? ? "active" : "inactive") %></div>
+  </div>
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Legacy role</p>
+    <p class="mt-2 text-2xl font-semibold"><%= @operator.role.humanize %></p>
+  </div>
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Username</p>
+    <p class="mt-2 text-2xl font-semibold"><%= @operator.credential&.username || "None" %></p>
+  </div>
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Default OU</p>
+    <p class="mt-2 text-lg font-semibold"><%= admin_operating_unit_label(@operator.default_operating_unit) %></p>
+  </div>
+</section>
+
+<section class="mt-8 grid gap-4 md:grid-cols-2">
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <h2 class="text-xl font-semibold">Credential reset</h2>
+    <%= form_with url: reset_credential_admin_operator_path(@operator), scope: :credential, method: :post, local: true, class: "mt-4 grid gap-4" do |form| %>
+      <div>
+        <%= form.label :username, class: "text-sm font-medium text-slate-700" %>
+        <%= form.text_field :username, value: @operator.credential&.username, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+      </div>
+      <div>
+        <%= form.label :password, "New password", class: "text-sm font-medium text-slate-700" %>
+        <%= form.password_field :password, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+      </div>
+      <%= form.submit "Reset credential", class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+    <% end %>
+  </div>
+
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <h2 class="text-xl font-semibold">Effective capabilities</h2>
+    <p class="mt-2 text-sm text-slate-600">For the operator default operating unit.</p>
+    <% if @effective_capabilities.any? %>
+      <div class="mt-4 flex flex-wrap gap-2">
+        <% @effective_capabilities.each do |capability| %>
+          <span class="rounded border border-slate-200 bg-slate-50 px-2 py-1 text-xs"><%= capability %></span>
+        <% end %>
+      </div>
+    <% else %>
+      <p class="mt-4 text-sm text-slate-600">No effective capabilities for the default scope.</p>
+    <% end %>
+  </div>
+</section>
+
+<section class="mt-8 rounded border border-slate-200 bg-white shadow-sm">
+  <div class="flex items-center justify-between border-b border-slate-200 px-5 py-4">
+    <h2 class="text-xl font-semibold">Role assignments</h2>
+    <%= link_to "Assign role", new_admin_operator_operator_role_assignment_path(@operator), class: "rounded border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700" %>
+  </div>
+  <% if @assignments.any? %>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-slate-200 text-sm">
+        <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+          <tr>
+            <th class="px-5 py-3">Role</th>
+            <th class="px-5 py-3">Scope</th>
+            <th class="px-5 py-3">Window</th>
+            <th class="px-5 py-3">Status</th>
+            <th class="px-5 py-3"></th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100">
+          <% @assignments.each do |assignment| %>
+            <tr>
+              <td class="px-5 py-4"><%= link_to assignment.role.code, admin_role_path(assignment.role), class: "font-medium underline" %></td>
+              <td class="px-5 py-4"><%= admin_assignment_scope_label(assignment) %></td>
+              <td class="px-5 py-4"><%= admin_datetime(assignment.starts_at) %> to <%= admin_datetime(assignment.ends_at) %></td>
+              <td class="px-5 py-4"><%= admin_status_badge(assignment.active? ? "active" : "inactive") %></td>
+              <td class="px-5 py-4 text-right">
+                <%= link_to "Edit", edit_admin_operator_operator_role_assignment_path(@operator, assignment), class: "text-sm font-medium underline" %>
+                <% if assignment.active? %>
+                  <%= button_to "Deactivate", deactivate_admin_operator_operator_role_assignment_path(@operator, assignment), method: :post, class: "ml-2 inline text-sm font-medium underline" %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <div class="px-5 py-8 text-sm text-slate-600">No role assignments recorded.</div>
+  <% end %>
+</section>
+
+<% if @operator.active? %>
+  <section class="mt-8 rounded border border-amber-200 bg-amber-50 p-5">
+    <h2 class="font-semibold text-amber-950">Deactivate operator</h2>
+    <p class="mt-2 text-sm text-amber-900">Deactivation prevents internal login because only active operators are loaded into the internal session.</p>
+    <%= button_to "Deactivate #{@operator.display_name}", deactivate_admin_operator_path(@operator), method: :post, class: "mt-4 rounded border border-amber-300 px-4 py-2 font-medium text-amber-950" %>
+  </section>
+<% end %>

--- a/app/views/admin/roles/_form.html.erb
+++ b/app/views/admin/roles/_form.html.erb
@@ -1,0 +1,58 @@
+<% if @error_message.present? %>
+  <div class="mb-4 rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800"><%= @error_message %></div>
+<% end %>
+
+<%= form_with model: @role,
+  scope: :role,
+  url: @role.persisted? ? admin_role_path(@role) : admin_roles_path,
+  method: @role.persisted? ? :patch : :post,
+  local: true,
+  class: "rounded border border-slate-200 bg-white p-5 shadow-sm" do |form| %>
+  <div class="grid gap-4 md:grid-cols-2">
+    <div>
+      <%= form.label :code, class: "text-sm font-medium text-slate-700" %>
+      <%= form.text_field :code, disabled: @role.persisted?, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2 disabled:bg-slate-100" %>
+    </div>
+    <div>
+      <%= form.label :name, class: "text-sm font-medium text-slate-700" %>
+      <%= form.text_field :name, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div class="md:col-span-2">
+      <%= form.label :description, class: "text-sm font-medium text-slate-700" %>
+      <%= form.text_area :description, rows: 3, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div class="flex items-center gap-2">
+      <%= form.check_box :active, checked: @role.active.nil? ? true : @role.active %>
+      <%= form.label :active, "Active", class: "text-sm font-medium text-slate-700" %>
+    </div>
+  </div>
+
+  <% if @role.new_record? %>
+    <div class="mt-6 border-t border-slate-200 pt-5">
+      <h2 class="font-semibold">Initial capabilities</h2>
+      <div class="mt-4 grid gap-4 md:grid-cols-2">
+        <% @capabilities.each do |category, capabilities| %>
+          <div>
+            <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500"><%= category %></h3>
+            <div class="mt-2 grid gap-2">
+              <% capabilities.each do |capability| %>
+                <label class="flex items-start gap-2 text-sm">
+                  <%= check_box_tag "capability_ids[]", capability.id, false %>
+                  <span>
+                    <span class="font-medium"><%= capability.code %></span>
+                    <span class="block text-slate-500"><%= capability.name %></span>
+                  </span>
+                </label>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="mt-6 flex gap-2">
+    <%= form.submit class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+    <%= link_to "Cancel", @role.persisted? ? admin_role_path(@role) : admin_roles_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+  </div>
+<% end %>

--- a/app/views/admin/roles/edit.html.erb
+++ b/app/views/admin/roles/edit.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "Edit Role - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">Edit role</h1>
+    <p class="mt-2 text-slate-600"><%= @role.code %></p>
+  </div>
+  <%= link_to "Role detail", admin_role_path(@role), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+</section>
+
+<section class="mt-8">
+  <%= render "form" %>
+</section>

--- a/app/views/admin/roles/index.html.erb
+++ b/app/views/admin/roles/index.html.erb
@@ -1,0 +1,40 @@
+<% content_for :title, "Roles - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">Roles</h1>
+    <p class="mt-2 text-slate-600">Runtime RBAC roles and capability mappings.</p>
+  </div>
+  <div class="flex gap-2">
+    <%= link_to "Admin dashboard", admin_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+    <%= link_to "New role", new_admin_role_path, class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+  </div>
+</section>
+
+<section class="mt-8 rounded border border-slate-200 bg-white shadow-sm">
+  <div class="overflow-x-auto">
+    <table class="min-w-full divide-y divide-slate-200 text-sm">
+      <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+        <tr>
+          <th class="px-5 py-3">Role</th>
+          <th class="px-5 py-3">Type</th>
+          <th class="px-5 py-3">Status</th>
+          <th class="px-5 py-3 text-right">Capabilities</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-slate-100">
+        <% @roles.each do |role| %>
+          <tr>
+            <td class="px-5 py-4">
+              <%= link_to role.code, admin_role_path(role), class: "font-medium text-slate-950 underline" %>
+              <div class="text-xs text-slate-500"><%= role.name %></div>
+            </td>
+            <td class="px-5 py-4"><%= role.system_role? ? "System" : "Custom" %></td>
+            <td class="px-5 py-4"><%= admin_status_badge(role.active? ? "active" : "inactive") %></td>
+            <td class="px-5 py-4 text-right"><%= role.capabilities.size %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</section>

--- a/app/views/admin/roles/new.html.erb
+++ b/app/views/admin/roles/new.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "New Role - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">New role</h1>
+    <p class="mt-2 text-slate-600">Create a custom role and initial capability mapping.</p>
+  </div>
+  <%= link_to "All roles", admin_roles_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+</section>
+
+<section class="mt-8">
+  <%= render "form" %>
+</section>

--- a/app/views/admin/roles/show.html.erb
+++ b/app/views/admin/roles/show.html.erb
@@ -1,0 +1,90 @@
+<% content_for :title, "#{@role.code} - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold"><%= @role.code %></h1>
+    <p class="mt-2 text-slate-600"><%= @role.name %></p>
+  </div>
+  <div class="flex flex-wrap gap-2">
+    <%= link_to "All roles", admin_roles_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+    <%= link_to "Edit", edit_admin_role_path(@role), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+  </div>
+</section>
+
+<section class="mt-8 grid gap-4 md:grid-cols-3">
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Status</p>
+    <div class="mt-3"><%= admin_status_badge(@role.active? ? "active" : "inactive") %></div>
+  </div>
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Type</p>
+    <p class="mt-2 text-2xl font-semibold"><%= @role.system_role? ? "System" : "Custom" %></p>
+  </div>
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Capabilities</p>
+    <p class="mt-2 text-2xl font-semibold"><%= @role.capabilities.size %></p>
+  </div>
+</section>
+
+<section class="mt-8 rounded border border-slate-200 bg-white p-5 shadow-sm">
+  <h2 class="text-xl font-semibold">Capability matrix</h2>
+  <%= form_with url: capabilities_admin_role_path(@role), method: :patch, local: true, class: "mt-4" do %>
+    <div class="grid gap-4 md:grid-cols-2">
+      <% @capabilities.each do |category, capabilities| %>
+        <div>
+          <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500"><%= category %></h3>
+          <div class="mt-2 grid gap-2">
+            <% capabilities.each do |capability| %>
+              <label class="flex items-start gap-2 text-sm">
+                <%= check_box_tag "capability_ids[]", capability.id, @role.capabilities.include?(capability) %>
+                <span>
+                  <span class="font-medium"><%= capability.code %></span>
+                  <span class="block text-slate-500"><%= capability.name %></span>
+                </span>
+              </label>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+    <%= submit_tag "Update capabilities", class: "mt-6 rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+  <% end %>
+</section>
+
+<section class="mt-8 rounded border border-slate-200 bg-white shadow-sm">
+  <div class="border-b border-slate-200 px-5 py-4">
+    <h2 class="text-xl font-semibold">Assigned operators</h2>
+  </div>
+  <% if @assignments.any? %>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-slate-200 text-sm">
+        <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+          <tr>
+            <th class="px-5 py-3">Operator</th>
+            <th class="px-5 py-3">Scope</th>
+            <th class="px-5 py-3">Status</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100">
+          <% @assignments.each do |assignment| %>
+            <tr>
+              <td class="px-5 py-4"><%= link_to assignment.operator.display_name, admin_operator_path(assignment.operator), class: "font-medium underline" %></td>
+              <td class="px-5 py-4"><%= admin_assignment_scope_label(assignment) %></td>
+              <td class="px-5 py-4"><%= admin_status_badge(assignment.active? ? "active" : "inactive") %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <div class="px-5 py-8 text-sm text-slate-600">No operators are assigned this role.</div>
+  <% end %>
+</section>
+
+<% if !@role.system_role? && @role.active? %>
+  <section class="mt-8 rounded border border-amber-200 bg-amber-50 p-5">
+    <h2 class="font-semibold text-amber-950">Deactivate role</h2>
+    <p class="mt-2 text-sm text-amber-900">Routine admin maintenance deactivates roles instead of deleting them.</p>
+    <%= button_to "Deactivate #{@role.code}", deactivate_admin_role_path(@role), method: :post, class: "mt-4 rounded border border-amber-300 px-4 py-2 font-medium text-amber-950" %>
+  </section>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,12 @@ Rails.application.routes.draw do
     resources :capabilities do
       post :deactivate, on: :member
     end
+    resources :operating_units do
+      post :close, on: :member
+    end
+    resources :cash_locations do
+      post :deactivate, on: :member
+    end
     resources :deposit_products, only: [ :index, :show ]
     get "deposit_products/:id/readiness", to: "deposit_products#readiness", as: :deposit_product_readiness
     resources :deposit_product_fee_rules, only: [ :index ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,20 @@ Rails.application.routes.draw do
   end
   get "admin", to: "admin/dashboard#index", as: :admin
   scope path: "admin", module: :admin, as: :admin do
+    resources :operators do
+      post :deactivate, on: :member
+      post :reset_credential, on: :member
+      resources :operator_role_assignments, only: [ :new, :create, :edit, :update ] do
+        post :deactivate, on: :member
+      end
+    end
+    resources :roles do
+      patch :capabilities, on: :member, action: :update_capabilities
+      post :deactivate, on: :member
+    end
+    resources :capabilities do
+      post :deactivate, on: :member
+    end
     resources :deposit_products, only: [ :index, :show ]
     get "deposit_products/:id/readiness", to: "deposit_products#readiness", as: :deposit_product_readiness
     resources :deposit_product_fee_rules, only: [ :index ]

--- a/docs/adr/0033-admin-rbac-maintenance.md
+++ b/docs/adr/0033-admin-rbac-maintenance.md
@@ -1,0 +1,58 @@
+# ADR-0033: Admin RBAC maintenance
+
+**Status:** Accepted - first slice implemented  
+**Date:** 2026-04-29  
+**Decision Type:** Workspace administration / authorization operations  
+**Aligns with:** [ADR-0025](0025-internal-workspace-ui.md), [ADR-0029](0029-capability-first-authorization-layer.md), [ADR-0032](0032-operating-units-and-branch-scope.md), [module catalog](../architecture/bankcore-module-catalog.md)
+
+---
+
+## 1. Context and Problem Statement
+
+BankCORE has database-backed Workspace RBAC tables for operators, roles, capabilities, role-capability mappings, and scoped role assignments. The runtime authorization path reads those database rows through `Workspace::Authorization::CapabilityResolver`, while `Workspace::Authorization::CapabilityRegistry` remains the seed/catalog baseline used by migrations and seed tasks.
+
+Admin staff need an internal HTML maintenance surface for this RBAC data. The first slice should support operational maintenance without changing the financial kernel, adding customer-facing behavior, or creating a new audit subsystem before the admin workflow settles.
+
+---
+
+## 2. Decision Outcome
+
+BankCORE will add an admin-facing HTML RBAC maintenance UI under the existing internal Admin workspace.
+
+The Workspace domain owns the operator and RBAC table family:
+
+- `operators`
+- `operator_credentials`
+- `roles`
+- `capabilities`
+- `role_capabilities`
+- `operator_role_assignments`
+
+The UI will call `Workspace::Commands` and `Workspace::Queries`; controllers remain workspace-oriented orchestration only.
+
+---
+
+## 3. Invariants
+
+- Runtime authorization uses persisted RBAC rows. The capability registry is the default catalog and seed source, not the direct runtime authorization store.
+- `operators.role` remains a legacy compatibility classification. Updating it does not imply automatic destructive rewrites of existing RBAC assignments.
+- System roles are viewable and assignable, but they must not be deleted through the admin UI.
+- Role and capability records should be deactivated rather than hard-deleted in routine admin workflows.
+- Scoped assignments support only global scope or `operating_unit` scope. No region or parent inheritance is implied.
+- This slice does not add operational events, posting rules, ledger entries, or financial flows.
+
+---
+
+## 4. Audit Boundary
+
+The first admin RBAC UI slice uses the existing `created_at` and `updated_at` columns as lightweight change evidence. It does not introduce a dedicated Workspace audit log table or new Core operational event types.
+
+A future slice may add durable admin-maintenance audit events after the workflow is exercised and the required evidence model is clearer.
+
+---
+
+## 5. Consequences
+
+- Admin maintenance can keep operators, credentials, role assignments, and role-capability mappings aligned with the database state that authorization actually evaluates.
+- Seeded roles and capabilities remain protected by conservative UI behavior rather than a new registry synchronization mechanism.
+- The design keeps Workspace administration separate from monetary truth and avoids expanding the Core financial event catalog for non-financial admin changes.

--- a/docs/adr/0034-admin-organization-cash-maintenance.md
+++ b/docs/adr/0034-admin-organization-cash-maintenance.md
@@ -1,0 +1,51 @@
+# ADR-0034: Admin organization and cash maintenance
+
+**Status:** Accepted - first slice implemented  
+**Date:** 2026-04-29  
+**Decision Type:** Admin configuration / branch operations reference data  
+**Aligns with:** [ADR-0031](0031-cash-inventory-and-management.md), [ADR-0032](0032-operating-units-and-branch-scope.md), [ADR-0033](0033-admin-rbac-maintenance.md), [module catalog](../architecture/bankcore-module-catalog.md)
+
+---
+
+## 1. Context and Problem Statement
+
+BankCORE now has first-class operating units for organizational scope and Cash-domain locations for custody points such as branch vaults, teller drawers, and internal transit locations. Admin staff need an internal HTML surface to maintain that reference data without weakening cash custody controls or turning operating units into accounting entities.
+
+---
+
+## 2. Decision Outcome
+
+BankCORE will add Admin HTML maintenance for:
+
+- Organization-owned `operating_units`
+- Cash-owned `cash_locations`
+
+The Admin controllers will orchestrate domain commands and queries. Organization and Cash remain the table owners and enforce lifecycle rules.
+
+This slice uses `system.configure` as the required admin capability.
+
+---
+
+## 3. Invariants
+
+- Operating units are operational scope only. They are not ledgers, legal entities, or business-date partitions.
+- Operating units and cash locations are never deleted through the Admin UI.
+- Seeded default operating-unit codes `BANKCORE` and `MAIN` must not be changed through Admin maintenance.
+- Cash locations must not move between operating units after creation. Cash custody changes use cash movements, counts, and balances, not metadata edits.
+- A cash location may be deactivated only when it has zero cash balance, no open teller session, no pending cash movement, and no pending cash variance.
+- An operating unit may be closed only when it has no active child operating units and no active cash locations.
+- Cash-location creation continues to use `Cash::Commands::CreateLocation` so zero-balance creation and active vault/drawer uniqueness remain centralized.
+
+---
+
+## 4. Audit Boundary
+
+This slice follows ADR-0033 and relies on standard `created_at` / `updated_at` timestamps as lightweight change evidence. It does not introduce a dedicated admin audit table or new operational event types.
+
+---
+
+## 5. Consequences
+
+- Admin users can configure operating-unit hierarchy and Cash custody locations without direct database edits.
+- Cash location status transitions are conservative and block unsafe deactivation while balances, sessions, or pending approvals remain.
+- The implementation keeps reference-data maintenance separate from monetary truth in Core posting and ledger.

--- a/test/domains/cash/admin_cash_location_commands_test.rb
+++ b/test/domains/cash/admin_cash_location_commands_test.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Cash
+  class AdminCashLocationCommandsTest < ActiveSupport::TestCase
+    setup do
+      BankCore::Seeds::OperatingUnits.seed!
+      BankCore::Seeds::Rbac.seed!
+      @operating_unit = Organization::Services::DefaultOperatingUnit.branch!
+      @operator = Workspace::Models::Operator.create!(
+        display_name: "Cash Admin Operator",
+        role: "admin",
+        active: true,
+        default_operating_unit: @operating_unit
+      )
+    end
+
+    test "updates location metadata without changing operating unit" do
+      parent = create_location!("Parent Vault", Models::CashLocation::TYPE_INTERNAL_TRANSIT)
+      location = create_location!("Managed Drawer", Models::CashLocation::TYPE_TELLER_DRAWER, drawer_code: "ADM1")
+
+      Commands::UpdateLocation.call(
+        cash_location_id: location.id,
+        attributes: {
+          name: "Updated Drawer",
+          responsible_operator_id: @operator.id,
+          parent_cash_location_id: parent.id,
+          drawer_code: "ADM2",
+          balancing_required: "0",
+          external_reference: "drawer-ref"
+        }
+      )
+
+      location.reload
+      assert_equal "Updated Drawer", location.name
+      assert_equal @operator.id, location.responsible_operator_id
+      assert_equal parent.id, location.parent_cash_location_id
+      assert_equal "ADM2", location.drawer_code
+      assert_not location.balancing_required?
+      assert_equal "drawer-ref", location.external_reference
+      assert_equal @operating_unit.id, location.operating_unit_id
+    end
+
+    test "deactivates only zero balance locations" do
+      location = create_location!("Zero Drawer", Models::CashLocation::TYPE_TELLER_DRAWER, drawer_code: "ZERO")
+      Commands::DeactivateLocation.call(cash_location_id: location.id)
+      assert_equal "inactive", location.reload.status
+
+      funded = create_location!("Funded Drawer", Models::CashLocation::TYPE_TELLER_DRAWER, drawer_code: "FUND")
+      funded.cash_balance.update!(amount_minor_units: 100)
+
+      error = assert_raises(Commands::DeactivateLocation::InvalidRequest) do
+        Commands::DeactivateLocation.call(cash_location_id: funded.id)
+      end
+      assert_match(/balance must be zero/, error.message)
+    end
+
+    test "blocks deactivation for open session pending movement and pending variance" do
+      session_location = create_location!("Session Drawer", Models::CashLocation::TYPE_TELLER_DRAWER, drawer_code: "OPEN")
+      Teller::Models::TellerSession.create!(
+        status: Teller::Models::TellerSession::STATUS_OPEN,
+        opened_at: Time.current,
+        drawer_code: "OPEN",
+        operating_unit: @operating_unit,
+        cash_location: session_location
+      )
+
+      error = assert_raises(Commands::DeactivateLocation::InvalidRequest) do
+        Commands::DeactivateLocation.call(cash_location_id: session_location.id)
+      end
+      assert_match(/open teller session/, error.message)
+
+      movement_location = create_location!("Movement Drawer", Models::CashLocation::TYPE_TELLER_DRAWER, drawer_code: "MOVE")
+      destination = create_location!("Transit", Models::CashLocation::TYPE_INTERNAL_TRANSIT)
+      Models::CashMovement.create!(
+        source_cash_location: movement_location,
+        destination_cash_location: destination,
+        operating_unit: @operating_unit,
+        actor: @operator,
+        amount_minor_units: 100,
+        currency: "USD",
+        business_date: Date.current,
+        status: Models::CashMovement::STATUS_PENDING_APPROVAL,
+        movement_type: Models::CashMovement::TYPE_INTERNAL_TRANSFER,
+        idempotency_key: "pending-movement-#{SecureRandom.hex(4)}",
+        request_fingerprint: SecureRandom.hex(16)
+      )
+
+      error = assert_raises(Commands::DeactivateLocation::InvalidRequest) do
+        Commands::DeactivateLocation.call(cash_location_id: movement_location.id)
+      end
+      assert_match(/pending cash movement/, error.message)
+
+      variance_location = create_location!("Variance Drawer", Models::CashLocation::TYPE_TELLER_DRAWER, drawer_code: "VAR")
+      count = Models::CashCount.create!(
+        cash_location: variance_location,
+        operating_unit: @operating_unit,
+        actor: @operator,
+        counted_amount_minor_units: 0,
+        expected_amount_minor_units: 0,
+        currency: "USD",
+        business_date: Date.current,
+        status: Models::CashCount::STATUS_RECORDED,
+        idempotency_key: "pending-variance-count-#{SecureRandom.hex(4)}",
+        request_fingerprint: SecureRandom.hex(16)
+      )
+      Models::CashVariance.create!(
+        cash_location: variance_location,
+        cash_count: count,
+        operating_unit: @operating_unit,
+        actor: @operator,
+        amount_minor_units: 100,
+        currency: "USD",
+        business_date: Date.current,
+        status: Models::CashVariance::STATUS_PENDING_APPROVAL
+      )
+
+      error = assert_raises(Commands::DeactivateLocation::InvalidRequest) do
+        Commands::DeactivateLocation.call(cash_location_id: variance_location.id)
+      end
+      assert_match(/pending cash variance/, error.message)
+    end
+
+    private
+
+    def create_location!(name, type, drawer_code: nil)
+      Commands::CreateLocation.call(
+        location_type: type,
+        operating_unit: @operating_unit,
+        name: name,
+        drawer_code: drawer_code
+      )
+    end
+  end
+end

--- a/test/domains/organization/admin_operating_unit_commands_test.rb
+++ b/test/domains/organization/admin_operating_unit_commands_test.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Organization
+  class AdminOperatingUnitCommandsTest < ActiveSupport::TestCase
+    setup do
+      BankCore::Seeds::OperatingUnits.seed!
+      @institution = Services::DefaultOperatingUnit.institution
+    end
+
+    test "creates and updates an operating unit" do
+      unit = Commands::CreateOperatingUnit.call(
+        attributes: {
+          code: "ops-#{SecureRandom.hex(4)}",
+          name: "Ops Center",
+          unit_type: "operations",
+          status: "active",
+          parent_operating_unit_id: @institution.id,
+          time_zone: "Eastern Time (US & Canada)",
+          opened_on: "2026-04-29"
+        }
+      )
+
+      assert_equal "OPS", unit.code.first(3)
+      assert_equal @institution.id, unit.parent_operating_unit_id
+
+      Commands::UpdateOperatingUnit.call(
+        operating_unit_id: unit.id,
+        attributes: {
+          name: "Updated Ops Center",
+          status: "inactive",
+          time_zone: "Central Time (US & Canada)"
+        }
+      )
+
+      assert_equal "Updated Ops Center", unit.reload.name
+      assert_equal "inactive", unit.status
+      assert_equal "Central Time (US & Canada)", unit.time_zone
+    end
+
+    test "protects seeded default operating unit codes" do
+      branch = Services::DefaultOperatingUnit.branch!
+
+      error = assert_raises(Commands::UpdateOperatingUnit::InvalidRequest) do
+        Commands::UpdateOperatingUnit.call(
+          operating_unit_id: branch.id,
+          attributes: { code: "RENAMED", name: branch.name }
+        )
+      end
+
+      assert_match(/cannot be changed/, error.message)
+      assert_equal "MAIN", branch.reload.code
+    end
+
+    test "prevents parent cycles" do
+      parent = create_unit!("PARENT")
+      child = create_unit!("CHILD", parent: parent)
+
+      error = assert_raises(Commands::UpdateOperatingUnit::InvalidRequest) do
+        Commands::UpdateOperatingUnit.call(
+          operating_unit_id: parent.id,
+          attributes: { parent_operating_unit_id: child.id }
+        )
+      end
+
+      assert_match(/descendant/, error.message)
+    end
+
+    test "closes operating unit only after active children and cash locations are cleared" do
+      unit = create_unit!("CLOSE")
+      create_unit!("ACTIVECHILD", parent: unit)
+
+      error = assert_raises(Commands::CloseOperatingUnit::InvalidRequest) do
+        Commands::CloseOperatingUnit.call(operating_unit_id: unit.id, closed_on: "2026-04-29")
+      end
+      assert_match(/active child/, error.message)
+
+      unit.child_operating_units.update_all(status: "inactive")
+      Cash::Commands::CreateLocation.call(
+        location_type: Cash::Models::CashLocation::TYPE_BRANCH_VAULT,
+        operating_unit: unit,
+        name: "Close Unit Vault"
+      )
+
+      error = assert_raises(Commands::CloseOperatingUnit::InvalidRequest) do
+        Commands::CloseOperatingUnit.call(operating_unit_id: unit.id, closed_on: "2026-04-29")
+      end
+      assert_match(/active cash locations/, error.message)
+
+      Cash::Models::CashLocation.where(operating_unit: unit).update_all(status: "inactive")
+      Commands::CloseOperatingUnit.call(operating_unit_id: unit.id, closed_on: "2026-04-29")
+
+      assert_equal "closed", unit.reload.status
+      assert_equal Date.new(2026, 4, 29), unit.closed_on
+    end
+
+    private
+
+    def create_unit!(code, parent: @institution)
+      Models::OperatingUnit.create!(
+        code: "#{code}-#{SecureRandom.hex(4)}",
+        name: "#{code.titleize} Unit",
+        unit_type: "branch",
+        parent_operating_unit: parent,
+        status: "active",
+        time_zone: "Eastern Time (US & Canada)",
+        opened_on: Date.current
+      )
+    end
+  end
+end

--- a/test/domains/workspace/admin_rbac_commands_test.rb
+++ b/test/domains/workspace/admin_rbac_commands_test.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Workspace
+  class AdminRbacCommandsTest < ActiveSupport::TestCase
+    setup do
+      BankCore::Seeds::Rbac.seed!
+      @branch = Organization::Services::DefaultOperatingUnit.branch
+    end
+
+    test "creates operator with normalized credential and resets password" do
+      operator = Commands::CreateOperator.call(
+        attributes: {
+          display_name: "RBAC Operator",
+          role: "teller",
+          active: true,
+          default_operating_unit_id: @branch.id,
+          username: "  RBAC-User  ",
+          password: "password123"
+        }
+      )
+
+      assert_equal "rbac-user", operator.credential.username
+      assert operator.active?
+
+      Commands::ResetOperatorCredential.call(
+        operator_id: operator.id,
+        username: "RBAC-Reset",
+        password: "new-password123"
+      )
+
+      credential = operator.reload.credential
+      assert_equal "rbac-reset", credential.username
+      assert credential.authenticate("new-password123")
+      assert_equal 0, credential.failed_login_attempts
+      assert_nil credential.locked_at
+    end
+
+    test "assigns operating unit scoped role and resolver sees capability" do
+      operator = Models::Operator.create!(
+        display_name: "Scoped Operator",
+        role: "teller",
+        active: true,
+        default_operating_unit: @branch
+      )
+      role = Models::Role.find_by!(code: Authorization::CapabilityRegistry::OPERATIONS)
+
+      assignment = Commands::AssignOperatorRole.call(
+        attributes: {
+          operator_id: operator.id,
+          role_id: role.id,
+          scope_type: "operating_unit",
+          scope_id: @branch.id,
+          active: true
+        }
+      )
+
+      assert_equal "operating_unit", assignment.scope_type
+      assert operator.has_capability?(Authorization::CapabilityRegistry::OPS_BATCH_PROCESS, scope: @branch)
+
+      Commands::DeactivateOperatorRoleAssignment.call(assignment_id: assignment.id)
+      assert_not operator.has_capability?(Authorization::CapabilityRegistry::OPS_BATCH_PROCESS, scope: @branch)
+    end
+
+    test "role capability updates affect runtime authorization" do
+      operator = Models::Operator.create!(
+        display_name: "Custom Role Operator",
+        role: "teller",
+        active: true,
+        default_operating_unit: @branch
+      )
+      role = Commands::CreateRole.call(
+        attributes: {
+          code: "custom_#{SecureRandom.hex(4)}",
+          name: "Custom Role",
+          active: true
+        }
+      )
+      capability = Models::Capability.find_by!(code: Authorization::CapabilityRegistry::AUDIT_EXPORT)
+      Commands::UpdateRoleCapabilities.call(role_id: role.id, capability_ids: [ capability.id ])
+      Commands::AssignOperatorRole.call(attributes: { operator_id: operator.id, role_id: role.id, active: true })
+
+      assert operator.has_capability?(Authorization::CapabilityRegistry::AUDIT_EXPORT, scope: @branch)
+
+      Commands::UpdateRoleCapabilities.call(role_id: role.id, capability_ids: [])
+      assert_not operator.has_capability?(Authorization::CapabilityRegistry::AUDIT_EXPORT, scope: @branch)
+    end
+
+    test "system roles cannot be deactivated" do
+      role = Models::Role.find_by!(code: Authorization::CapabilityRegistry::SYSTEM_ADMIN)
+
+      error = assert_raises(Commands::DeactivateRole::InvalidRequest) do
+        Commands::DeactivateRole.call(role_id: role.id)
+      end
+
+      assert_equal "System roles cannot be deactivated", error.message
+      assert role.reload.active?
+    end
+
+    test "capabilities are soft deactivated" do
+      capability = Commands::CreateCapability.call(
+        attributes: {
+          code: "custom.capability.#{SecureRandom.hex(4)}",
+          name: "Custom Capability",
+          category: "admin",
+          active: true
+        }
+      )
+
+      Commands::DeactivateCapability.call(capability_id: capability.id)
+      assert_not capability.reload.active?
+    end
+  end
+end

--- a/test/integration/admin_cash_locations_ui_test.rb
+++ b/test/integration/admin_cash_locations_ui_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AdminCashLocationsUiTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = create_operator_with_credential!(role: "admin", username: "admin-cash-locations")
+    @operating_unit = Organization::Services::DefaultOperatingUnit.branch!
+  end
+
+  test "admin can list create edit and deactivate cash locations" do
+    internal_login!(username: "admin-cash-locations")
+
+    get "/admin/cash_locations"
+    assert_response :success
+    assert_includes response.body, "Cash locations"
+
+    get "/admin/cash_locations/new"
+    assert_response :success
+    assert_includes response.body, "New cash location"
+    assert_includes response.body, 'name="cash_location[name]"'
+
+    assert_difference -> { Cash::Models::CashLocation.count }, 1 do
+      post "/admin/cash_locations",
+        params: {
+          cash_location: {
+            name: "Admin Transit",
+            location_type: "internal_transit",
+            operating_unit_id: @operating_unit.id,
+            status: "active",
+            currency: "USD",
+            balancing_required: "1",
+            external_reference: "admin-transit"
+          }
+        }
+    end
+    location = Cash::Models::CashLocation.order(:id).last
+    assert_redirected_to "/admin/cash_locations/#{location.id}"
+    assert_equal "Admin Transit", location.name
+    assert_equal 0, location.cash_balance.amount_minor_units
+
+    get "/admin/cash_locations/#{location.id}/edit"
+    assert_response :success
+    assert_includes response.body, "Edit cash location"
+    assert_includes response.body, 'name="cash_location[name]"'
+
+    patch "/admin/cash_locations/#{location.id}",
+      params: {
+        cash_location: {
+          name: "Updated Transit",
+          status: "active",
+          drawer_code: "",
+          balancing_required: "0",
+          external_reference: "updated-transit"
+        }
+      }
+    assert_redirected_to "/admin/cash_locations/#{location.id}"
+    assert_equal "Updated Transit", location.reload.name
+    assert_not location.balancing_required?
+
+    post "/admin/cash_locations/#{location.id}/deactivate"
+    assert_redirected_to "/admin/cash_locations/#{location.id}"
+    assert_equal "inactive", location.reload.status
+  end
+
+  test "cash location admin pages are forbidden to non-admin users" do
+    create_operator_with_credential!(role: "supervisor", username: "cash-location-non-admin")
+    internal_login!(username: "cash-location-non-admin")
+
+    get "/admin/cash_locations"
+    assert_response :forbidden
+  end
+end

--- a/test/integration/admin_operating_units_ui_test.rb
+++ b/test/integration/admin_operating_units_ui_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AdminOperatingUnitsUiTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = create_operator_with_credential!(role: "admin", username: "admin-ou")
+    @institution = Organization::Services::DefaultOperatingUnit.institution
+  end
+
+  test "admin can list create edit and close operating units" do
+    internal_login!(username: "admin-ou")
+
+    get "/admin/operating_units"
+    assert_response :success
+    assert_includes response.body, "Operating units"
+
+    get "/admin/operating_units/new"
+    assert_response :success
+    assert_includes response.body, "New operating unit"
+    assert_includes response.body, 'name="operating_unit[code]"'
+
+    assert_difference -> { Organization::Models::OperatingUnit.count }, 1 do
+      post "/admin/operating_units",
+        params: {
+          operating_unit: {
+            code: "adm-ou-#{SecureRandom.hex(4)}",
+            name: "Admin Managed Unit",
+            unit_type: "department",
+            status: "active",
+            parent_operating_unit_id: @institution.id,
+            time_zone: "Eastern Time (US & Canada)",
+            opened_on: "2026-04-29"
+          }
+        }
+    end
+    unit = Organization::Models::OperatingUnit.order(:id).last
+    assert_redirected_to "/admin/operating_units/#{unit.id}"
+    assert_equal "Admin Managed Unit", unit.name
+
+    get "/admin/operating_units/#{unit.id}/edit"
+    assert_response :success
+    assert_includes response.body, "Edit operating unit"
+    assert_includes response.body, 'name="operating_unit[name]"'
+
+    patch "/admin/operating_units/#{unit.id}",
+      params: {
+        operating_unit: {
+          code: unit.code,
+          name: "Updated Admin Unit",
+          unit_type: "department",
+          status: "inactive",
+          parent_operating_unit_id: @institution.id,
+          time_zone: "Central Time (US & Canada)"
+        }
+      }
+    assert_redirected_to "/admin/operating_units/#{unit.id}"
+    assert_equal "Updated Admin Unit", unit.reload.name
+    assert_equal "inactive", unit.status
+
+    post "/admin/operating_units/#{unit.id}/close",
+      params: { operating_unit: { closed_on: "2026-04-30" } }
+    assert_redirected_to "/admin/operating_units/#{unit.id}"
+    assert_equal "closed", unit.reload.status
+    assert_equal Date.new(2026, 4, 30), unit.closed_on
+  end
+
+  test "operating unit admin pages are forbidden to non-admin users" do
+    create_operator_with_credential!(role: "supervisor", username: "ou-non-admin")
+    internal_login!(username: "ou-non-admin")
+
+    get "/admin/operating_units"
+    assert_response :forbidden
+  end
+end

--- a/test/integration/admin_rbac_ui_test.rb
+++ b/test/integration/admin_rbac_ui_test.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AdminRbacUiTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = create_operator_with_credential!(role: "admin", username: "admin-rbac")
+    @branch = Organization::Services::DefaultOperatingUnit.branch
+  end
+
+  test "admin can create update deactivate operator and reset credentials" do
+    internal_login!(username: "admin-rbac")
+
+    get "/admin/operators"
+    assert_response :success
+    assert_includes response.body, "Operators"
+
+    get "/admin/operators/new"
+    assert_response :success
+    assert_includes response.body, "New operator"
+    assert_includes response.body, 'name="operator[display_name]"'
+
+    assert_difference -> { Workspace::Models::Operator.count }, 1 do
+      post "/admin/operators",
+        params: {
+          operator: {
+            display_name: "HTML Managed Operator",
+            role: "teller",
+            active: "1",
+            default_operating_unit_id: @branch.id,
+            username: "html-managed",
+            password: "password123"
+          }
+        }
+    end
+    operator = Workspace::Models::Operator.order(:id).last
+    assert_redirected_to "/admin/operators/#{operator.id}"
+    assert_equal "html-managed", operator.credential.username
+
+    get "/admin/operators/#{operator.id}/edit"
+    assert_response :success
+    assert_includes response.body, "Edit operator"
+    assert_includes response.body, 'name="operator[display_name]"'
+
+    patch "/admin/operators/#{operator.id}",
+      params: { operator: { display_name: "Updated HTML Operator", role: "supervisor", active: "1" } }
+    assert_redirected_to "/admin/operators/#{operator.id}"
+    assert_equal "Updated HTML Operator", operator.reload.display_name
+    assert_equal "supervisor", operator.role
+
+    post "/admin/operators/#{operator.id}/reset_credential",
+      params: { credential: { username: "html-reset", password: "new-password123" } }
+    assert_redirected_to "/admin/operators/#{operator.id}"
+    assert_equal "html-reset", operator.reload.credential.username
+
+    delete "/logout"
+    post "/login", params: { username: "html-reset", password: "new-password123" }
+    assert_redirected_to "/internal"
+
+    delete "/logout"
+    internal_login!(username: "admin-rbac")
+    get "/admin/operators/#{operator.id}"
+    assert_response :success
+    post "/admin/operators/#{operator.id}/deactivate"
+    assert_redirected_to "/admin/operators/#{operator.id}"
+    assert_not operator.reload.active?
+
+    delete "/logout"
+    post "/login", params: { username: "html-reset", password: "new-password123" }
+    assert_response :unauthorized
+  end
+
+  test "admin can manage custom role capability matrix and scoped assignments" do
+    operator = create_operator_with_credential!(role: "teller", username: "rbac-target")
+    capability = Workspace::Models::Capability.find_by!(
+      code: Workspace::Authorization::CapabilityRegistry::AUDIT_EXPORT
+    )
+
+    internal_login!(username: "admin-rbac")
+
+    get "/admin/roles/new"
+    assert_response :success
+    assert_includes response.body, "New role"
+    assert_includes response.body, 'name="role[name]"'
+
+    post "/admin/roles",
+      params: {
+        role: {
+          code: "html_role_#{SecureRandom.hex(4)}",
+          name: "HTML Role",
+          active: "1"
+        },
+        capability_ids: [ capability.id ]
+      }
+    role = Workspace::Models::Role.order(:id).last
+    assert_redirected_to "/admin/roles/#{role.id}"
+    assert_includes role.capabilities, capability
+
+    get "/admin/operators/#{operator.id}/operator_role_assignments/new"
+    assert_response :success
+    assert_includes response.body, "Assign role"
+    assert_includes response.body, 'name="operator_role_assignment[role_id]"'
+
+    get "/admin/roles/#{role.id}/edit"
+    assert_response :success
+    assert_includes response.body, "Edit role"
+    assert_includes response.body, 'name="role[name]"'
+
+    patch "/admin/roles/#{role.id}",
+      params: { role: { name: "Updated HTML Role", description: "Edited through admin UI", active: "1" } }
+    assert_redirected_to "/admin/roles/#{role.id}"
+    assert_equal "Updated HTML Role", role.reload.name
+
+    post "/admin/operators/#{operator.id}/operator_role_assignments",
+      params: {
+        operator_role_assignment: {
+          role_id: role.id,
+          scope_type: "operating_unit",
+          scope_id: @branch.id,
+          active: "1"
+        }
+      }
+    assert_redirected_to "/admin/operators/#{operator.id}"
+    assert operator.has_capability?(Workspace::Authorization::CapabilityRegistry::AUDIT_EXPORT, scope: @branch)
+    assignment = operator.operator_role_assignments.order(:id).last
+
+    get "/admin/operators/#{operator.id}"
+    assert_response :success
+    assert_includes response.body, Workspace::Authorization::CapabilityRegistry::AUDIT_EXPORT
+
+    get "/admin/operators/#{operator.id}/operator_role_assignments/#{assignment.id}/edit"
+    assert_response :success
+    assert_includes response.body, "Edit role assignment"
+    assert_includes response.body, 'name="operator_role_assignment[role_id]"'
+
+    patch "/admin/roles/#{role.id}/capabilities", params: { capability_ids: [] }
+    assert_redirected_to "/admin/roles/#{role.id}"
+    assert_not operator.has_capability?(Workspace::Authorization::CapabilityRegistry::AUDIT_EXPORT, scope: @branch)
+  end
+
+  test "admin can manage capabilities and non admin remains forbidden" do
+    internal_login!(username: "admin-rbac")
+
+    get "/admin/capabilities/new"
+    assert_response :success
+    assert_includes response.body, "New capability"
+    assert_includes response.body, 'name="capability[name]"'
+
+    assert_difference -> { Workspace::Models::Capability.count }, 1 do
+      post "/admin/capabilities",
+        params: {
+          capability: {
+            code: "custom.html.#{SecureRandom.hex(4)}",
+            name: "Custom HTML Capability",
+            category: "admin",
+            active: "1"
+          }
+        }
+    end
+    capability = Workspace::Models::Capability.order(:id).last
+    assert_redirected_to "/admin/capabilities/#{capability.id}"
+
+    get "/admin/capabilities/#{capability.id}/edit"
+    assert_response :success
+    assert_includes response.body, "Edit capability"
+    assert_includes response.body, 'name="capability[name]"'
+
+    patch "/admin/capabilities/#{capability.id}",
+      params: { capability: { name: "Updated Capability", category: "admin", active: "1" } }
+    assert_redirected_to "/admin/capabilities/#{capability.id}"
+    assert_equal "Updated Capability", capability.reload.name
+
+    post "/admin/capabilities/#{capability.id}/deactivate"
+    assert_redirected_to "/admin/capabilities"
+    assert_not capability.reload.active?
+
+    delete "/logout"
+    create_operator_with_credential!(role: "operations", username: "rbac-non-admin")
+    internal_login!(username: "rbac-non-admin")
+    get "/admin/operators"
+    assert_response :forbidden
+  end
+end


### PR DESCRIPTION
## Summary
- Add Admin HTML maintenance for operators, credentials, roles, capabilities, and scoped role assignments.
- Add Admin HTML maintenance for operating units and cash locations, with Organization/Cash domain commands and conservative lifecycle guardrails.
- Document the admin RBAC and organization/cash maintenance boundaries in ADR-0033 and ADR-0034.

## Test plan
- docker compose run --rm web bin/rails test test/domains/workspace/admin_rbac_commands_test.rb test/integration/admin_rbac_ui_test.rb
- docker compose run --rm web bin/rails test test/domains/organization/admin_operating_unit_commands_test.rb test/domains/cash/admin_cash_location_commands_test.rb test/integration/admin_operating_units_ui_test.rb test/integration/admin_cash_locations_ui_test.rb
- docker compose run --rm web bin/rails test

Made with [Cursor](https://cursor.com)