### PR TITLE
Add contextual Quick actions to Branch customer & account views

### DIFF
--- a/app/views/branch/account_activities/show.html.erb
+++ b/app/views/branch/account_activities/show.html.erb
@@ -1,11 +1,29 @@
 <% content_for :title, "Account Activity - BankCORE" %>
+<% customer_return_params = params[:query].present? ? { query: params[:query] } : {} %>
 
 <section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
   <div>
     <h1 class="text-3xl font-semibold">Account activity</h1>
     <p class="mt-2 text-slate-600">Account <%= @account.account_number %></p>
   </div>
-  <%= link_to "Back to account", branch_servicing_deposit_account_path(@account), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+  <%= link_to "Back to account", branch_servicing_deposit_account_path(@account, customer_return_params), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+</section>
+
+<section class="mt-4 rounded border border-slate-200 bg-slate-50 p-4">
+  <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-600">Quick actions</h2>
+  <div class="mt-3 flex flex-wrap gap-2 text-sm">
+    <%= link_to "Account profile", branch_servicing_deposit_account_path(@account, customer_return_params), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+    <% if can_place_servicing_hold? %>
+      <%= link_to "Place hold", branch_new_account_hold_path(@account, customer_return_params), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+    <% end %>
+    <%= link_to "Review holds", branch_account_holds_path(@account, customer_return_params), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+    <% if can_waive_fee? %>
+      <%= link_to "Post fee waiver", branch_new_fee_waiver_path(@account, customer_return_params), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+    <% end %>
+    <% if branch_operator_can?(Workspace::Authorization::CapabilityRegistry::OPERATIONAL_EVENT_VIEW) %>
+      <%= link_to "View events", branch_operational_events_path(source_account_id: @account.id), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+    <% end %>
+  </div>
 </section>
 
 <%= render "branch/shared/form_error", error_message: @error_message %>

--- a/app/views/branch/account_holds/index.html.erb
+++ b/app/views/branch/account_holds/index.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, "Account Holds - BankCORE" %>
+<% customer_return_params = params[:query].present? ? { query: params[:query] } : {} %>
 
 <section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
   <div>
@@ -6,11 +7,22 @@
     <p class="mt-2 text-slate-600">Account <%= @account.account_number %></p>
   </div>
   <nav class="flex flex-wrap gap-2 text-sm">
-    <%= link_to "Back to account", branch_servicing_deposit_account_path(@account), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+    <%= link_to "Back to account", branch_servicing_deposit_account_path(@account, customer_return_params), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
     <% if can_place_servicing_hold? %>
       <%= link_to "Place hold", branch_new_account_hold_path(@account), class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
     <% end %>
   </nav>
+</section>
+
+<section class="mt-4 rounded border border-slate-200 bg-slate-50 p-4">
+  <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-600">Quick actions</h2>
+  <div class="mt-3 flex flex-wrap gap-2 text-sm">
+    <%= link_to "Account profile", branch_servicing_deposit_account_path(@account, customer_return_params), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+    <%= link_to "Review transactions", branch_account_activity_path(@account, customer_return_params), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+    <% if branch_operator_can?(Workspace::Authorization::CapabilityRegistry::OPERATIONAL_EVENT_VIEW) %>
+      <%= link_to "View events", branch_operational_events_path(source_account_id: @account.id), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+    <% end %>
+  </div>
 </section>
 
 <%= render "branch/shared/form_error", error_message: @error_message %>

--- a/app/views/branch/customers/show.html.erb
+++ b/app/views/branch/customers/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, "#{@party.name} - BankCORE" %>
+<% customer_return_params = params[:query].present? ? { query: params[:query] } : {} %>
 
 <section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
   <div>
@@ -6,12 +7,24 @@
     <p class="mt-2 text-slate-600">Customer 360 for party #<%= @party.id %>.</p>
   </div>
   <nav class="flex flex-wrap gap-2 text-sm">
-    <%= link_to "Back to search", branch_customers_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+    <%= link_to "Back to search", branch_customers_path(customer_return_params), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
     <%= link_to "Open account", new_branch_deposit_account_path(party_record_id: @party.id), class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
     <% if can_update_party_contact? %>
       <%= link_to "Update contact", branch_new_party_contact_path(@party), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
     <% end %>
   </nav>
+</section>
+
+<section class="mt-4 rounded border border-slate-200 bg-slate-50 p-4">
+  <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-600">Quick actions</h2>
+  <p class="mt-1 text-sm text-slate-500">Jump into likely next steps for this customer.</p>
+  <div class="mt-3 flex flex-wrap gap-2 text-sm">
+    <%= link_to "Return to customer search", branch_customers_path(customer_return_params), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+    <%= link_to "Open account", new_branch_deposit_account_path(party_record_id: @party.id), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+    <% if can_update_party_contact? %>
+      <%= link_to "Update contact", branch_new_party_contact_path(@party), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+    <% end %>
+  </div>
 </section>
 
 <section class="mt-6 grid gap-4 md:grid-cols-3">
