### PR TITLE
Refine branch and ops table UX for operational event lists

### DIFF
--- a/app/helpers/branch/application_helper.rb
+++ b/app/helpers/branch/application_helper.rb
@@ -23,5 +23,33 @@ module Branch
     def branch_hold_reason_options
       Accounts::Models::Hold::REASON_CODES.map { |value| [ value.humanize, value ] }
     end
+
+    def branch_status_badge(value)
+      classes = case value.to_s
+      when "posted", "closed", "true"
+        "bg-emerald-50 text-emerald-800 border-emerald-200"
+      when "pending", "pending_supervisor", "false"
+        "bg-amber-50 text-amber-900 border-amber-200"
+      else
+        "bg-slate-50 text-slate-700 border-slate-200"
+      end
+      tag.span(value.to_s.humanize, class: "rounded border px-2 py-1 text-xs font-medium #{classes}")
+    end
+
+    def branch_event_type_badge(value)
+      event_type = value.to_s
+      classes = case event_type
+      when /\A(deposit|withdrawal|transfer|ach|interest)\./
+        "bg-blue-50 text-blue-800 border-blue-200"
+      when /\A(fee|overdraft)\./
+        "bg-violet-50 text-violet-800 border-violet-200"
+      when /\A(hold|posting)\./
+        "bg-amber-50 text-amber-900 border-amber-200"
+      else
+        "bg-slate-50 text-slate-700 border-slate-200"
+      end
+
+      tag.span(event_type.presence || "Unknown", class: "rounded border px-2 py-1 text-xs font-medium #{classes}")
+    end
   end
 end

--- a/app/helpers/ops/application_helper.rb
+++ b/app/helpers/ops/application_helper.rb
@@ -30,6 +30,22 @@ module Ops
       tag.span(value.to_s.humanize, class: "rounded border px-2 py-1 text-xs font-medium #{classes}")
     end
 
+    def ops_event_type_badge(value)
+      event_type = value.to_s
+      classes = case event_type
+      when /\A(deposit|withdrawal|transfer|ach|interest)\./
+        "bg-blue-50 text-blue-800 border-blue-200"
+      when /\A(fee|overdraft)\./
+        "bg-violet-50 text-violet-800 border-violet-200"
+      when /\A(hold|posting)\./
+        "bg-amber-50 text-amber-900 border-amber-200"
+      else
+        "bg-slate-50 text-slate-700 border-slate-200"
+      end
+
+      tag.span(event_type.presence || "Unknown", class: "rounded border px-2 py-1 text-xs font-medium #{classes}")
+    end
+
     def ops_account_label(account)
       return "None" if account.nil?
 

--- a/app/views/branch/customers/show.html.erb
+++ b/app/views/branch/customers/show.html.erb
@@ -104,8 +104,9 @@
   <% if @contact_summary.audits.any? %>
     <div class="overflow-x-auto">
       <table class="min-w-full divide-y divide-slate-200 text-sm">
-        <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+        <thead class="sticky top-0 z-10 bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
           <tr>
+            <th class="px-5 py-3">When</th>
             <th class="px-5 py-3">Action</th>
             <th class="px-5 py-3">Contact</th>
             <th class="px-5 py-3">New summary</th>
@@ -115,7 +116,10 @@
         <tbody class="divide-y divide-slate-100">
           <% @contact_summary.audits.each do |audit| %>
             <tr>
-              <td class="px-5 py-3 font-medium"><%= audit.action %></td>
+              <td class="px-5 py-3"><%= audit.created_at&.in_time_zone&.strftime("%Y-%m-%d %H:%M") || "Not recorded" %></td>
+              <td class="px-5 py-3">
+                <span class="rounded border border-slate-200 bg-slate-50 px-2 py-1 text-xs font-medium text-slate-700"><%= audit.action.to_s.humanize %></span>
+              </td>
               <td class="px-5 py-3"><%= audit.contact_table %> #<%= audit.contact_id %></td>
               <td class="px-5 py-3"><%= audit.new_summary.presence || audit.old_summary %></td>
               <td class="px-5 py-3">#<%= audit.actor_id %></td>

