### PR TITLE
Improve internal workspace accessibility and navigation semantics

### DIFF
--- a/app/views/branch/account_holds/index.html.erb
+++ b/app/views/branch/account_holds/index.html.erb
@@ -6,7 +6,7 @@
     <h1 class="text-3xl font-semibold">Account holds</h1>
     <p class="mt-2 text-slate-600">Account <%= @account.account_number %></p>
   </div>
-  <nav class="flex flex-wrap gap-2 text-sm">
+  <nav class="flex flex-wrap gap-2 text-sm" aria-label="Account hold actions">
     <%= link_to "Back to account", branch_servicing_deposit_account_path(@account, customer_return_params), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
     <% if can_place_servicing_hold? %>
       <%= link_to "Place hold", branch_new_account_hold_path(@account), class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>

--- a/app/views/branch/cash/index.html.erb
+++ b/app/views/branch/cash/index.html.erb
@@ -5,7 +5,7 @@
     <h1 class="text-3xl font-semibold">Cash position</h1>
     <p class="mt-2 text-slate-600">Branch vault and teller drawer custody balances.</p>
   </div>
-  <nav class="flex gap-2 text-sm">
+  <nav class="flex gap-2 text-sm" aria-label="Cash actions">
     <%= link_to "Transfer cash", branch_new_cash_transfer_path, class: "rounded bg-slate-900 px-3 py-2 font-medium text-white" %>
     <%= link_to "Receive shipment", branch_new_external_cash_shipment_path, class: "rounded border border-slate-300 px-3 py-2 font-medium text-slate-700" %>
     <%= link_to "Record count", branch_new_cash_count_path, class: "rounded border border-slate-300 px-3 py-2 font-medium text-slate-700" %>

--- a/app/views/branch/customers/show.html.erb
+++ b/app/views/branch/customers/show.html.erb
@@ -6,7 +6,7 @@
     <h1 class="text-3xl font-semibold"><%= @party.name %></h1>
     <p class="mt-2 text-slate-600">Customer 360 for party #<%= @party.id %>.</p>
   </div>
-  <nav class="flex flex-wrap gap-2 text-sm">
+  <nav class="flex flex-wrap gap-2 text-sm" aria-label="Customer actions">
     <%= link_to "Back to search", branch_customers_path(customer_return_params), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
     <%= link_to "Open account", new_branch_deposit_account_path(party_record_id: @party.id), class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
     <% if can_update_party_contact? %>

--- a/app/views/branch/operational_events/index.html.erb
+++ b/app/views/branch/operational_events/index.html.erb
@@ -5,7 +5,7 @@
     <h1 class="text-3xl font-semibold">Branch operational events</h1>
     <p class="mt-2 text-slate-600">Search recent teller-facing events and post pending events.</p>
   </div>
-  <nav class="flex flex-wrap gap-2 text-sm">
+  <nav class="flex flex-wrap gap-2 text-sm" aria-label="Operational event actions">
     <%= link_to "Place hold", new_branch_hold_path, class: "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 shadow-sm" %>
     <%= link_to "Release hold", release_branch_holds_path, class: "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 shadow-sm" %>
     <% if current_operator.supervisor? %>

--- a/app/views/branch/servicing_deposit_accounts/show.html.erb
+++ b/app/views/branch/servicing_deposit_accounts/show.html.erb
@@ -6,7 +6,7 @@
     <h1 class="text-3xl font-semibold">Account <%= @account.account_number %></h1>
     <p class="mt-2 text-slate-600"><%= @profile.product.product_code %> · <%= @profile.product.name %></p>
   </div>
-  <nav class="flex flex-wrap gap-2 text-sm">
+  <nav class="flex flex-wrap gap-2 text-sm" aria-label="Account actions">
     <%= link_to "Find customer", branch_customers_path(customer_return_params), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
     <% if can_manage_authorized_signers? %>
       <%= link_to "Add authorized signer", branch_new_account_authorized_signer_path(@account), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>

