### PR TITLE
Add external cash shipment receipts

### DIFF
--- a/app/controllers/branch/cash_controller.rb
+++ b/app/controllers/branch/cash_controller.rb
@@ -6,6 +6,8 @@ module Branch
       only: [ :index, :show_location ]
     before_action -> { require_branch_capability!(Workspace::Authorization::CapabilityRegistry::CASH_MOVEMENT_CREATE) },
       only: [ :new_transfer, :create_transfer ]
+    before_action -> { require_branch_capability!(Workspace::Authorization::CapabilityRegistry::CASH_SHIPMENT_RECEIVE) },
+      only: [ :new_external_shipment, :create_external_shipment ]
     before_action -> { require_branch_capability!(Workspace::Authorization::CapabilityRegistry::CASH_COUNT_RECORD) },
       only: [ :new_count, :create_count ]
 
@@ -31,6 +33,26 @@ module Branch
       @locations = active_locations
       @error_message = e.message
       render :new_transfer, status: :unprocessable_entity
+    end
+
+    def new_external_shipment
+      @vault_locations = active_vault_locations
+      @cash_shipment = {}
+    end
+
+    def create_external_shipment
+      @cash_shipment = external_shipment_params
+      movement = Cash::Commands::ReceiveExternalCashShipment.call(
+        **@cash_shipment,
+        actor_id: current_operator.id,
+        channel: branch_channel,
+        idempotency_key: @cash_shipment[:idempotency_key].presence || default_idempotency_key("cash-shipment")
+      )
+      redirect_to branch_cash_path, notice: "Received external cash shipment ##{movement.id}."
+    rescue Cash::Commands::ReceiveExternalCashShipment::Error => e
+      @vault_locations = active_vault_locations
+      @error_message = e.message
+      render :new_external_shipment, status: :unprocessable_entity
     end
 
     def new_count
@@ -65,6 +87,10 @@ module Branch
       Cash::Models::CashLocation.active.where(operating_unit: current_operating_unit).order(:location_type, :drawer_code, :id)
     end
 
