### PR TITLE
Add deterministic deposit account numbers

### DIFF
--- a/app/controllers/branch/servicing_deposit_accounts_controller.rb
+++ b/app/controllers/branch/servicing_deposit_accounts_controller.rb
@@ -3,6 +3,9 @@
 module Branch
   class ServicingDepositAccountsController < ApplicationController
     RECENT_ACTIVITY_DAYS = 30
+    RECENT_ACTIVITY_LIMIT = 10
+    OPERATIONAL_EVENTS_FETCH_LIMIT = 50
+    OPERATIONAL_EVENTS_DISPLAY_LIMIT = 10
 
     def show
       @profile = Accounts::Queries::DepositAccountProfile.call(deposit_account_id: params[:id])
@@ -15,12 +18,8 @@ module Branch
         period_start_on: activity_start_on,
         period_end_on: activity_end_on
       )
-      @events = Core::OperationalEvents::Queries::ListOperationalEvents.call(
-        business_date_from: activity_start_on,
-        business_date_to: activity_end_on,
-        source_account_id: @account.id,
-        limit: 10
-      )
+      @recent_activity_line_items = recent_activity_line_items
+      @events = account_operational_events(excluding_event_ids: recent_activity_event_ids)
       @can_place_holds = can_place_servicing_hold?
       @can_release_holds = can_release_servicing_hold?
       @can_waive_fees = can_waive_fee?
@@ -37,6 +36,36 @@ module Branch
 
     def activity_start_on
       @activity_start_on ||= activity_end_on - RECENT_ACTIVITY_DAYS
+    end
+
+    def recent_activity_line_items
+      @activity.line_items.select { |line| line.fetch(:affects_ledger) }.take(RECENT_ACTIVITY_LIMIT)
+    end
+
+    def recent_activity_event_ids
+      @recent_activity_line_items.filter_map { |line| line[:operational_event_id] }
+    end
+
+    def account_operational_events(excluding_event_ids:)
+      source_events = list_operational_events(source_account_id: @account.id)
+      destination_events = list_operational_events(destination_account_id: @account.id)
+      rows = (source_events[:rows] + destination_events[:rows])
+        .uniq(&:id)
+        .sort_by(&:id)
+        .reject { |event| excluding_event_ids.include?(event.id) }
+        .take(OPERATIONAL_EVENTS_DISPLAY_LIMIT)
+
+      source_events.merge(rows: rows)
+    end
+
+    def list_operational_events(source_account_id: nil, destination_account_id: nil)
+      Core::OperationalEvents::Queries::ListOperationalEvents.call(
+        business_date_from: activity_start_on,
+        business_date_to: activity_end_on,
+        source_account_id: source_account_id,
+        destination_account_id: destination_account_id,
+        limit: OPERATIONAL_EVENTS_FETCH_LIMIT
+      )
     end
   end
 end