--- a/app/views/branch/operational_events/index.html.erb
+++ b/app/views/branch/operational_events/index.html.erb
@@ -33,17 +33,21 @@
     </div>
     <div class="self-end">
       <%= form.submit "Search", class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+      <%= link_to "Clear filters", branch_operational_events_path, class: "ml-2 rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
     </div>
   <% end %>
 </section>
 
 <section class="mt-6 overflow-hidden rounded border border-slate-200 bg-white shadow-sm">
   <% if @event_search&.fetch(:rows)&.any? %>
+    <div class="overflow-x-auto">
     <table class="min-w-full divide-y divide-slate-200 text-sm">
-      <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+      <thead class="sticky top-0 z-10 bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
         <tr>
-          <th class="px-5 py-3">Event</th>
+          <th class="px-5 py-3">Event id</th>
+          <th class="px-5 py-3">Created</th>
           <th class="px-5 py-3">Status</th>
+          <th class="px-5 py-3">Event type</th>
           <th class="px-5 py-3">Account</th>
           <th class="px-5 py-3 text-right">Amount</th>
           <th class="px-5 py-3">Actions</th>
@@ -51,12 +55,14 @@
       </thead>
       <tbody class="divide-y divide-slate-100">
         <% @event_search[:rows].each do |event| %>
-          <tr>
+          <tr class="focus-within:bg-slate-50 hover:bg-slate-50">
             <td class="px-5 py-4">
-              <%= link_to "##{event.id}", branch_operational_event_path(event), class: "font-medium text-slate-950" %>
-              <div class="text-xs text-slate-500"><%= event.event_type %></div>
+              <%= link_to "##{event.id}", branch_operational_event_path(event), class: "font-semibold text-slate-950 underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500" %>
+              <div class="text-xs text-slate-500">Primary action: view details</div>
             </td>
-            <td class="px-5 py-4"><%= event.status %></td>
+            <td class="px-5 py-4"><%= event.created_at&.in_time_zone&.strftime("%Y-%m-%d %H:%M") || "Not recorded" %></td>
+            <td class="px-5 py-4"><%= branch_status_badge(event.status) %></td>
+            <td class="px-5 py-4"><%= branch_event_type_badge(event.event_type) %></td>
             <td class="px-5 py-4">#<%= event.source_account_id || event.destination_account_id || "none" %></td>
             <td class="px-5 py-4 text-right"><%= branch_money(event.amount_minor_units) %> <%= event.currency %></td>
             <td class="px-5 py-4">
@@ -70,7 +76,14 @@
         <% end %>
       </tbody>
     </table>
+    </div>
   <% else %>
-    <div class="p-6 text-sm text-slate-600">No operational events found.</div>
+    <div class="p-6 text-sm text-slate-600">
+      <p>No operational events found.</p>
+      <div class="mt-4 flex flex-wrap gap-2">
+        <%= link_to "Clear filters", branch_operational_events_path, class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+        <%= link_to "Try broader date range", branch_operational_events_path(request.query_parameters.merge(business_date: nil)), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+      </div>
+    </div>
   <% end %>
 </section>

--- a/app/views/ops/operational_events/index.html.erb
+++ b/app/views/ops/operational_events/index.html.erb
@@ -32,7 +32,7 @@
 
     <div class="flex items-end gap-3 md:col-span-4">
       <%= form.submit "Search", class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
-      <%= link_to "Clear", ops_operational_events_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+      <%= link_to "Clear filters", ops_operational_events_path, class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
     </div>
   <% end %>
 </section>
@@ -53,10 +53,12 @@
     <% if @event_search[:rows].any? %>
       <div class="overflow-x-auto">
         <table class="min-w-full divide-y divide-slate-200 text-sm">
-          <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+          <thead class="sticky top-0 z-10 bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
             <tr>
-              <th class="px-5 py-3">Event</th>
+              <th class="px-5 py-3">Event id</th>
+              <th class="px-5 py-3">Created</th>
               <th class="px-5 py-3">Status</th>
+              <th class="px-5 py-3">Event type</th>
               <th class="px-5 py-3">Business date</th>
               <th class="px-5 py-3">Channel</th>
               <th class="px-5 py-3 text-right">Amount</th>