+    def active_vault_locations
+      active_locations.where(location_type: Cash::Models::CashLocation::TYPE_BRANCH_VAULT)
+    end
+
     def transfer_params
       params.require(:cash_transfer).permit(
         :source_cash_location_id, :destination_cash_location_id, :amount_minor_units, :idempotency_key, :reason_code
@@ -74,6 +100,12 @@ module Branch
     def count_params
       params.require(:cash_count).permit(
         :cash_location_id, :counted_amount_minor_units, :expected_amount_minor_units, :idempotency_key
+      ).to_h.symbolize_keys
+    end
+
+    def external_shipment_params
+      params.require(:cash_shipment).permit(
+        :destination_cash_location_id, :amount_minor_units, :external_source, :shipment_reference, :idempotency_key
       ).to_h.symbolize_keys
     end
   end

--- a/app/domains/cash/commands/approve_cash_movement.rb
+++ b/app/domains/cash/commands/approve_cash_movement.rb
@@ -38,6 +38,8 @@ module Cash
         end
       rescue Workspace::Authorization::Forbidden => e
         raise InvalidState, e.message
+      rescue Cash::Commands::TransferCash::InvalidRequest => e
+        raise InvalidState, e.message
       end
     end
   end

--- a/app/domains/cash/commands/receive_external_cash_shipment.rb
+++ b/app/domains/cash/commands/receive_external_cash_shipment.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "digest"
+
+module Cash
+  module Commands
+    class ReceiveExternalCashShipment
+      class Error < StandardError; end
+      class InvalidRequest < Error; end
+      class MismatchedIdempotency < Error; end
+
+      def self.call(destination_cash_location_id:, amount_minor_units:, actor_id:, idempotency_key:,
+        external_source:, shipment_reference:, currency: "USD", business_date: nil, channel: "branch")
+        on_date = business_date || Core::BusinessDate::Services::CurrentBusinessDate.call
+        Core::BusinessDate::Services::AssertOpenPostingDate.call!(date: on_date)
+
+        destination = Cash::Models::CashLocation.lock.find_by(id: destination_cash_location_id)
+        raise InvalidRequest, "destination_cash_location_id not found" if destination.nil?
+
+        external_source = normalize_required_string(external_source, "external_source")
+        shipment_reference = normalize_required_string(shipment_reference, "shipment_reference")
+        validate_destination!(destination, currency)
+        authorize_actor!(actor_id, destination)
+
+        fp = fingerprint(
+          destination.id,
+          amount_minor_units,
+          actor_id,
+          currency,
+          on_date,
+          external_source,
+          shipment_reference
+        )
+
+        Cash::Models::CashMovement.transaction do
+          existing = Cash::Models::CashMovement.lock.find_by(idempotency_key: idempotency_key)
+          return existing if existing && existing.request_fingerprint == fp
+          raise MismatchedIdempotency, "idempotency replay does not match original external cash shipment receipt" if existing
+
+          movement = Cash::Models::CashMovement.create!(
+            source_cash_location: nil,
+            destination_cash_location: destination,
+            operating_unit: destination.operating_unit,
+            actor_id: actor_id,
+            amount_minor_units: amount_minor_units,
+            currency: currency,
+            business_date: on_date,
+            status: Cash::Models::CashMovement::STATUS_COMPLETED,
+            movement_type: Cash::Models::CashMovement::TYPE_EXTERNAL_SHIPMENT_RECEIVED,
+            external_source: external_source,
+            shipment_reference: shipment_reference,
+            idempotency_key: idempotency_key,
+            request_fingerprint: fp,
+            completed_at: Time.current
+          )
+
+          Cash::Services::BalanceProjector.apply_completed_movement!(movement)
+          event = record_and_post_event!(movement, channel)
+          movement.update!(operational_event: event)
+          movement
+        end
+      rescue Core::BusinessDate::Errors::InvalidPostingBusinessDate,
+        Core::BusinessDate::Errors::NotSet,
+        Workspace::Authorization::Forbidden,
+        Core::OperationalEvents::Commands::RecordEvent::Error,
+        Core::Posting::Commands::PostEvent::Error,
+        ActiveRecord::RecordNotFound => e
+        raise InvalidRequest, e.message
+      rescue ActiveRecord::RecordInvalid => e
+        raise InvalidRequest, e.record.errors.full_messages.to_sentence
+      end
+
+      def self.validate_destination!(destination, currency)
+        raise InvalidRequest, "destination cash location must be active" unless destination.active?
+        raise InvalidRequest, "destination cash location must be a branch vault" unless destination.vault?
+        raise InvalidRequest, "currency must be USD" unless currency.to_s == "USD"
+      end
+      private_class_method :validate_destination!
+
+      def self.authorize_actor!(actor_id, destination)
+        Workspace::Authorization::Authorizer.require_capability!(
+          actor_id: actor_id,
+          capability_code: Workspace::Authorization::CapabilityRegistry::CASH_SHIPMENT_RECEIVE,
+          scope: destination.operating_unit
+        )
+      end
+      private_class_method :authorize_actor!
+
+      def self.normalize_required_string(value, field_name)
+        normalized = value.to_s.strip
+        raise InvalidRequest, "#{field_name} is required" if normalized.blank?
+
+        normalized
+      end
+      private_class_method :normalize_required_string
+
+      def self.record_and_post_event!(movement, channel)
+        result = Core::OperationalEvents::Commands::RecordEvent.call(
+          event_type: "cash.shipment.received",
+          channel: channel,
+          idempotency_key: "cash-shipment-received:#{movement.id}",
+          amount_minor_units: movement.amount_minor_units,
+          currency: movement.currency,
+          actor_id: movement.actor_id,
+          operating_unit_id: movement.operating_unit_id,
+          reference_id: movement.id.to_s
+        )
+        Core::Posting::Commands::PostEvent.call(operational_event_id: result.fetch(:event).id)
+        result.fetch(:event).reload
+      end
+      private_class_method :record_and_post_event!
+
+      def self.fingerprint(destination_id, amount_minor_units, actor_id, currency, business_date, external_source, shipment_reference)
+        Digest::SHA256.hexdigest({
+          destination_cash_location_id: destination_id.to_i,
+          amount_minor_units: amount_minor_units.to_i,
+          actor_id: actor_id.to_i,
+          currency: currency.to_s,
+          business_date: business_date.to_s,
+          external_source: external_source.to_s,
+          shipment_reference: shipment_reference.to_s
+        }.to_json)
+      end
+      private_class_method :fingerprint
+    end
+  end
+end

--- a/app/domains/cash/models/cash_movement.rb
+++ b/app/domains/cash/models/cash_movement.rb
@@ -22,7 +22,14 @@ module Cash
       TYPE_DRAWER_TO_VAULT = "drawer_to_vault"
       TYPE_INTERNAL_TRANSFER = "internal_transfer"
       TYPE_ADJUSTMENT = "adjustment"
-      MOVEMENT_TYPES = [ TYPE_VAULT_TO_DRAWER, TYPE_DRAWER_TO_VAULT, TYPE_INTERNAL_TRANSFER, TYPE_ADJUSTMENT ].freeze
+      TYPE_EXTERNAL_SHIPMENT_RECEIVED = "external_shipment_received"
+      MOVEMENT_TYPES = [
+        TYPE_VAULT_TO_DRAWER,
+        TYPE_DRAWER_TO_VAULT,
+        TYPE_INTERNAL_TRANSFER,
+        TYPE_ADJUSTMENT,
+        TYPE_EXTERNAL_SHIPMENT_RECEIVED
+      ].freeze
 
       belongs_to :source_cash_location, class_name: "Cash::Models::CashLocation", optional: true
       belongs_to :destination_cash_location, class_name: "Cash::Models::CashLocation", optional: true
@@ -36,6 +43,7 @@ module Cash
       validates :status, inclusion: { in: STATUSES }
       validates :movement_type, inclusion: { in: MOVEMENT_TYPES }
       validates :business_date, :idempotency_key, :request_fingerprint, presence: true
+      validates :external_source, :shipment_reference, presence: true, if: :external_shipment_received?
 
       def completed?
         status == STATUS_COMPLETED
@@ -43,6 +51,10 @@ module Cash
 
       def pending_approval?
         status == STATUS_PENDING_APPROVAL
+      end
+
+      def external_shipment_received?
+        movement_type == TYPE_EXTERNAL_SHIPMENT_RECEIVED
       end
     end
   end

--- a/app/domains/core/operational_events/commands/record_event.rb
+++ b/app/domains/core/operational_events/commands/record_event.rb
@@ -25,11 +25,12 @@ module Core
 
         DRAWER_VARIANCE_POSTED = "teller.drawer.variance.posted"
         CASH_VARIANCE_POSTED = "cash.variance.posted"
+        CASH_SHIPMENT_RECEIVED = "cash.shipment.received"
         INTEREST_EVENT_TYPES = %w[interest.accrued interest.posted].freeze
 
         FINANCIAL_EVENT_TYPES = (
           %w[deposit.accepted withdrawal.posted transfer.completed fee.assessed fee.waived ach.credit.received] +
-            INTEREST_EVENT_TYPES + [ DRAWER_VARIANCE_POSTED, CASH_VARIANCE_POSTED ]
+            INTEREST_EVENT_TYPES + [ DRAWER_VARIANCE_POSTED, CASH_VARIANCE_POSTED, CASH_SHIPMENT_RECEIVED ]
         ).freeze
         CHANNELS = %w[teller branch api batch system].freeze
         STAFF_CHANNELS = %w[teller branch].freeze
@@ -70,6 +71,7 @@ module Core
           validate_teller_cash_session!(channel, event_type, teller_session_id)
           validate_drawer_variance!(event_type, channel, amount_minor_units, teller_session_id)
           validate_cash_variance!(event_type, channel, amount_minor_units, currency, reference_id)
+          validate_cash_shipment_received!(event_type, channel, amount_minor_units, currency, reference_id)
 
           on_date = business_date || Core::BusinessDate::Services::CurrentBusinessDate.call
           begin
@@ -148,7 +150,7 @@ module Core
 
         def self.fingerprint_for(event_type:, channel:, idempotency_key:, amount_minor_units:, currency:, source_account_id:,
                                 destination_account_id: nil, teller_session_id: nil, operating_unit_id: nil, reference_id: nil)
-          if [ DRAWER_VARIANCE_POSTED, CASH_VARIANCE_POSTED ].include?(event_type.to_s)
+          if [ DRAWER_VARIANCE_POSTED, CASH_VARIANCE_POSTED, CASH_SHIPMENT_RECEIVED ].include?(event_type.to_s)
             payload = {
               event_type: event_type.to_s,
               channel: channel.to_s,
@@ -219,6 +221,8 @@ module Core
           end
           raise InvalidRequest, "currency is required" if currency.blank?
           raise InvalidRequest, "currency must be USD" unless currency.to_s == "USD"
+          return if event_type.to_s == CASH_SHIPMENT_RECEIVED
+
           raise InvalidRequest, "source_account_id is required" if source_account_id.blank?
           if event_type.to_s == "transfer.completed" && destination_account_id.blank?
             raise InvalidRequest, "destination_account_id is required for transfer.completed"
@@ -226,7 +230,7 @@ module Core
         end
 
         def self.validate_source_account!(event_type, source_account_id)
-          return if [ DRAWER_VARIANCE_POSTED, CASH_VARIANCE_POSTED ].include?(event_type.to_s) && source_account_id.blank?
+          return if [ DRAWER_VARIANCE_POSTED, CASH_VARIANCE_POSTED, CASH_SHIPMENT_RECEIVED ].include?(event_type.to_s) && source_account_id.blank?
 
           acc = Accounts::Models::DepositAccount.find_by(id: source_account_id)
           raise InvalidRequest, "source_account_id not found" if acc.nil?
@@ -287,6 +291,28 @@ module Core
           end
         end
         private_class_method :validate_cash_variance!
+
+        def self.validate_cash_shipment_received!(event_type, channel, amount_minor_units, currency, reference_id)
+          return unless event_type.to_s == CASH_SHIPMENT_RECEIVED
+
+          raise InvalidRequest, "cash.shipment.received may only use channel branch" unless channel.to_s == "branch"
+          raise InvalidRequest, "amount_minor_units must be positive for cash.shipment.received" unless amount_minor_units.to_i.positive?
+          raise InvalidRequest, "currency must be USD" unless currency.to_s == "USD"
+          raise InvalidRequest, "reference_id is required for cash.shipment.received" if reference_id.blank?
+          unless reference_id.to_s.match?(/\A\d+\z/)
+            raise InvalidRequest, "reference_id must be the numeric id of a cash_movement"
+          end
+
+          movement = Cash::Models::CashMovement.find_by(id: reference_id.to_i)
+          raise InvalidRequest, "referenced cash movement not found" if movement.nil?
+          unless movement.movement_type == Cash::Models::CashMovement::TYPE_EXTERNAL_SHIPMENT_RECEIVED
+            raise InvalidRequest, "reference_id must identify an external shipment receipt movement"
+          end
+          unless movement.amount_minor_units.to_i == amount_minor_units.to_i && movement.currency.to_s == currency.to_s
+            raise InvalidRequest, "cash.shipment.received must match cash movement amount and currency"
+          end
+        end
+        private_class_method :validate_cash_shipment_received!
 
         def self.validate_withdrawal_available!(event_type, source_account_id, amount_minor_units)
           return unless event_type.to_s == "withdrawal.posted"

--- a/app/domains/core/operational_events/event_catalog.rb
+++ b/app/domains/core/operational_events/event_catalog.rb
@@ -199,6 +199,22 @@ module Core
           support_search_keys: %w[reference_id actor_id]
         ),
         Entry.new(
+          event_type: "cash.shipment.received",
+          category: "financial",
+          posts_to_gl: true,
+          record_command: "Cash::Commands::ReceiveExternalCashShipment",
+          reversible_via_posting_reversal: true,
+          compensating_event_type: "posting.reversal",
+          description: "External Fed or correspondent cash shipment received into branch vault custody",
+          lifecycle: "pending_to_posted",
+          allowed_channels: %w[branch],
+          financial_impact: "gl_posting",
+          customer_visible: false,
+          statement_visible: false,
+          payload_schema: "docs/operational_events/cash-shipment-received.md",
+          support_search_keys: %w[reference_id actor_id idempotency_key]
+        ),
+        Entry.new(
           event_type: "cash.movement.completed",
           category: "operational",
           posts_to_gl: false,

--- a/app/domains/core/posting/posting_rules/cash_shipment_received.rb
+++ b/app/domains/core/posting/posting_rules/cash_shipment_received.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Core
+  module Posting
+    module PostingRules
+      # External cash received into vault custody: physical cash increases and due-from settlement decreases.
+      module CashShipmentReceived
+        CASH_IN_VAULTS_GL = "1110"
+        DUE_FROM_CORRESPONDENT_GL = "1130"
+
+        module_function
+
+        def legs_for(event)
+          amount = event.amount_minor_units
+          if amount.nil? || amount <= 0
+            raise Core::Posting::Commands::PostEvent::InvalidState, "amount_minor_units required"
+          end
+
+          [
+            PostingLeg.new(
+              sequence_no: 1,
+              gl_account_number: CASH_IN_VAULTS_GL,
+              side: "debit",
+              amount_minor_units: amount,
+              deposit_account_id: nil
+            ),
+            PostingLeg.new(
+              sequence_no: 2,
+              gl_account_number: DUE_FROM_CORRESPONDENT_GL,
+              side: "credit",
+              amount_minor_units: amount,
+              deposit_account_id: nil
+            )
+          ]
+        end
+      end
+    end
+  end
+end

--- a/app/domains/core/posting/posting_rules/registry.rb
+++ b/app/domains/core/posting/posting_rules/registry.rb
@@ -15,7 +15,8 @@ module Core
           "interest.accrued" => InterestAccrued,
           "interest.posted" => InterestPosted,
           "teller.drawer.variance.posted" => TellerDrawerVariancePosted,
-          "cash.variance.posted" => CashVariancePosted
+          "cash.variance.posted" => CashVariancePosted,
+          "cash.shipment.received" => CashShipmentReceived
         }.freeze
 
         def self.legs_for(event)

--- a/app/domains/workspace/authorization/capability_registry.rb
+++ b/app/domains/workspace/authorization/capability_registry.rb
@@ -15,6 +15,7 @@ module Workspace
       CASH_COUNT_RECORD = "cash.count.record"
       CASH_VARIANCE_APPROVE = "cash.variance.approve"
       CASH_POSITION_VIEW = "cash.position.view"
+      CASH_SHIPMENT_RECEIVE = "cash.shipment.receive"
       PARTY_CREATE = "party.create"
       ACCOUNT_OPEN = "account.open"
       ACCOUNT_MAINTAIN = "account.maintain"
@@ -68,6 +69,8 @@ module Workspace
           description: "May approve Cash-domain variances and related GL posting." },
         { code: CASH_POSITION_VIEW, name: "View cash position", category: "cash",
           description: "May view Cash-domain positions and reconciliation summaries." },