@@ -127,6 +140,7 @@
     rows: @account_relationships.current_rows,
     show_account: true,
     show_actions: true,
+    customer_return_query: params[:query],
     empty_message: "No current deposit account relationships." %>
 </section>
 
@@ -138,5 +152,6 @@
     rows: @account_relationships.historical_rows,
     show_account: true,
     show_actions: true,
+    customer_return_query: params[:query],
     empty_message: "No historical deposit account relationships." %>
 </section>

--- a/app/views/branch/customers/show.html.erb
+++ b/app/views/branch/customers/show.html.erb
@@ -17,13 +17,11 @@
 
 <section class="mt-4 rounded border border-slate-200 bg-slate-50 p-4">
   <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-600">Quick actions</h2>
-  <p class="mt-1 text-sm text-slate-500">Jump into likely next steps for this customer.</p>
+  <p class="mt-1 text-sm text-slate-500">Jump to the customer sections you are most likely to use next.</p>
   <div class="mt-3 flex flex-wrap gap-2 text-sm">
-    <%= link_to "Return to customer search", branch_customers_path(customer_return_params), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
-    <%= link_to "Open account", new_branch_deposit_account_path(party_record_id: @party.id), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
-    <% if can_update_party_contact? %>
-      <%= link_to "Update contact", branch_new_party_contact_path(@party), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
-    <% end %>
+    <%= link_to "Review contact summary", "#contact-summary", class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+    <%= link_to "Review contact audit", "#contact-audit", class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+    <%= link_to "Review linked accounts", "#linked-accounts", class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
   </div>
 </section>
 
@@ -57,7 +55,7 @@
   </section>
 <% end %>
 
-<section class="mt-6 rounded border border-slate-200 bg-white p-6 shadow-sm">
+<section id="contact-summary" class="mt-6 rounded border border-slate-200 bg-white p-6 shadow-sm">
   <h2 class="text-xl font-semibold">Contact summary</h2>
   <div class="mt-4 grid gap-4 text-sm md:grid-cols-3">
     <div>
@@ -99,7 +97,7 @@
   </div>
 </section>
 
-<section class="mt-6 overflow-hidden rounded border border-slate-200 bg-white shadow-sm">
+<section id="contact-audit" class="mt-6 overflow-hidden rounded border border-slate-200 bg-white shadow-sm">
   <div class="border-b border-slate-200 px-5 py-4">
     <h2 class="text-xl font-semibold">Contact audit</h2>
   </div>
@@ -131,7 +129,7 @@
   <% end %>
 </section>
 
-<section class="mt-6 overflow-hidden rounded border border-slate-200 bg-white shadow-sm">
+<section id="linked-accounts" class="mt-6 overflow-hidden rounded border border-slate-200 bg-white shadow-sm">
   <div class="border-b border-slate-200 px-5 py-4">
     <h2 class="text-xl font-semibold">Current deposit account relationships</h2>
     <p class="mt-1 text-sm text-slate-500">As of <%= branch_date(@account_relationships.as_of) %></p>

--- a/app/views/branch/servicing_deposit_accounts/show.html.erb
+++ b/app/views/branch/servicing_deposit_accounts/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, "Account #{@account.account_number} - BankCORE" %>
+<% customer_return_params = params[:query].present? ? { query: params[:query] } : {} %>
 
 <section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
   <div>
@@ -6,7 +7,7 @@
     <p class="mt-2 text-slate-600"><%= @profile.product.product_code %> · <%= @profile.product.name %></p>
   </div>
   <nav class="flex flex-wrap gap-2 text-sm">
-    <%= link_to "Find customer", branch_customers_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+    <%= link_to "Find customer", branch_customers_path(customer_return_params), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
     <% if can_manage_authorized_signers? %>
       <%= link_to "Add authorized signer", branch_new_account_authorized_signer_path(@account), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
     <% end %>
@@ -21,6 +22,24 @@
       <% end %>
     <% end %>
   </nav>
