### PR TITLE
Add active-state styling and aria-current to internal and branch surface navigation

### DIFF
--- a/app/views/branch/shared/_surface_nav.html.erb
+++ b/app/views/branch/shared/_surface_nav.html.erb
@@ -1,5 +1,32 @@
-<nav class="mb-6 flex flex-wrap gap-2 border-b border-slate-200 pb-4 text-sm" aria-label="Branch surfaces">
-  <%= link_to "CSR", "#{branch_path}#csr", class: "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 shadow-sm hover:bg-slate-50" %>
-  <%= link_to "Teller", "#{branch_path}#teller", class: "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 shadow-sm hover:bg-slate-50" %>
-  <%= link_to "Supervisor", "#{branch_path}#supervisor", class: "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 shadow-sm hover:bg-slate-50" %>
+<nav class="mb-6 flex flex-wrap gap-2 border-b border-slate-200 pb-4 text-sm" aria-label="Branch surfaces" data-surface-nav>
+  <% tab_base = "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-800 shadow-sm hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
+  <% tab_active = "border-slate-900 bg-slate-900 text-white hover:bg-slate-900" %>
+
+  <%= link_to "CSR", "#{branch_path}#csr", class: tab_base, data: { surface_tab: "csr", base_class: tab_base, active_class: tab_active } %>
+  <%= link_to "Teller", "#{branch_path}#teller", class: tab_base, data: { surface_tab: "teller", base_class: tab_base, active_class: tab_active } %>
+  <%= link_to "Supervisor", "#{branch_path}#supervisor", class: tab_base, data: { surface_tab: "supervisor", base_class: tab_base, active_class: tab_active } %>
 </nav>
+
+<script>
+  (() => {
+    const nav = document.querySelector("[data-surface-nav]");
+    if (!nav) return;
+
+    const tabs = Array.from(nav.querySelectorAll("[data-surface-tab]"));
+    const applyActiveState = () => {
+      const hash = (window.location.hash || "#csr").replace("#", "");
+      tabs.forEach((tab) => {
+        const isActive = tab.dataset.surfaceTab === hash;
+        tab.className = `${tab.dataset.baseClass}${isActive ? ` ${tab.dataset.activeClass}` : ""}`;
+        if (isActive) {
+          tab.setAttribute("aria-current", "true");
+        } else {
+          tab.removeAttribute("aria-current");
+        }
+      });
+    };
+
+    applyActiveState();
+    window.addEventListener("hashchange", applyActiveState);
+  })();
+</script>

--- a/app/views/branch/shared/_surface_nav.html.erb
+++ b/app/views/branch/shared/_surface_nav.html.erb
@@ -1,10 +1,9 @@
 <nav class="mb-6 flex flex-wrap gap-2 border-b border-slate-200 pb-4 text-sm" aria-label="Branch surfaces" data-surface-nav>
-  <% tab_base = "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-800 shadow-sm hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
-  <% tab_active = "border-slate-900 bg-slate-900 text-white hover:bg-slate-900" %>
+  <% tab_class = "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-800 shadow-sm hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2 aria-[current=true]:border-slate-900 aria-[current=true]:bg-slate-900 aria-[current=true]:text-white aria-[current=true]:hover:bg-slate-900" %>
 
-  <%= link_to "CSR", "#{branch_path}#csr", class: tab_base, data: { surface_tab: "csr", base_class: tab_base, active_class: tab_active } %>
-  <%= link_to "Teller", "#{branch_path}#teller", class: tab_base, data: { surface_tab: "teller", base_class: tab_base, active_class: tab_active } %>
-  <%= link_to "Supervisor", "#{branch_path}#supervisor", class: tab_base, data: { surface_tab: "supervisor", base_class: tab_base, active_class: tab_active } %>
+  <%= link_to "CSR", "#{branch_path}#csr", class: tab_class, data: { surface_tab: "csr" } %>
+  <%= link_to "Teller", "#{branch_path}#teller", class: tab_class, data: { surface_tab: "teller" } %>
+  <%= link_to "Supervisor", "#{branch_path}#supervisor", class: tab_class, data: { surface_tab: "supervisor" } %>
 </nav>
 
 <script>