--- a/app/views/branch/shared/_account_relationship_table.html.erb
+++ b/app/views/branch/shared/_account_relationship_table.html.erb
@@ -45,13 +45,13 @@
           <td class="px-5 py-4"><%= branch_date(row.relationship.ended_on) %></td>
           <% if local_assigns.fetch(:show_actions, false) %>
             <td class="px-5 py-4">
-              <%= link_to "Service account", branch_servicing_deposit_account_path(row.account, customer_context_params), class: "rounded bg-slate-900 px-3 py-1.5 font-medium text-white" %>
+              <%= link_to "Service account", branch_servicing_deposit_account_path(row.account, customer_context_params), class: "rounded bg-slate-900 px-3 py-1.5 font-medium text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
             </td>
           <% end %>
           <% if local_assigns.fetch(:can_end_authorized_signers, false) %>
             <td class="px-5 py-4">
               <% if row.relationship.role == Accounts::Models::DepositAccountParty::ROLE_AUTHORIZED_SIGNER && row.relationship.status == Accounts::Models::DepositAccountParty::STATUS_ACTIVE && row.relationship.ended_on.nil? %>
-                <%= link_to "End signer", branch_end_account_authorized_signer_path(row.account, row.relationship), class: "rounded border border-slate-300 px-3 py-1.5 font-medium text-slate-700" %>
+                <%= link_to "End signer", branch_end_account_authorized_signer_path(row.account, row.relationship), class: "rounded border border-slate-300 px-3 py-1.5 font-medium text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
               <% else %>
                 <span class="text-slate-500">No action</span>
               <% end %>

--- a/app/views/branch/shared/_event_table.html.erb
+++ b/app/views/branch/shared/_event_table.html.erb
@@ -21,9 +21,9 @@
           <td class="px-5 py-4 text-right"><%= branch_money(event.amount_minor_units) %> <%= event.currency %></td>
           <td class="px-5 py-4">
             <% if local_assigns.fetch(:can_waive_fees, false) && event.event_type == "fee.assessed" && event.status == Core::OperationalEvents::Models::OperationalEvent::STATUS_POSTED %>
-              <%= link_to "Waive fee", branch_new_fee_waiver_path(event.source_account_id, fee_assessment_event_id: event.id), class: "rounded border border-slate-300 px-3 py-1.5 font-medium text-slate-700" %>
+              <%= link_to "Waive fee", branch_new_fee_waiver_path(event.source_account_id, fee_assessment_event_id: event.id), class: "rounded border border-slate-300 px-3 py-1.5 font-medium text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
             <% elsif local_assigns.fetch(:can_reverse_events, false) && event.status == Core::OperationalEvents::Models::OperationalEvent::STATUS_POSTED %>
-              <%= link_to "Reverse", new_branch_reversal_path(original_operational_event_id: event.id), class: "rounded border border-slate-300 px-3 py-1.5 font-medium text-slate-700" %>
+              <%= link_to "Reverse", new_branch_reversal_path(original_operational_event_id: event.id), class: "rounded border border-slate-300 px-3 py-1.5 font-medium text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
             <% else %>
               <span class="text-slate-500">View only</span>
             <% end %>

--- a/app/views/branch/shared/_hold_table.html.erb
+++ b/app/views/branch/shared/_hold_table.html.erb
@@ -37,7 +37,7 @@
           </td>
           <td class="px-5 py-4">
             <% if local_assigns.fetch(:can_release, false) && hold.status == Accounts::Models::Hold::STATUS_ACTIVE %>
-              <%= link_to "Release", branch_release_account_hold_path(hold.deposit_account_id, hold.id), class: "rounded border border-slate-300 px-3 py-1.5 font-medium text-slate-700" %>
+              <%= link_to "Release", branch_release_account_hold_path(hold.deposit_account_id, hold.id), class: "rounded border border-slate-300 px-3 py-1.5 font-medium text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
             <% else %>
               <span class="text-slate-500">No action</span>
             <% end %>