@@ -64,17 +66,18 @@
               <th class="px-5 py-3">Destination</th>
               <th class="px-5 py-3">Actor/session</th>
               <th class="px-5 py-3">Support keys</th>
-              <th class="px-5 py-3">Created</th>
             </tr>
           </thead>
           <tbody class="divide-y divide-slate-100">
             <% @event_search[:rows].each do |event| %>
-              <tr>
+              <tr class="focus-within:bg-slate-50 hover:bg-slate-50">
                 <td class="px-5 py-4">
-                  <%= link_to "##{event.id}", ops_operational_event_path(event), class: "font-medium text-slate-950 underline" %>
-                  <div class="text-xs text-slate-500"><%= event.event_type %></div>
+                  <%= link_to "##{event.id}", ops_operational_event_path(event), class: "font-semibold text-slate-950 underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500" %>
+                  <div class="text-xs text-slate-500">Primary action: view details</div>
                 </td>
+                <td class="px-5 py-4"><%= ops_time(event.created_at) %></td>
                 <td class="px-5 py-4"><%= ops_status_badge(event.status) %></td>
+                <td class="px-5 py-4"><%= ops_event_type_badge(event.event_type) %></td>
                 <td class="px-5 py-4"><%= event.business_date.iso8601 %></td>
                 <td class="px-5 py-4"><%= event.channel %></td>
                 <td class="px-5 py-4 text-right"><%= ops_event_amount(event) %></td>
@@ -89,14 +92,19 @@
                   <div>Idempotency: <%= event.idempotency_key %></div>
                   <div>Reversal of: <%= event.reversal_of_event_id || "none" %></div>
                 </td>
-                <td class="px-5 py-4"><%= ops_time(event.created_at) %></td>
               </tr>
             <% end %>
           </tbody>
         </table>
       </div>
     <% else %>
-      <div class="px-5 py-8 text-sm text-slate-600">No operational events matched these filters.</div>
+      <div class="px-5 py-8 text-sm text-slate-600">
+        <p>No operational events matched these filters.</p>
+        <div class="mt-4 flex flex-wrap gap-2">
+          <%= link_to "Clear filters", ops_operational_events_path, class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+          <%= link_to "Try broader date range", ops_operational_events_path(request.query_parameters.merge(business_date: nil, business_date_from: nil, business_date_to: nil, limit: 100)), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+        </div>
+      </div>
     <% end %>
   </section>
 


### PR DESCRIPTION
### Motivation
- Improve usability of long, horizontally-scrollable tables in Branch and Ops workspaces by making headers sticky and improving column prioritization for quick scanning.
- Provide consistent, accessible visual signals for event `status` and `event_type` with text + color rather than color-only chips.
- Make primary row actions more discoverable and keyboard-accessible, and offer actionable empty-state options when no rows match filters.

### Description
- Added reusable event-type badge helpers `ops_event_type_badge` and `branch_event_type_badge` and a `branch_status_badge` to `app/helpers/ops/application_helper.rb` and `app/helpers/branch/application_helper.rb` to render text + color badges for event types and statuses.
- Updated `app/views/ops/operational_events/index.html.erb` to use a sticky header (`thead` with `sticky top-0 z-10`), move `Event id` and `Created` earlier, render status and event-type badges, make the detail link visually stronger and keyboard-focusable, and add empty-state actions (`Clear filters`, `Try broader date range`).
- Updated `app/views/branch/operational_events/index.html.erb` to wrap tables with horizontal scroll, add sticky headers, prioritize identifier/timestamp columns, use the new badges, add focus/hover row affordances, and include empty-state actions for clearing filters and broadening the date range.
- Refined the Customer 360 contact-audit table in `app/views/branch/customers/show.html.erb` by adding a leading `When` timestamp column, styling the `Action` as a small badge for scanability, and enabling a sticky header for long lists.

### Testing
- Attempted to run helper tests with `bin/rails test test/helpers/ops test/helpers/branch`, but the environment lacks Ruby (`/usr/bin/env: ‘ruby’: No such file or directory`) so tests could not be executed here.
- No other automated test runs were performed in this environment; changes were validated by static inspection of the updated views and helpers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f41b365078832c809e94abd6b75fdf)