+        { code: CASH_SHIPMENT_RECEIVE, name: "Receive external cash shipment", category: "cash",
+          description: "May record external Fed or correspondent cash shipments into branch vault custody." },
         { code: PARTY_CREATE, name: "Create party", category: "party",
           description: "May create party records." },
         { code: ACCOUNT_OPEN, name: "Open account", category: "account",
@@ -127,7 +130,7 @@ module Workspace
         BRANCH_SUPERVISOR => [
           DEPOSIT_ACCEPT, WITHDRAWAL_POST, TRANSFER_COMPLETE, TELLER_SESSION_OPEN, TELLER_SESSION_CLOSE,
           CASH_DRAWER_MANAGE, CASH_LOCATION_MANAGE, CASH_MOVEMENT_CREATE, CASH_MOVEMENT_APPROVE,
-          CASH_COUNT_RECORD, CASH_VARIANCE_APPROVE, CASH_POSITION_VIEW,
+          CASH_COUNT_RECORD, CASH_VARIANCE_APPROVE, CASH_POSITION_VIEW, CASH_SHIPMENT_RECEIVE,
           PARTY_CREATE, ACCOUNT_OPEN, ACCOUNT_MAINTAIN, HOLD_PLACE, FEE_WAIVE, HOLD_RELEASE,
           BUSINESS_DATE_CLOSE, TELLER_SESSION_VARIANCE_APPROVE, REVERSAL_CREATE, OPERATIONAL_EVENT_VIEW, REPORT_VIEW
         ],
@@ -141,7 +144,7 @@ module Workspace
         OPERATIONS => [
           OPS_BATCH_PROCESS, OPS_EXCEPTION_RESOLVE, OPS_RECONCILIATION_PERFORM, OPERATIONAL_EVENT_VIEW,
           JOURNAL_ENTRY_VIEW, AUDIT_EXPORT, REPORT_VIEW, BUSINESS_DATE_CLOSE, TELLER_SESSION_VARIANCE_APPROVE,
-          CASH_MOVEMENT_APPROVE, CASH_VARIANCE_APPROVE, CASH_POSITION_VIEW
+          CASH_MOVEMENT_APPROVE, CASH_VARIANCE_APPROVE, CASH_POSITION_VIEW, CASH_SHIPMENT_RECEIVE
         ],
         AUDITOR => [
           OPERATIONAL_EVENT_VIEW, JOURNAL_ENTRY_VIEW, AUDIT_EXPORT, REPORT_VIEW

--- a/app/views/branch/cash/index.html.erb
+++ b/app/views/branch/cash/index.html.erb
@@ -7,6 +7,7 @@
   </div>
   <nav class="flex gap-2 text-sm">
     <%= link_to "Transfer cash", branch_new_cash_transfer_path, class: "rounded bg-slate-900 px-3 py-2 font-medium text-white" %>
+    <%= link_to "Receive shipment", branch_new_external_cash_shipment_path, class: "rounded border border-slate-300 px-3 py-2 font-medium text-slate-700" %>
     <%= link_to "Record count", branch_new_cash_count_path, class: "rounded border border-slate-300 px-3 py-2 font-medium text-slate-700" %>
   </nav>
 </section>

--- a/app/views/branch/cash/new_external_shipment.html.erb
+++ b/app/views/branch/cash/new_external_shipment.html.erb
@@ -1,0 +1,32 @@
+<% content_for :title, "Receive Cash Shipment - BankCORE" %>
+
+<h1 class="text-3xl font-semibold">Receive external cash shipment</h1>
+<p class="mt-2 max-w-2xl text-sm text-slate-600">
+  Record cash that has already arrived from the Federal Reserve or a correspondent bank into branch vault custody.
+</p>
+<%= render "branch/shared/form_error", error_message: @error_message if @error_message.present? %>
+
+<%= form_with url: branch_external_cash_shipments_path, scope: :cash_shipment, class: "mt-6 max-w-xl space-y-4 rounded border border-slate-200 bg-white p-5 shadow-sm" do |form| %>
+  <div>
+    <%= form.label :destination_cash_location_id, "Destination vault", class: "block text-sm font-medium text-slate-700" %>
+    <%= form.collection_select :destination_cash_location_id, @vault_locations, :id, :name, {}, class: "mt-1 w-full rounded border-slate-300" %>
+  </div>
+  <div>
+    <%= form.label :amount_minor_units, "Amount in cents", class: "block text-sm font-medium text-slate-700" %>
+    <%= form.number_field :amount_minor_units, min: 1, class: "mt-1 w-full rounded border-slate-300" %>
+  </div>
+  <div>
+    <%= form.label :external_source, "External source", class: "block text-sm font-medium text-slate-700" %>
+    <%= form.text_field :external_source, placeholder: "Federal Reserve or correspondent bank", class: "mt-1 w-full rounded border-slate-300" %>
+  </div>
+  <div>
+    <%= form.label :shipment_reference, "Shipment reference", class: "block text-sm font-medium text-slate-700" %>
+    <%= form.text_field :shipment_reference, class: "mt-1 w-full rounded border-slate-300" %>
+  </div>
+  <div>
+    <%= form.label :idempotency_key, "Idempotency key", class: "block text-sm font-medium text-slate-700" %>
+    <%= form.text_field :idempotency_key, class: "mt-1 w-full rounded border-slate-300" %>
+    <p class="mt-1 text-xs text-slate-500">Optional. Leave blank to generate a one-time receipt key.</p>
+  </div>
+  <%= form.submit "Receive shipment", class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,8 @@ Rails.application.routes.draw do
     get "cash", to: "cash#index", as: :cash
     get "cash/transfers/new", to: "cash#new_transfer", as: :new_cash_transfer
     post "cash/transfers", to: "cash#create_transfer", as: :cash_transfers
+    get "cash/shipments/received/new", to: "cash#new_external_shipment", as: :new_external_cash_shipment
+    post "cash/shipments/received", to: "cash#create_external_shipment", as: :external_cash_shipments
     get "cash/counts/new", to: "cash#new_count", as: :new_cash_count
     post "cash/counts", to: "cash#create_count", as: :cash_counts
     get "cash/locations/:id", to: "cash#show_location", as: :cash_location

--- a/db/migrate/20260429210200_add_external_shipment_receipts_to_cash_movements.rb
+++ b/db/migrate/20260429210200_add_external_shipment_receipts_to_cash_movements.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class AddExternalShipmentReceiptsToCashMovements < ActiveRecord::Migration[8.1]
+  OLD_MOVEMENT_TYPES = %w[vault_to_drawer drawer_to_vault internal_transfer adjustment].freeze
+  NEW_MOVEMENT_TYPES = (OLD_MOVEMENT_TYPES + %w[external_shipment_received]).freeze
+
+  def up
+    add_column :cash_movements, :external_source, :string
+    add_column :cash_movements, :shipment_reference, :string
+    add_index :cash_movements, [ :external_source, :shipment_reference ],
+      name: "idx_cash_movements_external_shipment_reference"
+
+    remove_check_constraint :cash_movements, name: "cash_movements_type_check"
+    add_check_constraint :cash_movements, in_list_sql("movement_type", NEW_MOVEMENT_TYPES),
+      name: "cash_movements_type_check"
+    add_check_constraint :cash_movements,
+      <<~SQL.squish,
+        movement_type <> 'external_shipment_received'
+        OR (
+          source_cash_location_id IS NULL
+          AND destination_cash_location_id IS NOT NULL
+          AND external_source IS NOT NULL
+          AND length(trim(external_source)) > 0
+          AND shipment_reference IS NOT NULL
+          AND length(trim(shipment_reference)) > 0
+        )
+      SQL
+      name: "cash_movements_external_shipment_required_fields_check"
+  end
+
+  def down
+    remove_check_constraint :cash_movements, name: "cash_movements_external_shipment_required_fields_check"
+    remove_check_constraint :cash_movements, name: "cash_movements_type_check"
+    add_check_constraint :cash_movements, in_list_sql("movement_type", OLD_MOVEMENT_TYPES),
+      name: "cash_movements_type_check"
+    remove_index :cash_movements, name: "idx_cash_movements_external_shipment_reference"
+    remove_column :cash_movements, :shipment_reference
+    remove_column :cash_movements, :external_source
+  end
+
+  private
+
+  def in_list_sql(column_name, values)
+    quoted = values.map { |value| connection.quote(value) }.join(", ")
+    "#{column_name} IN (#{quoted})"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -299,11 +299,14 @@ CREATE TABLE public.cash_movements (
     rejected_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
+    external_source character varying,
+    shipment_reference character varying,
     CONSTRAINT cash_movements_currency_usd_check CHECK (((currency)::text = 'USD'::text)),
+    CONSTRAINT cash_movements_external_shipment_required_fields_check CHECK ((((movement_type)::text <> 'external_shipment_received'::text) OR ((source_cash_location_id IS NULL) AND (destination_cash_location_id IS NOT NULL) AND (external_source IS NOT NULL) AND (length(TRIM(BOTH FROM external_source)) > 0) AND (shipment_reference IS NOT NULL) AND (length(TRIM(BOTH FROM shipment_reference)) > 0)))),
     CONSTRAINT cash_movements_location_present_check CHECK (((source_cash_location_id IS NOT NULL) OR (destination_cash_location_id IS NOT NULL))),
     CONSTRAINT cash_movements_positive_amount_check CHECK ((amount_minor_units > 0)),
     CONSTRAINT cash_movements_status_check CHECK (((status)::text = ANY (ARRAY[('pending_approval'::character varying)::text, ('approved'::character varying)::text, ('completed'::character varying)::text, ('cancelled'::character varying)::text, ('rejected'::character varying)::text]))),
-    CONSTRAINT cash_movements_type_check CHECK (((movement_type)::text = ANY (ARRAY[('vault_to_drawer'::character varying)::text, ('drawer_to_vault'::character varying)::text, ('internal_transfer'::character varying)::text, ('adjustment'::character varying)::text])))
+    CONSTRAINT cash_movements_type_check CHECK (((movement_type)::text = ANY (ARRAY[('vault_to_drawer'::character varying)::text, ('drawer_to_vault'::character varying)::text, ('internal_transfer'::character varying)::text, ('adjustment'::character varying)::text, ('external_shipment_received'::character varying)::text])))
 );
 
 
@@ -1840,6 +1843,13 @@ CREATE UNIQUE INDEX idx_active_cash_drawer_identity ON public.cash_locations USI
 
 
 --
+-- Name: idx_cash_movements_external_shipment_reference; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_cash_movements_external_shipment_reference ON public.cash_movements USING btree (external_source, shipment_reference);
+
+
+--
 -- Name: idx_dap_maintenance_audits_idempotency; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3074,6 +3084,7 @@ ALTER TABLE ONLY public.operational_events
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260429210200'),
 ('20260429190000'),
 ('20260424120017'),
 ('20260424120016'),

--- a/docs/adr/0035-external-cash-shipments.md
+++ b/docs/adr/0035-external-cash-shipments.md
@@ -1,0 +1,53 @@
+# ADR-0035: External Cash Shipment Receipts
+
+## Status
+
+Accepted
+
+## Context
+
+ADR-0031 established the Cash domain as the owner of physical cash custody and deferred Fed/correspondent shipment accounting until a COA mapping was explicit. Internal vault, drawer, and transit movements stay within aggregate GL `1110` and do not post journal entries. Receiving physical cash from an external counterparty is different: institutional cash under custody increases and the external settlement or due-from asset decreases.
+
+The seeded chart of accounts already defines:
+
+- `1110` Cash in Vaults (physical cash under branch custody)
+- `1120` ACH Settlement (reserved for ACH receipt flows)
+- `1130` Due from Correspondent Banks (nostro/correspondent balances)
+
+`1120` must remain ACH-specific. For this slice, external cash shipments from the Federal Reserve or correspondent banks settle against `1130`.
+
+## Decision
+
+BankCORE will implement `Cash::Commands::ReceiveExternalCashShipment` as a single-step receipt command for cash that has already arrived at an active branch vault.
+
+The command will:
+
+- Create a completed `cash_movements` row with movement type `external_shipment_received`.
+- Require a destination branch vault, positive USD amount, actor, operating unit, source name, shipment reference, business date, and idempotency key.
+- Increase the destination vault cash balance through the Cash balance projector.
+- Record and immediately post `cash.shipment.received` through `Core::OperationalEvents` and `Core::Posting`.
+
+Posting pattern:
+
+```text
+Dr 1110 Cash in Vaults
+Cr 1130 Due from Correspondent Banks
+```
+
+`reference_id` on the operational event is the numeric `cash_movements.id`. The movement stores the external source and shipment reference for support evidence.
+
+## Controls
+
+- `cash.shipment.receive` gates branch receipt entry.
+- Receipts are append-oriented; edits are not allowed after posting.
+- The idempotency key is unique on `cash_movements`. A replay with the same material fields returns the original movement and must not re-project cash or re-post GL.
+- A replay with different material fields is rejected.
+- The command must run only for the current open business date.
+
+## Reversals
+
+`cash.shipment.received` is reversible through the existing `posting.reversal` mechanism for GL correction. Reversing GL does not automatically unwind Cash-domain custody. Operational custody corrections should be made with a later Cash-domain count and approved variance, or a future explicit external shipment correction workflow.
+
+## Deferred
+
+This ADR does not add outbound shipment dispatch, shipment requests, carrier manifests, in-transit states, partial receipts, over/short shipment exceptions, or settlement matching. Those workflows can introduce a dedicated `cash_shipments` table when lifecycle state becomes first-class.

--- a/docs/operational_events/README.md
+++ b/docs/operational_events/README.md
@@ -68,6 +68,7 @@ Catalog metadata fields:
 | [interest-posted.md](interest-posted.md) | `interest.posted` | Yes | `RecordEvent` | `pending_to_posted` | `system` | Yes | Yes |
 | [teller-drawer-variance-posted.md](teller-drawer-variance-posted.md) | `teller.drawer.variance.posted` | Yes (optional flag) | `RecordEvent` | `pending_to_posted` | `system` | No | No |
 | [cash-variance-posted.md](cash-variance-posted.md) | `cash.variance.posted` | Yes (optional GL) | `RecordEvent` | `pending_to_posted` | `system` | No | No |
+| [cash-shipment-received.md](cash-shipment-received.md) | `cash.shipment.received` | Yes | `Cash::Commands::ReceiveExternalCashShipment` | `pending_to_posted` | `branch` | No | No |
 | [cash-movement-completed.md](cash-movement-completed.md) | `cash.movement.completed` | No | `Cash::Commands::TransferCash` | `posted_immediately` | `teller`, `branch`, `system` | No | No |
 | [cash-count-recorded.md](cash-count-recorded.md) | `cash.count.recorded` | No | `Cash::Commands::RecordCashCount` | `posted_immediately` | `teller`, `branch`, `system` | No | No |
 

--- a/docs/operational_events/cash-shipment-received.md
+++ b/docs/operational_events/cash-shipment-received.md
@@ -1,0 +1,63 @@
+# cash.shipment.received
+
+## Summary
+
+Records that an external cash shipment from the Federal Reserve or a correspondent bank has been received into an active branch vault.
+
+## Registry
+
+| Field | Value |
+| ----- | ----- |
+| **event_type** | `cash.shipment.received` |
+| **Category** | `financial` |
+| **Lifecycle** | `pending_to_posted` |
+| **Allowed channels** | `branch` |
+| **Financial impact** | `gl_posting` |
+| **Customer visible** | No |
+| **Statement visible** | No |
+| **Payload schema** | `docs/operational_events/cash-shipment-received.md` |
+| **Support search keys** | `reference_id`, `actor_id`, `idempotency_key` |
+
+## Semantics
+
+`reference_id` is the numeric id of a completed `cash_movements` row with movement type `external_shipment_received`. The movement stores the destination vault, external source, shipment reference, actor, business date, and operating unit.
+
+## Persistence
+
+The event stores `amount_minor_units`, `currency`, `actor_id`, `operating_unit_id`, and `reference_id`.
+
+## Lifecycle
+
+The receipt command creates the movement, projects the vault balance, records a pending event through `RecordEvent`, posts it through `Core::Posting::Commands::PostEvent`, and links the movement to the posted event in one transaction.
+
+## Posting
+
+Dr `1110` Cash in Vaults; Cr `1130` Due from Correspondent Banks.
+
+## Idempotency
+
+The command-level key is supplied by the caller. Replay must match destination vault, amount, currency, business date, source, shipment reference, and actor. Matching replay returns the original movement and does not create another event, projection, or journal entry.
+
+## Reversals
+
+Reversible through `posting.reversal` for GL correction. The reversal does not automatically change Cash-domain custody balances; physical custody corrections remain Cash-domain activity.
+
+## Module ownership
+
+`Cash` owns the receipt command, movement row, and custody balance projection. `Core::OperationalEvents` owns event validation, and `Core::Posting` owns journal generation.
+
+## References
+
+[ADR-0035](../adr/0035-external-cash-shipments.md)
+
+## Examples
+
+```json
+{
+  "event_type": "cash.shipment.received",
+  "channel": "branch",
+  "reference_id": "42",
+  "amount_minor_units": 5000000,
+  "currency": "USD"
+}
+```

--- a/test/domains/cash/cash_inventory_test.rb
+++ b/test/domains/cash/cash_inventory_test.rb
@@ -91,6 +91,31 @@ class CashInventoryTest < ActiveSupport::TestCase
     assert_equal "completed", approved.status
   end
 
+  test "cash movement approval reports insufficient source balance without completing" do
+    vault = vault!
+    drawer = drawer!("B3")
+    movement = Cash::Commands::TransferCash.call(
+      source_cash_location_id: vault.id,
+      destination_cash_location_id: drawer.id,
+      amount_minor_units: 2_500,
+      actor_id: @teller.id,
+      idempotency_key: "vault-to-drawer-insufficient"
+    )
+
+    error = assert_raises(Cash::Commands::ApproveCashMovement::InvalidState) do
+      Cash::Commands::ApproveCashMovement.call(
+        cash_movement_id: movement.id,
+        approving_actor_id: @supervisor.id
+      )
+    end
+
+    assert_equal "source cash balance is insufficient", error.message
+    assert_equal Cash::Models::CashMovement::STATUS_PENDING_APPROVAL, movement.reload.status
+    assert_nil movement.operational_event_id
+    assert_equal 0, vault.cash_balance.reload.amount_minor_units
+    assert_equal 0, drawer.cash_balance.reload.amount_minor_units
+  end
+
   test "cash count variance approval posts cash variance to GL once" do
     drawer = drawer!("C1")
     Cash::Commands::RecordCashCount.call(
@@ -160,6 +185,88 @@ class CashInventoryTest < ActiveSupport::TestCase
     )
 
     assert_equal "posted", variance.status
+  end
+
+  test "external cash shipment receipt increases vault cash and posts GL" do
+    vault = vault!
+
+    movement = Cash::Commands::ReceiveExternalCashShipment.call(
+      destination_cash_location_id: vault.id,
+      amount_minor_units: 50_000,
+      actor_id: @supervisor.id,
+      idempotency_key: "fed-cash-receipt-1",
+      external_source: "Federal Reserve",
+      shipment_reference: "FRB-20260429-001"
+    )
+
+    assert_equal Cash::Models::CashMovement::STATUS_COMPLETED, movement.status
+    assert_equal Cash::Models::CashMovement::TYPE_EXTERNAL_SHIPMENT_RECEIVED, movement.movement_type
+    assert_nil movement.source_cash_location_id
+    assert_equal vault.id, movement.destination_cash_location_id
+    assert_equal "Federal Reserve", movement.external_source
+    assert_equal "FRB-20260429-001", movement.shipment_reference
+    assert_equal 50_000, vault.cash_balance.reload.amount_minor_units
+
+    event = movement.operational_event
+    assert_equal "cash.shipment.received", event.event_type
+    assert_equal "posted", event.status
+    assert_equal movement.id.to_s, event.reference_id
+    lines = event.journal_entries.sole.journal_lines.includes(:gl_account).order(:sequence_no)
+    assert_equal "1110", lines.first.gl_account.account_number
+    assert_equal "debit", lines.first.side
+    assert_equal "1130", lines.second.gl_account.account_number
+    assert_equal "credit", lines.second.side
+  end
+
+  test "external cash shipment receipt is idempotent" do
+    vault = vault!
+    attrs = {
+      destination_cash_location_id: vault.id,
+      amount_minor_units: 25_000,
+      actor_id: @supervisor.id,
+      idempotency_key: "fed-cash-receipt-idempotent",
+      external_source: "Correspondent Bank",
+      shipment_reference: "CORR-001"
+    }
+
+    first = Cash::Commands::ReceiveExternalCashShipment.call(**attrs)
+
+    assert_no_difference -> { Cash::Models::CashMovement.count } do
+      assert_no_difference -> { Core::OperationalEvents::Models::OperationalEvent.count } do
+        second = Cash::Commands::ReceiveExternalCashShipment.call(**attrs)
+        assert_equal first.id, second.id
+      end
+    end
+    assert_equal 25_000, vault.cash_balance.reload.amount_minor_units
+    assert_equal 1, first.operational_event.journal_entries.count
+  end
+
+  test "external cash shipment receipt requires shipment capability and branch vault destination" do
+    drawer = drawer!("D1")
+
+    assert_raises(Cash::Commands::ReceiveExternalCashShipment::InvalidRequest) do
+      Cash::Commands::ReceiveExternalCashShipment.call(
+        destination_cash_location_id: drawer.id,
+        amount_minor_units: 10_000,
+        actor_id: @supervisor.id,
+        idempotency_key: "cash-receipt-drawer",
+        external_source: "Federal Reserve",
+        shipment_reference: "BAD-DEST"
+      )
+    end
+
+    vault = vault!
+    error = assert_raises(Cash::Commands::ReceiveExternalCashShipment::InvalidRequest) do
+      Cash::Commands::ReceiveExternalCashShipment.call(
+        destination_cash_location_id: vault.id,
+        amount_minor_units: 10_000,
+        actor_id: @teller.id,
+        idempotency_key: "cash-receipt-unauthorized",
+        external_source: "Federal Reserve",
+        shipment_reference: "NO-AUTH"
+      )
+    end
+    assert_includes error.message, "cash.shipment.receive"
   end
 
   private

--- a/test/domains/core/posting/post_event_test.rb
+++ b/test/domains/core/posting/post_event_test.rb
@@ -132,6 +132,56 @@ class CorePostingPostEventTest < ActiveSupport::TestCase
     assert_equal @account.id, cr.deposit_account_id
   end
 
+  test "posts cash shipment received as Dr 1110 Cr 1130" do
+    operating_unit = Organization::Services::DefaultOperatingUnit.branch
+    operator = Workspace::Models::Operator.create!(
+      role: "supervisor",
+      display_name: "Cash Shipment Supervisor",
+      active: true,
+      default_operating_unit: operating_unit
+    )
+    vault = Cash::Commands::CreateLocation.call(
+      location_type: "branch_vault",
+      operating_unit_id: operating_unit.id,
+      actor_id: operator.id
+    )
+    movement = Cash::Models::CashMovement.create!(
+      destination_cash_location: vault,
+      operating_unit: operating_unit,
+      actor: operator,
+      amount_minor_units: 75_000,
+      currency: "USD",
+      business_date: Date.new(2026, 4, 22),
+      status: Cash::Models::CashMovement::STATUS_COMPLETED,
+      movement_type: Cash::Models::CashMovement::TYPE_EXTERNAL_SHIPMENT_RECEIVED,
+      external_source: "Federal Reserve",
+      shipment_reference: "POST-FRB-001",
+      idempotency_key: "post-cash-shipment-movement",
+      request_fingerprint: "post-cash-shipment-fingerprint",
+      completed_at: Time.current
+    )
+    event = Core::OperationalEvents::Models::OperationalEvent.create!(
+      event_type: "cash.shipment.received",
+      status: "pending",
+      business_date: Date.new(2026, 4, 22),
+      channel: "branch",
+      idempotency_key: "post-cash-shipment-event",
+      amount_minor_units: 75_000,
+      currency: "USD",
+      actor: operator,
+      operating_unit: operating_unit,
+      reference_id: movement.id.to_s
+    )
+
+    Core::Posting::Commands::PostEvent.call(operational_event_id: event.id)
+
+    lines = event.reload.posting_batches.sole.journal_entries.sole.journal_lines.includes(:gl_account).order(:sequence_no)
+    assert_equal "1110", lines.first.gl_account.account_number
+    assert_equal "debit", lines.first.side
+    assert_equal "1130", lines.second.gl_account.account_number
+    assert_equal "credit", lines.second.side
+  end
+
   private
 
   def fund_account!(amount)

--- a/test/integration/branch_transaction_forms_test.rb
+++ b/test/integration/branch_transaction_forms_test.rb
@@ -35,6 +35,40 @@ class BranchTransactionFormsTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
   end
 
+  test "branch supervisor can receive external cash shipment and teller cannot" do
+    vault = Cash::Commands::CreateLocation.call(
+      location_type: "branch_vault",
+      operating_unit_id: @supervisor.default_operating_unit_id,
+      actor_id: @supervisor.id
+    )
+
+    internal_login!(username: "branch-forms-teller")
+    get "/branch/cash/shipments/received/new"
+    assert_redirected_to "/branch"
+    delete "/logout"
+
+    internal_login!(username: "branch-forms-supervisor")
+    get "/branch/cash/shipments/received/new"
+    assert_response :success
+    assert_includes response.body, "cash_shipment[shipment_reference]"
+
+    post "/branch/cash/shipments/received", params: {
+      cash_shipment: {
+        destination_cash_location_id: vault.id,
+        amount_minor_units: 90_000,
+        external_source: "Federal Reserve",
+        shipment_reference: "UI-FRB-001",
+        idempotency_key: "ui-fed-cash-receipt"
+      }
+    }
+
+    assert_redirected_to "/branch/cash"
+    movement = Cash::Models::CashMovement.find_by!(idempotency_key: "ui-fed-cash-receipt")
+    assert_equal Cash::Models::CashMovement::TYPE_EXTERNAL_SHIPMENT_RECEIVED, movement.movement_type
+    assert_equal 90_000, vault.cash_balance.reload.amount_minor_units
+    assert_equal "posted", movement.operational_event.status
+  end
+
   test "party creation redirects to open account form and unsupported party renders validation" do
     internal_login!(username: "branch-forms-teller")
 

--- a/test/integration/ops_control_surfaces_test.rb
+++ b/test/integration/ops_control_surfaces_test.rb
@@ -93,6 +93,36 @@ class OpsControlSurfacesTest < ActionDispatch::IntegrationTest
     assert_equal @operator.id, session.supervisor_operator_id
   end
 
+  test "cash movement approval redirects when source balance is insufficient" do
+    teller = create_operator_with_credential!(role: "teller", username: "ops-cash-teller")
+    operating_unit = Organization::Services::DefaultOperatingUnit.branch!
+    vault = Cash::Commands::CreateLocation.call(
+      location_type: Cash::Models::CashLocation::TYPE_BRANCH_VAULT,
+      operating_unit: operating_unit,
+      name: "Ops Insufficient Vault"
+    )
+    drawer = Cash::Commands::CreateLocation.call(
+      location_type: Cash::Models::CashLocation::TYPE_TELLER_DRAWER,
+      operating_unit: operating_unit,
+      drawer_code: "OPS-INSUFF",
+      name: "Ops Insufficient Drawer"
+    )
+    movement = Cash::Commands::TransferCash.call(
+      source_cash_location_id: vault.id,
+      destination_cash_location_id: drawer.id,
+      amount_minor_units: 2_500,
+      actor_id: teller.id,
+      idempotency_key: "ops-insufficient-cash-movement"
+    )
+
+    internal_login!(username: "ops-controls")
+    post "/ops/cash/movements/#{movement.id}/approve"
+
+    assert_redirected_to "/ops/cash"
+    assert_equal "source cash balance is insufficient", flash[:alert]
+    assert_equal Cash::Models::CashMovement::STATUS_PENDING_APPROVAL, movement.reload.status
+  end
+
   test "ops controls remain forbidden to branch roles" do
     create_operator_with_credential!(role: "teller", username: "ops-control-teller")
     internal_login!(username: "ops-control-teller")


### PR DESCRIPTION
## Summary
- Add a single-step external cash shipment receipt flow for branch vault custody.
- Register and post `cash.shipment.received` through Core with Dr `1110` / Cr `1130`.
- Add Branch UI, RBAC capability, ADR/event docs, migration, and regression coverage.

## Test plan
- `docker compose run --rm web bin/rails test test/domains/cash/cash_inventory_test.rb test/domains/core/posting/post_event_test.rb test/domains/core/operational_events/event_catalog_test.rb test/integration/branch_transaction_forms_test.rb`
- `docker compose run --rm web bin/rails test`


Made with [Cursor](https://cursor.com)