--- a/app/controllers/ops/ach_receipt_ingestions_controller.rb
+++ b/app/controllers/ops/ach_receipt_ingestions_controller.rb
@@ -10,7 +10,7 @@ module Ops
           items: [
             {
               item_id: "trace-091000019-000001",
-              account_number: "001234567890",
+              account_number: "126040000013",
               amount_minor_units: 12_500,
               currency: "USD"
             }

--- a/app/domains/accounts/commands/open_account.rb
+++ b/app/domains/accounts/commands/open_account.rb
@@ -37,7 +37,7 @@ module Accounts
 
         Models::DepositAccount.transaction do
           account = Models::DepositAccount.create!(
-            account_number: generate_account_number,
+            account_number: Accounts::Services::DepositAccountNumberGenerator.call(on_date: on_date),
             currency: deposit_product.currency,
             status: Models::DepositAccount::STATUS_OPEN,
             deposit_product: deposit_product,
@@ -85,11 +85,6 @@ module Accounts
         raise ProductNotFound, e.message
       end
       private_class_method :resolve_deposit_product!
-
-      def self.generate_account_number
-        "DA#{SecureRandom.hex(8).upcase}"
-      end
-      private_class_method :generate_account_number
     end
   end
 end

--- a/app/domains/accounts/models/deposit_account.rb
+++ b/app/domains/accounts/models/deposit_account.rb
@@ -18,7 +18,9 @@ module Accounts
                                     inverse_of: :deposit_account,
                                     dependent: :restrict_with_exception
 
-      validates :account_number, presence: true, uniqueness: true
+      validates :account_number, presence: true, uniqueness: true,
+        format: { with: /\A1\d{11}\z/, message: "must be a 12-digit deposit account number" }
+      validate :account_number_luhn_check_digit
       validates :currency, presence: true
       validates :status, presence: true, inclusion: { in: [ STATUS_OPEN, STATUS_CLOSED ] }
       validates :product_code, presence: true
@@ -30,6 +32,13 @@ module Accounts
         return if deposit_product.nil?
 
         errors.add(:product_code, "must match deposit_product.product_code") if product_code != deposit_product.product_code
+      end
+
+      def account_number_luhn_check_digit
+        return if account_number.blank?
+        return if Accounts::Services::DepositAccountNumberGenerator.valid_luhn?(account_number)
+
+        errors.add(:account_number, "has an invalid check digit")
       end
     end
   end

--- a/app/domains/accounts/models/deposit_account_number_allocation.rb
+++ b/app/domains/accounts/models/deposit_account_number_allocation.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Models
+    class DepositAccountNumberAllocation < ApplicationRecord
+      self.table_name = "deposit_account_number_allocations"
+
+      GLOBAL_KEY = "global"
+      MAX_SEQUENCE = 999_999
+
+      validates :allocation_key, presence: true, uniqueness: true
+      validates :last_sequence, numericality: {
+        only_integer: true,
+        greater_than_or_equal_to: 0,
+        less_than_or_equal_to: MAX_SEQUENCE
+      }
+    end
+  end
+end

--- a/app/domains/accounts/services/deposit_account_number_generator.rb
+++ b/app/domains/accounts/services/deposit_account_number_generator.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Services
+    class DepositAccountNumberGenerator
+      class SequenceExhausted < StandardError; end
+
+      def self.call(on_date:)
+        new(on_date: on_date).call
+      end
+
+      def self.valid_luhn?(account_number)
+        normalized = account_number.to_s
+        return false unless normalized.match?(/\A1\d{11}\z/)
+
+        normalized.reverse.chars.each_with_index.sum do |char, index|
+          digit = char.to_i
+          if index.odd?
+            doubled = digit * 2
+            doubled > 9 ? doubled - 9 : doubled
+          else
+            digit
+          end
+        end % 10 == 0
+      end
+
+      def self.check_digit(base)
+        sum = base.to_s.reverse.chars.each_with_index.sum do |char, index|
+          digit = char.to_i
+          if index.even?
+            doubled = digit * 2
+            doubled > 9 ? doubled - 9 : doubled
+          else
+            digit
+          end
+        end
+
+        (10 - (sum % 10)) % 10
+      end
+
+      def initialize(on_date:)
+        @on_date = on_date.to_date
+      end
+
+      def call
+        Models::DepositAccountNumberAllocation.transaction do
+          allocation = find_or_create_allocation!
+          allocation.lock!
+          sequence = allocation.last_sequence + 1
+          if sequence > Models::DepositAccountNumberAllocation::MAX_SEQUENCE
+            raise SequenceExhausted, "deposit account number sequence exhausted"
+          end
+
+          allocation.update!(last_sequence: sequence)
+          account_number_for(sequence)
+        end
+      end
+
+      private
+
+      attr_reader :on_date
+
+      def find_or_create_allocation!
+        Models::DepositAccountNumberAllocation.find_by(allocation_key: Models::DepositAccountNumberAllocation::GLOBAL_KEY) ||
+          Models::DepositAccountNumberAllocation.create!(allocation_key: Models::DepositAccountNumberAllocation::GLOBAL_KEY)
+      rescue ActiveRecord::RecordNotUnique
+        retry
+      end
+
+      def account_number_for(sequence)
+        base = "1#{on_date.strftime("%y%m")}#{sequence.to_s.rjust(6, "0")}"
+        "#{base}#{self.class.check_digit(base)}"
+      end
+    end
+  end
+end

--- a/app/views/branch/servicing_deposit_accounts/show.html.erb
+++ b/app/views/branch/servicing_deposit_accounts/show.html.erb
@@ -58,42 +58,40 @@
   </div>
 </section>
 
-<section class="mt-6 grid gap-4 lg:grid-cols-2">
-  <div class="rounded border border-slate-200 bg-white p-6 shadow-sm">
-    <h2 class="text-xl font-semibold">Current parties</h2>
-    <p class="mt-1 text-sm text-slate-500">As of <%= branch_date(@account_relationships.as_of) %></p>
-    <div class="mt-4 overflow-hidden rounded border border-slate-200">
-      <%= render "branch/shared/account_relationship_table",
-        rows: @account_relationships.current_rows,
-        show_party: true,
-        can_end_authorized_signers: can_manage_authorized_signers?,
-        empty_message: "No current account parties." %>
-    </div>
-    <% if @account_relationships.historical_rows.any? %>
-      <details class="mt-4">
-        <summary class="cursor-pointer text-sm font-medium text-slate-700">Historical parties (<%= @account_relationships.historical_rows.size %>)</summary>
-        <div class="mt-3 overflow-hidden rounded border border-slate-200">
-          <%= render "branch/shared/account_relationship_table",
-            rows: @account_relationships.historical_rows,
-            show_party: true,
-            empty_message: "No historical account parties." %>
-        </div>
-      </details>
-    <% end %>
+<section class="mt-6 rounded border border-slate-200 bg-white p-6 shadow-sm">
+  <h2 class="text-xl font-semibold">Current parties</h2>
+  <p class="mt-1 text-sm text-slate-500">As of <%= branch_date(@account_relationships.as_of) %></p>
+  <div class="mt-4 overflow-hidden rounded border border-slate-200">
+    <%= render "branch/shared/account_relationship_table",
+      rows: @account_relationships.current_rows,
+      show_party: true,
+      can_end_authorized_signers: can_manage_authorized_signers?,
+      empty_message: "No current account parties." %>
   </div>
+  <% if @account_relationships.historical_rows.any? %>
+    <details class="mt-4">
+      <summary class="cursor-pointer text-sm font-medium text-slate-700">Historical parties (<%= @account_relationships.historical_rows.size %>)</summary>
+      <div class="mt-3 overflow-hidden rounded border border-slate-200">
+        <%= render "branch/shared/account_relationship_table",
+          rows: @account_relationships.historical_rows,
+          show_party: true,
+          empty_message: "No historical account parties." %>
+      </div>
+    </details>
+  <% end %>
+</section>
 
-  <div class="rounded border border-slate-200 bg-white p-6 shadow-sm">
-    <h2 class="text-xl font-semibold">Product</h2>
-    <dl class="mt-4 grid gap-4 text-sm md:grid-cols-2">
-      <div><dt class="font-medium text-slate-500">Code</dt><dd><%= @profile.product.product_code %></dd></div>
-      <div><dt class="font-medium text-slate-500">Name</dt><dd><%= @profile.product.name %></dd></div>
-      <div><dt class="font-medium text-slate-500">Currency</dt><dd><%= @profile.product.currency %></dd></div>
-      <div><dt class="font-medium text-slate-500">Business date</dt><dd><%= branch_date(@profile.current_business_date) %></dd></div>
-    </dl>
-    <% if admin_access? %>
-      <%= link_to "Admin product detail", admin_deposit_product_path(@profile.product), class: "mt-4 inline-block rounded border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700" %>
-    <% end %>
-  </div>
+<section class="mt-6 rounded border border-slate-200 bg-white p-6 shadow-sm">
+  <h2 class="text-xl font-semibold">Product</h2>
+  <dl class="mt-4 grid gap-4 text-sm md:grid-cols-2">
+    <div><dt class="font-medium text-slate-500">Code</dt><dd><%= @profile.product.product_code %></dd></div>
+    <div><dt class="font-medium text-slate-500">Name</dt><dd><%= @profile.product.name %></dd></div>
+    <div><dt class="font-medium text-slate-500">Currency</dt><dd><%= @profile.product.currency %></dd></div>
+    <div><dt class="font-medium text-slate-500">Business date</dt><dd><%= branch_date(@profile.current_business_date) %></dd></div>
+  </dl>
+  <% if admin_access? %>
+    <%= link_to "Admin product detail", admin_deposit_product_path(@profile.product), class: "mt-4 inline-block rounded border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700" %>
+  <% end %>
 </section>
 
 <section class="mt-6 overflow-hidden rounded border border-slate-200 bg-white shadow-sm">

--- a/app/views/branch/servicing_deposit_accounts/show.html.erb
+++ b/app/views/branch/servicing_deposit_accounts/show.html.erb
@@ -184,7 +184,7 @@
     <h2 class="text-xl font-semibold">Recent activity</h2>
     <%= link_to "Full activity", branch_account_activity_path(@account), class: "text-sm font-medium text-slate-700" %>
   </div>
-  <%= render "branch/shared/activity_table", line_items: @activity.line_items.take(10) %>
+  <%= render "branch/shared/activity_table", line_items: @recent_activity_line_items %>
 </section>
 
 <section class="mt-6 overflow-hidden rounded border border-slate-200 bg-white shadow-sm">

--- a/db/migrate/20260502160000_create_deposit_account_number_allocations.rb
+++ b/db/migrate/20260502160000_create_deposit_account_number_allocations.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+class CreateDepositAccountNumberAllocations < ActiveRecord::Migration[8.1]
+  GLOBAL_KEY = "global"
+  MAX_SEQUENCE = 999_999
+
+  def up
+    create_table :deposit_account_number_allocations do |t|
+      t.string :allocation_key, null: false
+      t.integer :last_sequence, null: false, default: 0
+      t.timestamps
+    end
+
+    add_index :deposit_account_number_allocations, :allocation_key, unique: true
+    add_check_constraint :deposit_account_number_allocations,
+      "last_sequence >= 0 AND last_sequence <= #{MAX_SEQUENCE}",
+      name: "chk_deposit_account_number_allocations_sequence_range"
+
+    backfill_deposit_account_numbers!
+
+    add_check_constraint :deposit_accounts,
+      "account_number ~ '^1[0-9]{11}$'",
+      name: "chk_deposit_accounts_account_number_12_digits"
+  end
+
+  def down
+    remove_check_constraint :deposit_accounts, name: "chk_deposit_accounts_account_number_12_digits"
+    drop_table :deposit_account_number_allocations
+  end
+
+  private
+
+  def backfill_deposit_account_numbers!
+    sequence = 0
+
+    select_all("SELECT id, created_at FROM deposit_accounts ORDER BY id").each do |row|
+      sequence += 1
+      raise "deposit account number sequence exhausted" if sequence > MAX_SEQUENCE
+
+      created_on = row.fetch("created_at")&.to_date || Date.current
+      account_number = account_number_for(on_date: created_on, sequence: sequence)
+      execute <<~SQL.squish
+        UPDATE deposit_accounts
+        SET account_number = #{quote(account_number)}
+        WHERE id = #{row.fetch("id").to_i}
+      SQL
+    end
+
+    execute <<~SQL.squish
+      INSERT INTO deposit_account_number_allocations (allocation_key, last_sequence, created_at, updated_at)
+      VALUES (#{quote(GLOBAL_KEY)}, #{sequence}, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+    SQL
+  end
+
+  def account_number_for(on_date:, sequence:)
+    base = "1#{on_date.strftime("%y%m")}#{sequence.to_s.rjust(6, "0")}"
+    "#{base}#{luhn_check_digit(base)}"
+  end
+
+  def luhn_check_digit(base)
+    sum = base.reverse.chars.each_with_index.sum do |char, index|
+      digit = char.to_i
+      if index.even?
+        doubled = digit * 2
+        doubled > 9 ? doubled - 9 : doubled
+      else
+        digit
+      end
+    end
+
+    (10 - (sum % 10)) % 10
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -530,6 +530,39 @@ ALTER SEQUENCE public.core_business_date_settings_id_seq OWNED BY public.core_bu
 
 
 --
+-- Name: deposit_account_number_allocations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.deposit_account_number_allocations (
+    id bigint NOT NULL,
+    allocation_key character varying NOT NULL,
+    last_sequence integer DEFAULT 0 NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    CONSTRAINT chk_deposit_account_number_allocations_sequence_range CHECK (((last_sequence >= 0) AND (last_sequence <= 999999)))
+);
+
+
+--
+-- Name: deposit_account_number_allocations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.deposit_account_number_allocations_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: deposit_account_number_allocations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.deposit_account_number_allocations_id_seq OWNED BY public.deposit_account_number_allocations.id;
+
+
+--
 -- Name: deposit_account_parties; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -621,7 +654,8 @@ CREATE TABLE public.deposit_accounts (
     product_code character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    deposit_product_id bigint NOT NULL
+    deposit_product_id bigint NOT NULL,
+    CONSTRAINT chk_deposit_accounts_account_number_12_digits CHECK (((account_number)::text ~ '^1[0-9]{11}$'::text))
 );
 
 
@@ -1671,6 +1705,13 @@ ALTER TABLE ONLY public.core_business_date_settings ALTER COLUMN id SET DEFAULT 
 
 
 --
+-- Name: deposit_account_number_allocations id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.deposit_account_number_allocations ALTER COLUMN id SET DEFAULT nextval('public.deposit_account_number_allocations_id_seq'::regclass);
+
+
+--
 -- Name: deposit_account_parties id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1945,6 +1986,14 @@ ALTER TABLE ONLY public.core_business_date_close_events
 
 ALTER TABLE ONLY public.core_business_date_settings
     ADD CONSTRAINT core_business_date_settings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: deposit_account_number_allocations deposit_account_number_allocations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.deposit_account_number_allocations
+    ADD CONSTRAINT deposit_account_number_allocations_pkey PRIMARY KEY (id);
 
 
 --
@@ -2610,6 +2659,13 @@ CREATE UNIQUE INDEX index_core_business_date_close_events_on_closed_on ON public
 --
 
 CREATE UNIQUE INDEX index_dap_unique_open_active_per_account_party_role ON public.deposit_account_parties USING btree (deposit_account_id, party_record_id, role) WHERE (((status)::text = 'active'::text) AND (ended_on IS NULL));
+
+
+--
+-- Name: index_deposit_account_number_allocations_on_allocation_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_deposit_account_number_allocations_on_allocation_key ON public.deposit_account_number_allocations USING btree (allocation_key);
 
 
 --
@@ -3692,6 +3748,7 @@ ALTER TABLE ONLY public.operational_events
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260502160000'),
 ('20260430120000'),
 ('20260429223000'),
 ('20260429210200'),

--- a/docs/adr/0011-accounts-deposit-vertical-slice-mvp.md
+++ b/docs/adr/0011-accounts-deposit-vertical-slice-mvp.md
@@ -29,7 +29,7 @@ The **Accounts** module owns a new **`deposit_accounts`** table with at least:
 | Column            | Type     | Notes |
 | ----------------- | -------- | ----- |
 | `id`              | bigint   | PK |
-| `account_number`  | string   | NOT NULL, **UNIQUE** — institution-unique display/reference; generation strategy is implementation detail (tests may use random; production may use sequential or another allocator later). |
+| `account_number`  | string   | NOT NULL, **UNIQUE** — institution-unique 12-digit display/reference in the form `1YYMM######C`, where `######` is a global increasing sequence and `C` is a Luhn check digit. |
 | `currency`        | string   | NOT NULL, default **`USD`** (ADR-0008 single-currency MVP). |
 | `status`          | string   | NOT NULL — application enum for slice 1: **`open`**, **`closed`** (extend only via ADR/catalog when needed). |
 | `deposit_product_id` | bigint | NOT NULL, FK → **`deposit_products`** — Phase 2 narrow implementation ([ADR-0017](0017-deposit-products-fk-narrow-scope.md)). |
@@ -74,7 +74,7 @@ Per [ADR-0007 §2.8](0007-party-account-ownership.md), **`OpenAccount`** always 
 
 **Result:**
 
-1. One **`deposit_accounts`** row: `account_number` unique, `currency: "USD"`, `status: "open"`, **`deposit_product_id`** → seeded **`deposit_products`** row, `product_code: "slice1_demand_deposit"` (cache).
+1. One **`deposit_accounts`** row: `account_number` unique (for example `126040000013`), `currency: "USD"`, `status: "open"`, **`deposit_product_id`** → seeded **`deposit_products`** row, `product_code: "slice1_demand_deposit"` (cache).
 2. One or two **`deposit_account_parties`** rows: primary `party_record_id: 42`, `role: "owner"`, `status: "active"`, `effective_on: 2026-04-22`, `ended_on: NULL`; when joint is supplied, a second row with `role: "joint_owner"` and the same `effective_on` / `ended_on`.
 
 3. **`RecordEvent`** for `deposit.accepted` (with `source_account_id` set to the new **`deposit_accounts.id`**, channel, idempotency key, amount, currency) creates an **`operational_events`** row in **`pending`** status; **`PostEvent`** then moves it to **`posted`** with a balanced journal (1110 / 2110). Posting remains **account-scoped**; it does not branch on joint participation.

--- a/docs/adr/0028-ach-receipt-ingestion.md
+++ b/docs/adr/0028-ach-receipt-ingestion.md
@@ -76,7 +76,7 @@ Rules:
 
 ### 2.4 Account lookup
 
-ACH item account lookup uses exact `deposit_accounts.account_number`.
+ACH item account lookup uses exact `deposit_accounts.account_number`. Deposit account numbers are 12-digit strings in the Accounts-owned `1YYMM######C` format; ACH ingestion treats them as strings and must not coerce them to integers.
 
 Rules:
 
@@ -169,7 +169,7 @@ Input item:
   "file_id": "file-20260425-001",
   "batch_id": "batch-1",
   "item_id": "trace-091000019-000001",
-  "account_number": "DAABC123",
+  "account_number": "126040000013",
   "amount_minor_units": 12500,
   "currency": "USD"
 }

--- a/docs/samples/ach-receipt-sample.json
+++ b/docs/samples/ach-receipt-sample.json
@@ -6,13 +6,13 @@
       "items": [
         {
           "item_id": "trace-091000019-000001",
-          "account_number": "REPLACE_WITH_OPEN_ACCOUNT_NUMBER",
+          "account_number": "126040000013",
           "amount_minor_units": 12500,
           "currency": "USD"
         },
         {
           "item_id": "trace-091000019-000002",
-          "account_number": "REPLACE_WITH_OPEN_ACCOUNT_NUMBER",
+          "account_number": "126040000021",
           "amount_minor_units": 5000,
           "currency": "USD"
         }

--- a/test/domains/accounts/deposit_account_number_generator_test.rb
+++ b/test/domains/accounts/deposit_account_number_generator_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AccountsDepositAccountNumberGeneratorTest < ActiveSupport::TestCase
+  setup do
+    Accounts::Models::DepositAccountNumberAllocation.delete_all
+  end
+
+  test "generates 12 digit account number with date, sequence, and Luhn check digit" do
+    account_number = Accounts::Services::DepositAccountNumberGenerator.call(on_date: Date.new(2026, 4, 30))
+
+    assert_equal "126040000013", account_number
+    assert Accounts::Services::DepositAccountNumberGenerator.valid_luhn?(account_number)
+  end
+
+  test "increments the global sequence across months" do
+    first = Accounts::Services::DepositAccountNumberGenerator.call(on_date: Date.new(2026, 4, 30))
+    second = Accounts::Services::DepositAccountNumberGenerator.call(on_date: Date.new(2026, 5, 1))
+
+    assert_equal "000001", first[5, 6]
+    assert_equal "000002", second[5, 6]
+    assert_equal "12605", second.first(5)
+  end
+
+  test "raises when global six digit sequence is exhausted" do
+    Accounts::Models::DepositAccountNumberAllocation.create!(
+      allocation_key: Accounts::Models::DepositAccountNumberAllocation::GLOBAL_KEY,
+      last_sequence: Accounts::Models::DepositAccountNumberAllocation::MAX_SEQUENCE
+    )
+
+    assert_raises(Accounts::Services::DepositAccountNumberGenerator::SequenceExhausted) do
+      Accounts::Services::DepositAccountNumberGenerator.call(on_date: Date.new(2026, 4, 30))
+    end
+  end
+
+  test "valid_luhn rejects bad format and bad check digit" do
+    assert_not Accounts::Services::DepositAccountNumberGenerator.valid_luhn?("DAABC123")
+    assert_not Accounts::Services::DepositAccountNumberGenerator.valid_luhn?("126040000014")
+  end
+end

--- a/test/domains/accounts/open_account_test.rb
+++ b/test/domains/accounts/open_account_test.rb
@@ -17,6 +17,9 @@ class AccountsOpenAccountTest < ActiveSupport::TestCase
     assert_equal Accounts::SLICE1_PRODUCT_CODE, account.deposit_product.product_code
     assert_equal Accounts::Models::DepositAccount::STATUS_OPEN, account.status
     assert_equal "USD", account.currency
+    assert_match(/\A1\d{11}\z/, account.account_number)
+    assert Accounts::Services::DepositAccountNumberGenerator.valid_luhn?(account.account_number)
+    assert_equal "12604", account.account_number.first(5)
     assert_equal 1, account.deposit_account_parties.count
     row = account.deposit_account_parties.first
     assert_equal Accounts::Models::DepositAccountParty::ROLE_OWNER, row.role
@@ -29,6 +32,16 @@ class AccountsOpenAccountTest < ActiveSupport::TestCase
     on = Date.new(2026, 5, 1)
     account = Accounts::Commands::OpenAccount.call(party_record_id: @party.id, effective_on: on)
     assert_equal on, account.deposit_account_parties.first.effective_on
+    assert_equal "12605", account.account_number.first(5)
+  end
+
+  test "allocates globally incrementing account numbers" do
+    first = Accounts::Commands::OpenAccount.call(party_record_id: @party.id)
+    second_party = Party::Commands::CreateParty.call(party_type: "individual", first_name: "Seq", last_name: "Two")
+    second = Accounts::Commands::OpenAccount.call(party_record_id: second_party.id)
+
+    assert_equal "000001", first.account_number[5, 6]
+    assert_equal "000002", second.account_number[5, 6]
   end
 
   test "raises when party is missing" do
@@ -93,5 +106,23 @@ class AccountsOpenAccountTest < ActiveSupport::TestCase
     assert_raises(Accounts::Commands::OpenAccount::JointPartyNotFound) do
       Accounts::Commands::OpenAccount.call(party_record_id: @party.id, joint_party_record_id: 9_999_998)
     end
+  end
+
+  test "deposit account validates numeric account number shape and check digit" do
+    product = Products::Models::DepositProduct.find_by!(product_code: Accounts::SLICE1_PRODUCT_CODE)
+    account = Accounts::Models::DepositAccount.new(
+      account_number: "DAABC123",
+      currency: "USD",
+      status: Accounts::Models::DepositAccount::STATUS_OPEN,
+      deposit_product: product,
+      product_code: product.product_code
+    )
+
+    assert_not account.valid?
+    assert_includes account.errors[:account_number], "must be a 12-digit deposit account number"
+
+    account.account_number = "126040000014"
+    assert_not account.valid?
+    assert_includes account.errors[:account_number], "has an invalid check digit"
   end
 end

--- a/test/domains/accounts/queries/find_deposit_account_by_account_number_test.rb
+++ b/test/domains/accounts/queries/find_deposit_account_by_account_number_test.rb
@@ -8,11 +8,10 @@ class AccountsQueriesFindDepositAccountByAccountNumberTest < ActiveSupport::Test
     Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.new(2026, 4, 25))
     party = Party::Commands::CreateParty.call(party_type: "individual", first_name: "Ach", last_name: "Lookup")
     @account = Accounts::Commands::OpenAccount.call(party_record_id: party.id)
-    @account.update!(account_number: "001234567890")
   end
 
-  test "finds an account by exact normalized account number preserving leading zeroes" do
-    found = Accounts::Queries::FindDepositAccountByAccountNumber.call(account_number: " 001234567890 ")
+  test "finds an account by exact normalized account number preserving the string" do
+    found = Accounts::Queries::FindDepositAccountByAccountNumber.call(account_number: " #{@account.account_number} ")
 
     assert_equal @account.id, found.id
   end
@@ -20,7 +19,7 @@ class AccountsQueriesFindDepositAccountByAccountNumberTest < ActiveSupport::Test
   test "open returns nil for closed account" do
     @account.update!(status: Accounts::Models::DepositAccount::STATUS_CLOSED)
 
-    assert_nil Accounts::Queries::FindDepositAccountByAccountNumber.open(account_number: "001234567890")
+    assert_nil Accounts::Queries::FindDepositAccountByAccountNumber.open(account_number: @account.account_number)
   end
 
   test "blank account number is invalid" do

--- a/test/domains/integration/ach/ingest_receipt_file_test.rb
+++ b/test/domains/integration/ach/ingest_receipt_file_test.rb
@@ -10,7 +10,6 @@ class IntegrationAchIngestReceiptFileTest < ActiveSupport::TestCase
 
     @party = Party::Commands::CreateParty.call(party_type: "individual", first_name: "Ava", last_name: "Ach")
     @account = Accounts::Commands::OpenAccount.call(party_record_id: @party.id)
-    @account.update!(account_number: "001234567890")
   end
 
   test "posts a valid ACH credit item with reconciliation evidence" do
@@ -20,7 +19,7 @@ class IntegrationAchIngestReceiptFileTest < ActiveSupport::TestCase
     assert_equal({ posted: 1 }, result.counts)
     row = result.outcomes.sole
     assert_equal :posted, row.fetch(:outcome)
-    assert_equal "001234567890", row.fetch(:account_number)
+    assert_equal @account.account_number, row.fetch(:account_number)
     assert_equal @account.id, row.fetch(:deposit_account_id)
     assert row.fetch(:operational_event_id)
     assert row.fetch(:posting_batch_id)
@@ -41,17 +40,17 @@ class IntegrationAchIngestReceiptFileTest < ActiveSupport::TestCase
     assert_equal @account.id, lines.second.deposit_account_id
   end
 
-  test "preserves leading zeroes in account number lookup and outcome evidence" do
+  test "preserves exact account number string in lookup and outcome evidence" do
     result = ingest!(item_id: "trace-leading-zero")
 
     assert_equal :posted, result.outcomes.sole.fetch(:outcome)
-    assert_equal "001234567890", result.outcomes.sole.fetch(:account_number)
+    assert_equal @account.account_number, result.outcomes.sole.fetch(:account_number)
   end
 
   test "returns account-not-found and account-closed outcomes" do
     closed_party = Party::Commands::CreateParty.call(party_type: "individual", first_name: "Closed", last_name: "Ach")
     closed = Accounts::Commands::OpenAccount.call(party_record_id: closed_party.id)
-    closed.update!(account_number: "009999999999", status: Accounts::Models::DepositAccount::STATUS_CLOSED)
+    closed.update!(status: Accounts::Models::DepositAccount::STATUS_CLOSED)
 
     result = Integration::Ach::Commands::IngestReceiptFile.call(
       file_id: "file-20260425-002",
@@ -60,7 +59,7 @@ class IntegrationAchIngestReceiptFileTest < ActiveSupport::TestCase
           batch_id: "batch-1",
           items: [
             ach_item(item_id: "missing", account_number: "000000000000"),
-            ach_item(item_id: "closed", account_number: "009999999999")
+            ach_item(item_id: "closed", account_number: closed.account_number)
           ]
         }
       ]

--- a/test/integration/branch_customer_servicing_test.rb
+++ b/test/integration/branch_customer_servicing_test.rb
@@ -37,6 +37,38 @@ class BranchCustomerServicingTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "Operational events"
   end
 
+  test "account profile separates balance activity from other operational events" do
+    deposit_event = fund_account!(amount: 5_000, key: "account-profile-balance-deposit")
+    hold_event = Accounts::Commands::PlaceHold.call(
+      deposit_account_id: @account.id,
+      amount_minor_units: 500,
+      currency: "USD",
+      channel: "branch",
+      idempotency_key: "account-profile-non-balance-hold",
+      actor_id: @supervisor.id,
+      hold_type: "administrative",
+      reason_code: "manual_review",
+      reason_description: "Profile display test",
+      expires_on: "2026-09-15"
+    ).fetch(:event)
+
+    internal_login!(username: "csr-teller")
+    get branch_servicing_deposit_account_path(@account)
+    assert_response :success
+
+    recent_activity_section = response.body.split("Recent activity", 2).last.split("Statements", 2).first
+    operational_events_section = response.body.split("Operational events", 2).last
+
+    assert_includes recent_activity_section, "deposit.accepted"
+    assert_includes recent_activity_section, "Event: #{deposit_event.id}"
+    assert_not_includes recent_activity_section, "hold.placed"
+
+    assert_includes operational_events_section, "hold.placed"
+    assert_includes operational_events_section, "##{hold_event.id}"
+    assert_not_includes operational_events_section, "deposit.accepted"
+    assert_not_includes operational_events_section, "##{deposit_event.id}"
+  end
+
   test "branch customer and account views show current and historical account-party relationships" do
     former_party = Party::Commands::CreateParty.call(party_type: "individual", first_name: "Former", last_name: "Signer")
     Accounts::Models::DepositAccountParty.create!(

--- a/test/integration/internal_workspace_phase35b_test.rb
+++ b/test/integration/internal_workspace_phase35b_test.rb
@@ -92,7 +92,6 @@ class InternalWorkspacePhase35bTest < ActionDispatch::IntegrationTest
 
   test "ops support search finds ACH receipt items by reference and idempotency keys" do
     account = open_account!
-    account.update!(account_number: "001234567890")
     ach = Integration::Ach::Commands::IngestReceiptFile.call(
       file_id: "file-ops-ach-001",
       batches: [
@@ -101,7 +100,7 @@ class InternalWorkspacePhase35bTest < ActionDispatch::IntegrationTest
           items: [
             {
               item_id: "trace-ops-001",
-              account_number: "001234567890",
+              account_number: account.account_number,
               amount_minor_units: 12_500,
               currency: "USD"
             }
@@ -128,7 +127,6 @@ class InternalWorkspacePhase35bTest < ActionDispatch::IntegrationTest
 
   test "ops can preview and ingest structured ACH receipt upload" do
     account = open_account!
-    account.update!(account_number: "001234567890")
 
     internal_login!(username: "ops-user")
 
@@ -146,7 +144,7 @@ class InternalWorkspacePhase35bTest < ActionDispatch::IntegrationTest
           items: [
             {
               item_id: "trace-form-001",
-              account_number: "001234567890",
+              account_number: account.account_number,
               amount_minor_units: 12_500,
               currency: "USD"
             }


### PR DESCRIPTION
## Summary
- Add an Accounts-owned allocator and Luhn generator for 12-digit deposit account numbers in the `1YYMM######C` format.
- Backfill existing deposit account numbers, tighten model/schema validation, and update ACH samples/docs/tests for the numeric format.
- Refine the Branch account detail page so parties/product panels are full width and balance-affecting recent activity is separated from other operational events.

## Test plan
- `docker compose run --rm web bin/rails test`


Made with [Cursor](https://cursor.com)