--- a/app/views/branch/shared/_surface_nav.html.erb
+++ b/app/views/branch/shared/_surface_nav.html.erb
@@ -1,4 +1,4 @@
-<nav class="mb-6 flex flex-wrap gap-2 border-b border-slate-200 pb-4 text-sm" aria-label="Branch surfaces" data-surface-nav>
+<nav class="mb-6 flex flex-wrap gap-2 border-b border-slate-200 pb-4 text-sm" aria-label="Branch surface navigation" data-surface-nav>
   <% tab_class = "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-800 shadow-sm hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2 aria-[current=true]:border-slate-900 aria-[current=true]:bg-slate-900 aria-[current=true]:text-white aria-[current=true]:hover:bg-slate-900" %>
 
   <%= link_to "CSR", "#{branch_path}#csr", class: tab_class, data: { surface_tab: "csr" } %>

--- a/app/views/branch/shared/_transaction_form.html.erb
+++ b/app/views/branch/shared/_transaction_form.html.erb
@@ -23,7 +23,7 @@
   <%= form_with url: path, scope: scope, method: :post, class: "grid gap-4 md:grid-cols-2" do |form| %>
     <% account_fields.each do |field_name, label, account_number_field| %>
       <div>
-        <%= form.label field_name, label, class: "block text-sm font-medium text-slate-700" %>
+        <%= form.label field_name, label, class: "block text-sm font-medium text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
         <%= form.text_field field_name, value: normalized_form_data[field_name.to_s], class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
         <p class="mt-1 text-xs text-slate-500">Enter an internal numeric ID (example: <code>123</code>).</p>
         <% if (message = inline_error_for.call(field_name)).present? %>
@@ -32,7 +32,7 @@
       </div>
       <% if account_number_field.present? %>
         <div>
-          <%= form.label account_number_field, "#{label.sub(/ id\z/i, "")} number", class: "block text-sm font-medium text-slate-700" %>
+          <%= form.label account_number_field, "#{label.sub(/ id\z/i, "")} number", class: "block text-sm font-medium text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
           <%= form.text_field account_number_field, value: normalized_form_data[account_number_field.to_s], class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
           <p class="mt-1 text-xs text-slate-500">Use either ID or account number. Keep leading zeros when applicable.</p>
           <% if (message = inline_error_for.call(account_number_field)).present? %>
@@ -42,7 +42,7 @@
       <% end %>
     <% end %>
     <div>
-      <%= form.label :amount_minor_units, "Amount minor units", class: "block text-sm font-medium text-slate-700" %>
+      <%= form.label :amount_minor_units, "Amount minor units", class: "block text-sm font-medium text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
       <%= form.text_field :amount_minor_units, value: normalized_form_data["amount_minor_units"], class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
       <p class="mt-1 text-xs text-slate-500">Enter whole-number minor units (example: <code>1050</code> = $10.50 USD).</p>
       <% if (message = inline_error_for.call(:amount_minor_units)).present? %>
@@ -50,7 +50,7 @@
       <% end %>
     </div>
     <div>
-      <%= form.label :currency, class: "block text-sm font-medium text-slate-700" %>
+      <%= form.label :currency, class: "block text-sm font-medium text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
       <%= form.text_field :currency, value: normalized_form_data["currency"] || "USD", class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
       <p class="mt-1 text-xs text-slate-500">Use ISO currency code (example: <code>USD</code>).</p>
       <% if (message = inline_error_for.call(:currency)).present? %>
@@ -59,7 +59,7 @@
     </div>
     <% if include_teller_session %>
       <div>
-        <%= form.label :teller_session_id, "Open teller session id", class: "block text-sm font-medium text-slate-700" %>
+        <%= form.label :teller_session_id, "Open teller session id", class: "block text-sm font-medium text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
         <%= form.text_field :teller_session_id, value: normalized_form_data["teller_session_id"], class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
         <p class="mt-1 text-xs text-slate-500">Required for teller cash flows when open-session checks are enabled.</p>
         <% if (message = inline_error_for.call(:teller_session_id)).present? %>
@@ -68,7 +68,7 @@
       </div>
     <% end %>
     <div class="md:col-span-2">
-      <%= form.label :idempotency_key, class: "block text-sm font-medium text-slate-700" %>
+      <%= form.label :idempotency_key, class: "block text-sm font-medium text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
       <%= form.text_field :idempotency_key, value: normalized_form_data["idempotency_key"], class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
       <p class="mt-1 text-xs text-slate-500">Reference identifier for safe retries (example: <code>branch-deposit-2026-05-01-001</code>).</p>
       <% if (message = inline_error_for.call(:idempotency_key)).present? %>