+</section>
+
+<section class="mt-4 rounded border border-slate-200 bg-slate-50 p-4">
+  <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-600">Quick actions</h2>
+  <div class="mt-3 flex flex-wrap gap-2 text-sm">
+    <%= link_to "Account profile", branch_servicing_deposit_account_path(@account, customer_return_params), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+    <% if @can_place_holds %>
+      <%= link_to "Place hold", branch_new_account_hold_path(@account, customer_return_params), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+    <% end %>
+    <%= link_to "Review holds", branch_account_holds_path(@account, customer_return_params), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+    <%= link_to "Review transactions", branch_account_activity_path(@account, customer_return_params), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+    <% if can_waive_fee? %>
+      <%= link_to "Post fee waiver", branch_new_fee_waiver_path(@account, customer_return_params), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+    <% end %>
+    <% if branch_operator_can?(Workspace::Authorization::CapabilityRegistry::OPERATIONAL_EVENT_VIEW) %>
+      <%= link_to "View events", branch_operational_events_path(source_account_id: @account.id), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+    <% end %>
+  </div>
 </section>
 
 <section class="mt-6 grid gap-4 md:grid-cols-4">

--- a/app/views/branch/servicing_deposit_accounts/show.html.erb
+++ b/app/views/branch/servicing_deposit_accounts/show.html.erb
@@ -27,12 +27,9 @@
 <section class="mt-4 rounded border border-slate-200 bg-slate-50 p-4">
   <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-600">Quick actions</h2>
   <div class="mt-3 flex flex-wrap gap-2 text-sm">
-    <%= link_to "Account profile", branch_servicing_deposit_account_path(@account, customer_return_params), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
-    <% if @can_place_holds %>
-      <%= link_to "Place hold", branch_new_account_hold_path(@account, customer_return_params), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
-    <% end %>
     <%= link_to "Review holds", branch_account_holds_path(@account, customer_return_params), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
     <%= link_to "Review transactions", branch_account_activity_path(@account, customer_return_params), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+    <%= link_to "Review statements", branch_account_statements_path(@account, customer_return_params), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
     <% if can_waive_fee? %>
       <%= link_to "Post fee waiver", branch_new_fee_waiver_path(@account, customer_return_params), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
     <% end %>

--- a/app/views/branch/shared/_account_relationship_table.html.erb
+++ b/app/views/branch/shared/_account_relationship_table.html.erb
@@ -1,4 +1,5 @@
 <% if rows.any? %>
+  <% customer_context_params = local_assigns.fetch(:customer_return_query, nil).present? ? { query: local_assigns.fetch(:customer_return_query) } : {} %>
   <table class="min-w-full divide-y divide-slate-200 text-sm">
     <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
       <tr>
@@ -44,7 +45,7 @@
           <td class="px-5 py-4"><%= branch_date(row.relationship.ended_on) %></td>
           <% if local_assigns.fetch(:show_actions, false) %>
             <td class="px-5 py-4">
-              <%= link_to "Service account", branch_servicing_deposit_account_path(row.account), class: "rounded bg-slate-900 px-3 py-1.5 font-medium text-white" %>
+              <%= link_to "Service account", branch_servicing_deposit_account_path(row.account, customer_context_params), class: "rounded bg-slate-900 px-3 py-1.5 font-medium text-white" %>
             </td>
           <% end %>
           <% if local_assigns.fetch(:can_end_authorized_signers, false) %>


### PR DESCRIPTION
### Motivation
- Surface likely next steps directly on customer 360 and account pages so operators can jump to common tasks without hunting through navigation.
- Keep actions task-focused (e.g., “Place hold”, “Post fee waiver”, “View events”) and enforce existing capability gating so only authorized operators see actionable links.
- Preserve back-navigation/search context by carrying the `query` param through inter-page links so users return to the originating search state.

### Description
- Add compact `Quick actions` UI blocks to `app/views/branch/customers/show.html.erb`, `app/views/branch/servicing_deposit_accounts/show.html.erb`, `app/views/branch/account_holds/index.html.erb`, and `app/views/branch/account_activities/show.html.erb` that surface task-oriented links (profile, place hold, review holds, review transactions, post fee waiver, view events).
- Gate link visibility using existing helpers/flags (`can_update_party_contact?`, `can_place_servicing_hold?`, `can_waive_fee?`, `branch_operator_can?`, and controller-provided `@can_*` values).
- Preserve customer-search return context by computing `customer_return_params = params[:query].present? ? { query: params[:query] } : {}` and passing it to `branch_customers_path`, `branch_servicing_deposit_account_path`, `branch_account_holds_path`, `branch_account_activity_path`, etc.
- Update the shared table `app/views/branch/shared/_account_relationship_table.html.erb` to accept a `customer_return_query` local and propagate it into the existing "Service account" link so navigation from the customer table preserves search context.
- No behavioral model/controller changes were required beyond using already-provided capability helpers and controller instance vars.

### Testing
- Attempted to run linting with `bundle exec rubocop app/views/branch/...` but it failed in this environment due to `bundle: command not found` (automated lint could not be executed here).
- No automated feature or unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3f9c7f85c832cb512ba8f6782acca)