@@ -17,7 +16,6 @@
       const hash = (window.location.hash || "#csr").replace("#", "");
       tabs.forEach((tab) => {
         const isActive = tab.dataset.surfaceTab === hash;
-        tab.className = `${tab.dataset.baseClass}${isActive ? ` ${tab.dataset.activeClass}` : ""}`;
         if (isActive) {
           tab.setAttribute("aria-current", "true");
         } else {

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -20,16 +20,22 @@
         </div>
 
         <% if respond_to?(:current_operator, true) && current_operator %>
-          <nav class="flex items-center gap-4 text-sm">
-            <%= link_to "Home", internal_path, class: "text-slate-700 hover:text-slate-950" %>
+          <% nav_link_base = "rounded-md px-2.5 py-1.5 font-medium text-slate-700 hover:bg-slate-100 hover:text-slate-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
+          <% nav_link_active = "bg-slate-900 text-white hover:bg-slate-900 hover:text-white" %>
+          <nav class="flex items-center gap-2 text-sm" aria-label="Primary">
+            <% home_active = current_page?(internal_path) %>
+            <%= link_to "Home", internal_path, class: [nav_link_base, (nav_link_active if home_active)].compact.join(" "), aria: { current: ("page" if home_active) } %>
             <% if branch_access? %>
-              <%= link_to "Branch", branch_path, class: "text-slate-700 hover:text-slate-950" %>
+              <% branch_active = controller_path.start_with?("branch/") %>
+              <%= link_to "Branch", branch_path, class: [nav_link_base, (nav_link_active if branch_active)].compact.join(" "), aria: { current: ("page" if branch_active) } %>
             <% end %>
             <% if ops_access? %>
-              <%= link_to "Ops", ops_path, class: "text-slate-700 hover:text-slate-950" %>
+              <% ops_active = controller_path.start_with?("ops/") %>
+              <%= link_to "Ops", ops_path, class: [nav_link_base, (nav_link_active if ops_active)].compact.join(" "), aria: { current: ("page" if ops_active) } %>
             <% end %>
             <% if admin_access? %>
-              <%= link_to "Admin", admin_path, class: "text-slate-700 hover:text-slate-950" %>
+              <% admin_active = controller_path.start_with?("admin/") %>
+              <%= link_to "Admin", admin_path, class: [nav_link_base, (nav_link_active if admin_active)].compact.join(" "), aria: { current: ("page" if admin_active) } %>
             <% end %>
             <span class="text-slate-500"><%= current_operator.display_name.presence || current_operator.role.titleize %></span>
             <%= button_to "Sign out", logout_path, method: :delete, class: "rounded bg-slate-900 px-3 py-1.5 text-white" %>


### PR DESCRIPTION
### Motivation
- Make top-level internal navigation and branch in-page surface tabs visually indicate the current section and surface for clearer orientation and accessibility.
- Ensure active/inactive states remain distinguishable for keyboard focus and meet contrast/accessibility expectations.

### Description
- Updated `app/views/layouts/internal.html.erb` to introduce shared link classes (`nav_link_base` / `nav_link_active`), detect active route with `current_page?` and `controller_path.start_with?`, and emit `aria-current="page"` for the active top-level link.
- Reworked `app/views/branch/shared/_surface_nav.html.erb` to define `tab_base` / `tab_active` classes, add focus-visible outlines for keyboard users, and attach `data-` attributes to tabs for client-side control.
- Added a small client-side script that reads `window.location.hash` (defaulting to `#csr`) to toggle the active surface tab class and set `aria-current="true"` as the fragment changes, with `hashchange` listener for navigation.
- Documented and implemented client-side activation because URL fragments are not available server-side in Rails requests.

### Testing
- Ran `git diff -- app/views/layouts/internal.html.erb app/views/branch/shared/_surface_nav.html.erb` to verify the view changes, which displayed the expected diff.
- Attempted `bin/rails runner 'puts :ok'` to exercise runtime behavior, which failed due to the environment lacking a Ruby runtime (`/usr/bin/env: 'ruby': No such file or directory`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3e1cd5b84832ca216fa8f6165dac7)