@@ -83,7 +83,7 @@
       <p class="mt-1 text-xs text-slate-500">Posting eligibility, account restrictions, and balance guards are rechecked by the command on submit.</p>
     </div>
     <div class="md:col-span-2">
-      <%= form.submit submit_label, class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+      <%= form.submit submit_label, class: "rounded bg-slate-900 px-4 py-2 font-medium text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
     </div>
   <% end %>
 </section>

--- a/app/views/branch/shared/_transaction_result.html.erb
+++ b/app/views/branch/shared/_transaction_result.html.erb
@@ -32,29 +32,29 @@
 
     <% if event.status == Core::OperationalEvents::Models::OperationalEvent::STATUS_PENDING %>
       <div class="mt-6 flex flex-wrap gap-3">
-        <%= button_to "Post event", branch_operational_event_post_path(event), method: :post, class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
-        <%= link_to "Event detail", branch_operational_event_path(event), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
-        <%= link_to "Trace receipt", branch_operational_event_receipt_path(event), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+        <%= button_to "Post event", branch_operational_event_post_path(event), method: :post, class: "rounded bg-slate-900 px-4 py-2 font-medium text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
+        <%= link_to "Event detail", branch_operational_event_path(event), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
+        <%= link_to "Trace receipt", branch_operational_event_receipt_path(event), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
         <% if event.source_account_id.present? %>
-          <%= link_to "Source account", branch_servicing_deposit_account_path(event.source_account_id), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
-          <%= link_to "Source activity", branch_account_activity_path(event.source_account_id), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+          <%= link_to "Source account", branch_servicing_deposit_account_path(event.source_account_id), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
+          <%= link_to "Source activity", branch_account_activity_path(event.source_account_id), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
         <% end %>
         <% if event.destination_account_id.present? %>
-          <%= link_to "Destination account", branch_servicing_deposit_account_path(event.destination_account_id), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
-          <%= link_to "Destination activity", branch_account_activity_path(event.destination_account_id), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+          <%= link_to "Destination account", branch_servicing_deposit_account_path(event.destination_account_id), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
+          <%= link_to "Destination activity", branch_account_activity_path(event.destination_account_id), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
         <% end %>
       </div>
     <% else %>
       <div class="mt-6 flex flex-wrap gap-3">
-        <%= link_to "Event detail", branch_operational_event_path(event), class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
-        <%= link_to "Trace receipt", branch_operational_event_receipt_path(event), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+        <%= link_to "Event detail", branch_operational_event_path(event), class: "rounded bg-slate-900 px-4 py-2 font-medium text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
+        <%= link_to "Trace receipt", branch_operational_event_receipt_path(event), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
         <% if event.source_account_id.present? %>
-          <%= link_to "Source account", branch_servicing_deposit_account_path(event.source_account_id), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
-          <%= link_to "Source activity", branch_account_activity_path(event.source_account_id), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+          <%= link_to "Source account", branch_servicing_deposit_account_path(event.source_account_id), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
+          <%= link_to "Source activity", branch_account_activity_path(event.source_account_id), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
         <% end %>
         <% if event.destination_account_id.present? %>
-          <%= link_to "Destination account", branch_servicing_deposit_account_path(event.destination_account_id), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
-          <%= link_to "Destination activity", branch_account_activity_path(event.destination_account_id), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+          <%= link_to "Destination account", branch_servicing_deposit_account_path(event.destination_account_id), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
+          <%= link_to "Destination activity", branch_account_activity_path(event.destination_account_id), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -10,6 +10,7 @@
   </head>
 
   <body class="bg-slate-100 text-slate-950">
+    <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded focus:bg-slate-900 focus:px-4 focus:py-2 focus:text-white">Skip to main content</a>
     <header class="border-b border-slate-200 bg-white">
       <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
         <div>
@@ -22,7 +23,7 @@
         <% if respond_to?(:current_operator, true) && current_operator %>
           <% nav_link_base = "rounded-md px-2.5 py-1.5 font-medium text-slate-700 hover:bg-slate-100 hover:text-slate-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
           <% nav_link_active = "bg-slate-900 text-white hover:bg-slate-900 hover:text-white" %>
-          <nav class="flex items-center gap-2 text-sm" aria-label="Primary">
+          <nav class="flex items-center gap-2 text-sm" aria-label="Global primary navigation">
             <% home_active = current_page?(internal_path) %>
             <%= link_to "Home", internal_path, class: [nav_link_base, (nav_link_active if home_active)].compact.join(" "), aria: { current: ("page" if home_active) } %>
             <% if branch_access? %>
@@ -38,21 +39,21 @@
               <%= link_to "Admin", admin_path, class: [nav_link_base, (nav_link_active if admin_active)].compact.join(" "), aria: { current: ("page" if admin_active) } %>
             <% end %>
             <span class="text-slate-500"><%= current_operator.display_name.presence || current_operator.role.titleize %></span>
-            <%= button_to "Sign out", logout_path, method: :delete, class: "rounded bg-slate-900 px-3 py-1.5 text-white" %>
+            <%= button_to "Sign out", logout_path, method: :delete, class: "rounded bg-slate-900 px-3 py-1.5 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2" %>
           </nav>
         <% end %>
       </div>
     </header>
 
-    <main class="mx-auto max-w-6xl px-6 py-8">
+    <main id="main-content" class="mx-auto max-w-6xl px-6 py-8" tabindex="-1">
       <% if controller_path.start_with?("branch/") %>
         <%= render "branch/shared/surface_nav" %>
       <% end %>
       <% if notice.present? %>
-        <div class="mb-4 rounded border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900"><%= notice %></div>
+        <div role="status" aria-live="polite" class="mb-4 rounded border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900"><%= notice %></div>
       <% end %>
       <% if alert.present? %>
-        <div class="mb-4 rounded border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"><%= alert %></div>
+        <div role="alert" aria-live="assertive" class="mb-4 rounded border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"><%= alert %></div>
       <% end %>
 
       <%= yield %>


### PR DESCRIPTION
### Motivation
- Improve keyboard and screen-reader accessibility for the internal workspaces by adding a skip link and explicit main target so keyboard users can jump to content quickly.
- Ensure flash messages announce to assistive tech by providing appropriate live-region semantics for notices and alerts.
- Make interactive controls visibly focusable for keyboard users by adding consistent `focus-visible` indicators to nav links, action chips and form controls.
- Clarify navigation landmarks with unique `aria-label` values to improve landmark discovery and avoid duplicate labels.

### Description
- Add a “Skip to main content” link and target the main container with `id="main-content"` and `tabindex="-1"` so skip targets are focusable and programmatically reachable (`app/views/layouts/internal.html.erb`).
- Add live-region semantics to flash containers so notices use `role="status"` + `aria-live="polite"` and alerts use `role="alert"` + `aria-live="assertive"` (`app/views/layouts/internal.html.erb`).
- Add visible keyboard focus styles (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-700 focus-visible:ring-offset-2`) to the sign-out control, action chips, control labels and primary form submit buttons so interactive elements show a consistent focus ring (`app/views/branch/shared/*`, `app/views/branch/*`).
- Disambiguate landmark labels by adding/clarifying `aria-label` values for the global primary nav and branch-level nav regions (e.g. `aria-label="Global primary navigation"`, `aria-label="Branch surface navigation"`, and page-specific action navs like `aria-label="Account actions"`) across branch views and the surface nav partial (`app/views/layouts/internal.html.erb`, `app/views/branch/shared/_surface_nav.html.erb`, and several `app/views/branch/*` files).
- Reviewed heading structure on affected dashboard/detail pages and preserved the `h1 -> h2 -> h3` progression where applicable (no heading-level regressions introduced).

### Testing
- Attempted to run `bin/rails zeitwerk:check` to validate autoloading, which failed in this environment with `/usr/bin/env: 'ruby': No such file or directory` so runtime checks could not be executed here.
- No other automated test runs were possible in the current environment; changes were limited to view templates and sanity-checked via static inspection and diffs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f41cc93ad8832cb91223330f894752)