### PR TITLE
Add account balance projections and snapshots

### DIFF
--- a/app/controllers/ops/balance_projections_controller.rb
+++ b/app/controllers/ops/balance_projections_controller.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+module Ops
+  class BalanceProjectionsController < ApplicationController
+    before_action :require_reconciliation_capability!, only: [ :mark_stale, :rebuild, :create_bulk_repair ]
+
+    def index
+      load_health
+      load_account_detail if account_lookup.present?
+    end
+
+    def mark_stale
+      account = find_account_by_id!
+      Accounts::Commands::MarkDepositBalanceProjectionStale.call(deposit_account_id: account.id)
+      redirect_to ops_balance_projections_path(account: account.account_number),
+        notice: "Marked projection stale for account #{account.account_number}."
+    rescue ActiveRecord::RecordNotFound
+      redirect_to ops_balance_projections_path, alert: "Deposit account was not found."
+    end
+
+    def rebuild
+      account = find_account_by_id!
+      Accounts::Commands::RebuildDepositBalanceProjection.call(deposit_account_id: account.id)
+      redirect_to ops_balance_projections_path(account: account.account_number),
+        notice: "Rebuilt projection for account #{account.account_number}."
+    rescue ActiveRecord::RecordNotFound
+      redirect_to ops_balance_projections_path, alert: "Deposit account was not found."
+    end
+
+    def bulk_repair
+      load_health
+    end
+
+    def create_bulk_repair
+      outcome = bulk_repair_action
+      redirect_to ops_balance_projection_bulk_repair_path, notice: outcome
+    rescue ArgumentError => e
+      load_health
+      @error_message = e.message
+      render :bulk_repair, status: :unprocessable_entity
+    end
+
+    private
+
+    def load_health
+      @health = Accounts::Queries::DepositBalanceProjectionHealth.call
+    end
+
+    def account_lookup
+      params[:account].to_s.strip
+    end
+
+    def load_account_detail
+      @account = resolve_account(account_lookup)
+      if @account.nil?
+        @account_error = "No deposit account matched #{account_lookup.inspect}."
+        return
+      end
+
+      @projection = @account.deposit_account_balance_projection
+      @drift = Accounts::Queries::DepositBalanceProjectionDrift.call(deposit_account_id: @account.id)
+      @rebuild_requests = Accounts::Models::DepositBalanceRebuildRequest
+        .where(deposit_account_id: @account.id)
+        .order(requested_at: :desc, id: :desc)
+        .limit(10)
+      @daily_snapshots = Reporting::Models::DailyBalanceSnapshot
+        .where(
+          account_domain: Reporting::Models::DailyBalanceSnapshot::ACCOUNT_DOMAIN_DEPOSITS,
+          account_id: @account.id
+        )
+        .order(as_of_date: :desc, calculation_version: :desc, id: :desc)
+        .limit(10)
+    end
+
+    def resolve_account(value)
+      if value.match?(/\A\d+\z/)
+        Accounts::Models::DepositAccount.find_by(id: value) ||
+          Accounts::Models::DepositAccount.find_by(account_number: value)
+      else
+        Accounts::Models::DepositAccount.find_by(account_number: value)
+      end
+    end
+
+    def find_account_by_id!
+      Accounts::Models::DepositAccount.find(params[:deposit_account_id])
+    end
+
+    def require_reconciliation_capability!
+      Workspace::Authorization::Authorizer.require_capability!(
+        actor_id: current_operator.id,
+        capability_code: Workspace::Authorization::CapabilityRegistry::OPS_RECONCILIATION_PERFORM,
+        scope: current_operating_unit
+      )
+    rescue Workspace::Authorization::Forbidden => e
+      render plain: e.message, status: :forbidden
+    end
+
+    def bulk_repair_action
+      case params.dig(:bulk_repair, :action_type).to_s
+      when "mark_projection_versions"
+        result = Accounts::Commands::MarkDepositBalanceProjectionsStaleForVersion.call
+        "Marked #{result.marked_count} projection(s) stale and created #{result.rebuild_requests_created} rebuild request(s)."
+      when "mark_snapshot_versions"
+        result = Reporting::Commands::MarkDailyBalanceSnapshotsStaleForVersion.call
+        "Marked #{result.marked_count} daily snapshot(s) stale."
+      when "rebuild_stale_projections"
+        count = rebuild_stale_projection_batch
+        "Rebuilt #{count} stale projection(s)."
+      else
+        raise ArgumentError, "Select a valid bulk repair action."
+      end
+    end
+
+    def rebuild_stale_projection_batch
+      limit = Integer(params.dig(:bulk_repair, :limit).presence || 25)
+      limit = limit.clamp(1, 200)
+      projections = Accounts::Models::DepositAccountBalanceProjection
+        .where(stale: true)
+        .order(:deposit_account_id)
+        .limit(limit)
+      projections.count.tap do
+        projections.find_each do |projection|
+          Accounts::Commands::RebuildDepositBalanceProjection.call(
+            deposit_account_id: projection.deposit_account_id,
+            reason: Accounts::Models::DepositBalanceRebuildRequest::REASON_MANUAL_REBUILD
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/ops/business_date_closes_controller.rb
+++ b/app/controllers/ops/business_date_closes_controller.rb
@@ -47,6 +47,7 @@ module Ops
     def load_preview
       @readiness = Teller::Queries::EodReadiness.call(business_date: @business_date)
       @trial_balance_rows = Core::Ledger::Queries::TrialBalanceForBusinessDate.call(business_date: @business_date)
+      @balance_projection_health = Accounts::Queries::DepositBalanceProjectionHealth.call
     rescue Core::BusinessDate::Errors::NotSet => e
       @error_message = e.message
     end

--- a/app/domains/accounts/commands/expire_due_holds.rb
+++ b/app/domains/accounts/commands/expire_due_holds.rb
@@ -58,6 +58,12 @@ module Accounts
             expired_by_operational_event: event
           )
 
+          Accounts::Services::DepositBalanceProjector.refresh_available_balance!(
+            deposit_account_id: hold.deposit_account_id,
+            operational_event: event,
+            as_of_business_date: as_of
+          )
+
           { outcome: :expired, event: event, hold: hold.reload }
         end
       rescue ActiveRecord::RecordNotUnique

--- a/app/domains/accounts/commands/mark_deposit_balance_projection_stale.rb
+++ b/app/domains/accounts/commands/mark_deposit_balance_projection_stale.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Commands
+    class MarkDepositBalanceProjectionStale
+      def self.call(
+        deposit_account_id:,
+        reason: Models::DepositBalanceRebuildRequest::REASON_DRIFT_DETECTED,
+        stale_from_date: nil,
+        source_operational_event_id: nil,
+        expected_calculation_version: Models::DepositAccountBalanceProjection::CURRENT_CALCULATION_VERSION
+      )
+        new(
+          deposit_account_id: deposit_account_id,
+          reason: reason,
+          stale_from_date: stale_from_date,
+          source_operational_event_id: source_operational_event_id,
+          expected_calculation_version: expected_calculation_version
+        ).call
+      end
+
+      def initialize(deposit_account_id:, reason:, stale_from_date:, source_operational_event_id:, expected_calculation_version:)
+        @deposit_account_id = deposit_account_id
+        @reason = reason
+        @stale_from_date = stale_from_date
+        @source_operational_event_id = source_operational_event_id
+        @expected_calculation_version = expected_calculation_version
+      end
+
+      def call
+        Models::DepositAccountBalanceProjection.transaction do
+          projection = Models::DepositAccountBalanceProjection.lock.find_by(deposit_account_id: deposit_account_id)
+          drift = Queries::DepositBalanceProjectionDrift.call(
+            deposit_account_id: deposit_account_id,
+            expected_calculation_version: expected_calculation_version
+          )
+          return { projection: projection, drift: drift, rebuild_request: nil } unless drift.drifted
+
+          projection&.update!(
+            stale: true,
+            stale_from_date: resolved_stale_from_date(projection)
+          )
+
+          rebuild_request = Models::DepositBalanceRebuildRequest.create!(
+            deposit_account_id: deposit_account_id,
+            rebuild_type: Models::DepositBalanceRebuildRequest::REBUILD_TYPE_PROJECTION,
+            reason: reason,
+            status: Models::DepositBalanceRebuildRequest::STATUS_REQUESTED,
+            rebuild_from_date: resolved_stale_from_date(projection),
+            source_operational_event_id: source_operational_event_id,
+            calculation_version: expected_calculation_version,
+            requested_at: Time.current
+          )
+
+          { projection: projection&.reload, drift: drift, rebuild_request: rebuild_request }
+        end
+      end
+
+      private
+
+      attr_reader :deposit_account_id, :reason, :stale_from_date, :source_operational_event_id, :expected_calculation_version
+
+      def resolved_stale_from_date(projection)
+        stale_from_date || projection&.as_of_business_date || Core::BusinessDate::Services::CurrentBusinessDate.call
+      end
+    end
+  end
+end

--- a/app/domains/accounts/commands/mark_deposit_balance_projections_stale_for_version.rb
+++ b/app/domains/accounts/commands/mark_deposit_balance_projections_stale_for_version.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Commands
+    class MarkDepositBalanceProjectionsStaleForVersion
+      Result = Data.define(:expected_calculation_version, :marked_count, :rebuild_requests_created)
+
+      def self.call(expected_calculation_version: Models::DepositAccountBalanceProjection::CURRENT_CALCULATION_VERSION)
+        new(expected_calculation_version: expected_calculation_version).call
+      end
+
+      def initialize(expected_calculation_version:)
+        @expected_calculation_version = expected_calculation_version
+      end
+
+      def call
+        marked_count = 0
+        rebuild_requests_created = 0
+        Models::DepositAccountBalanceProjection.transaction do
+          stale_scope.find_each do |projection|
+            projection.lock!
+            projection.update!(
+              stale: true,
+              stale_from_date: projection.stale_from_date || projection.as_of_business_date || Core::BusinessDate::Services::CurrentBusinessDate.call
+            )
+            Models::DepositBalanceRebuildRequest.create!(
+              deposit_account_id: projection.deposit_account_id,
+              rebuild_type: Models::DepositBalanceRebuildRequest::REBUILD_TYPE_PROJECTION,
+              reason: Models::DepositBalanceRebuildRequest::REASON_FORMULA_VERSION_CHANGE,
+              status: Models::DepositBalanceRebuildRequest::STATUS_REQUESTED,
+              rebuild_from_date: projection.stale_from_date,
+              calculation_version: expected_calculation_version,
+              requested_at: Time.current
+            )
+            marked_count += 1
+            rebuild_requests_created += 1
+          end
+        end
+
+        Result.new(
+          expected_calculation_version: expected_calculation_version,
+          marked_count: marked_count,
+          rebuild_requests_created: rebuild_requests_created
+        )
+      end
+
+      private
+
+      attr_reader :expected_calculation_version
+
+      def stale_scope
+        Models::DepositAccountBalanceProjection
+          .where(stale: false)
+          .where.not(calculation_version: expected_calculation_version)
+      end
+    end
+  end
+end

--- a/app/domains/accounts/commands/open_account.rb
+++ b/app/domains/accounts/commands/open_account.rb
@@ -64,6 +64,13 @@ module Accounts
             )
           end
 
+          Models::DepositAccountBalanceProjection.create!(
+            deposit_account: account,
+            as_of_business_date: on_date,
+            last_calculated_at: Time.current,
+            calculation_version: Models::DepositAccountBalanceProjection::CURRENT_CALCULATION_VERSION
+          )
+
           account.reload
         end
       end

--- a/app/domains/accounts/commands/place_hold.rb
+++ b/app/domains/accounts/commands/place_hold.rb
@@ -83,6 +83,12 @@ module Accounts
               expires_on: normalized_expires_on
             )
 
+            Accounts::Services::DepositBalanceProjector.refresh_available_balance!(
+              deposit_account_id: deposit_account_id,
+              operational_event: event,
+              as_of_business_date: on_date
+            )
+
             { outcome: :created, event: event, hold: hold }
           end
         rescue ActiveRecord::RecordNotUnique

--- a/app/domains/accounts/commands/rebuild_deposit_balance_projection.rb
+++ b/app/domains/accounts/commands/rebuild_deposit_balance_projection.rb
@@ -3,13 +3,18 @@
 module Accounts
   module Commands
     class RebuildDepositBalanceProjection
-      def self.call(deposit_account_id:, calculation_version: Models::DepositAccountBalanceProjection::CURRENT_CALCULATION_VERSION)
-        new(deposit_account_id: deposit_account_id, calculation_version: calculation_version).call
+      def self.call(
+        deposit_account_id:,
+        calculation_version: Models::DepositAccountBalanceProjection::CURRENT_CALCULATION_VERSION,
+        reason: Models::DepositBalanceRebuildRequest::REASON_MANUAL_REBUILD
+      )
+        new(deposit_account_id: deposit_account_id, calculation_version: calculation_version, reason: reason).call
       end
 
-      def initialize(deposit_account_id:, calculation_version:)
+      def initialize(deposit_account_id:, calculation_version:, reason:)
         @deposit_account_id = deposit_account_id
         @calculation_version = calculation_version
+        @reason = reason
       end
 
       def call
@@ -29,13 +34,14 @@ module Accounts
             stale_from_date: nil,
             calculation_version: calculation_version
           )
+          record_rebuild_completed!
           projection
         end
       end
 
       private
 
-      attr_reader :deposit_account_id, :calculation_version
+      attr_reader :deposit_account_id, :calculation_version, :reason
 
       def locked_projection
         projection = Models::DepositAccountBalanceProjection.lock.find_by(deposit_account_id: deposit_account_id)
@@ -66,6 +72,18 @@ module Accounts
 
       def dda_account
         @dda_account ||= Core::Ledger::Models::GlAccount.find_by(account_number: Services::AvailableBalanceResolver::GL_DDA)
+      end
+
+      def record_rebuild_completed!
+        Models::DepositBalanceRebuildRequest.create!(
+          deposit_account_id: deposit_account_id,
+          rebuild_type: Models::DepositBalanceRebuildRequest::REBUILD_TYPE_PROJECTION,
+          reason: reason,
+          status: Models::DepositBalanceRebuildRequest::STATUS_COMPLETED,
+          calculation_version: calculation_version,
+          requested_at: Time.current,
+          processed_at: Time.current
+        )
       end
     end
   end

--- a/app/domains/accounts/commands/rebuild_deposit_balance_projection.rb
+++ b/app/domains/accounts/commands/rebuild_deposit_balance_projection.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Commands
+    class RebuildDepositBalanceProjection
+      def self.call(deposit_account_id:, calculation_version: Models::DepositAccountBalanceProjection::CURRENT_CALCULATION_VERSION)
+        new(deposit_account_id: deposit_account_id, calculation_version: calculation_version).call
+      end
+
+      def initialize(deposit_account_id:, calculation_version:)
+        @deposit_account_id = deposit_account_id
+        @calculation_version = calculation_version
+      end
+
+      def call
+        Models::DepositAccount.find(deposit_account_id)
+
+        Models::DepositAccountBalanceProjection.transaction do
+          projection = locked_projection
+          latest_entry = latest_journal_entry
+          Services::DepositBalanceProjector.rebuild_projection!(
+            projection,
+            journal_entry: latest_entry,
+            operational_event: latest_entry&.operational_event,
+            as_of_business_date: latest_entry&.business_date || Core::BusinessDate::Services::CurrentBusinessDate.call
+          )
+          projection.update!(
+            stale: false,
+            stale_from_date: nil,
+            calculation_version: calculation_version
+          )
+          projection
+        end
+      end
+
+      private
+
+      attr_reader :deposit_account_id, :calculation_version
+
+      def locked_projection
+        projection = Models::DepositAccountBalanceProjection.lock.find_by(deposit_account_id: deposit_account_id)
+        return projection if projection
+
+        Models::DepositAccountBalanceProjection.create!(deposit_account_id: deposit_account_id)
+      rescue ActiveRecord::RecordNotUnique
+        retry
+      end
+
+      def latest_journal_entry
+        return nil if dda_account.nil?
+
+        Core::Ledger::Models::JournalLine
+          .joins(:journal_entry)
+          .where(
+            gl_account_id: dda_account.id,
+            deposit_account_id: deposit_account_id
+          )
+          .order(
+            "journal_entries.business_date DESC",
+            "journal_entries.id DESC",
+            "journal_lines.id DESC"
+          )
+          .first
+          &.journal_entry
+      end
+
+      def dda_account
+        @dda_account ||= Core::Ledger::Models::GlAccount.find_by(account_number: Services::AvailableBalanceResolver::GL_DDA)
+      end
+    end
+  end
+end

--- a/app/domains/accounts/commands/release_hold.rb
+++ b/app/domains/accounts/commands/release_hold.rb
@@ -59,6 +59,12 @@ module Accounts
             released_by_operational_event: event
           )
 
+          Accounts::Services::DepositBalanceProjector.refresh_available_balance!(
+            deposit_account_id: hold.deposit_account_id,
+            operational_event: event,
+            as_of_business_date: on_date
+          )
+
           { outcome: :created, event: event, hold: hold.reload }
         end
       rescue ActiveRecord::RecordNotUnique

--- a/app/domains/accounts/models/deposit_account.rb
+++ b/app/domains/accounts/models/deposit_account.rb
@@ -16,6 +16,10 @@ module Accounts
         class_name: "Accounts::Models::DepositAccountBalanceProjection",
         dependent: :restrict_with_exception,
         inverse_of: :deposit_account
+      has_many :deposit_balance_rebuild_requests,
+        class_name: "Accounts::Models::DepositBalanceRebuildRequest",
+        dependent: :restrict_with_exception,
+        inverse_of: :deposit_account
 
       belongs_to :deposit_product, class_name: "Products::Models::DepositProduct"
       has_many :deposit_statements, class_name: "Deposits::Models::DepositStatement",

--- a/app/domains/accounts/models/deposit_account.rb
+++ b/app/domains/accounts/models/deposit_account.rb
@@ -12,6 +12,10 @@ module Accounts
         inverse_of: :deposit_account
       has_many :account_restrictions, class_name: "Accounts::Models::AccountRestriction", dependent: :restrict_with_exception
       has_many :account_lifecycle_events, class_name: "Accounts::Models::AccountLifecycleEvent", dependent: :restrict_with_exception
+      has_one :deposit_account_balance_projection,
+        class_name: "Accounts::Models::DepositAccountBalanceProjection",
+        dependent: :restrict_with_exception,
+        inverse_of: :deposit_account
 
       belongs_to :deposit_product, class_name: "Products::Models::DepositProduct"
       has_many :deposit_statements, class_name: "Deposits::Models::DepositStatement",

--- a/app/domains/accounts/models/deposit_account_balance_projection.rb
+++ b/app/domains/accounts/models/deposit_account_balance_projection.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Models
+    class DepositAccountBalanceProjection < ApplicationRecord
+      self.table_name = "deposit_account_balance_projections"
+
+      belongs_to :deposit_account, class_name: "Accounts::Models::DepositAccount",
+        inverse_of: :deposit_account_balance_projection
+      belongs_to :last_journal_entry, class_name: "Core::Ledger::Models::JournalEntry", optional: true
+      belongs_to :last_operational_event, class_name: "Core::OperationalEvents::Models::OperationalEvent", optional: true
+
+      validates :deposit_account, presence: true, uniqueness: true
+      validates :ledger_balance_minor_units, :available_balance_minor_units,
+        numericality: { only_integer: true }
+      validates :hold_balance_minor_units,
+        numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+      validates :collected_balance_minor_units,
+        numericality: { only_integer: true },
+        allow_nil: true
+      validates :calculation_version,
+        numericality: { only_integer: true, greater_than: 0 }
+    end
+  end
+end

--- a/app/domains/accounts/models/deposit_account_balance_projection.rb
+++ b/app/domains/accounts/models/deposit_account_balance_projection.rb
@@ -5,6 +5,8 @@ module Accounts
     class DepositAccountBalanceProjection < ApplicationRecord
       self.table_name = "deposit_account_balance_projections"
 
+      CURRENT_CALCULATION_VERSION = 1
+
       belongs_to :deposit_account, class_name: "Accounts::Models::DepositAccount",
         inverse_of: :deposit_account_balance_projection
       belongs_to :last_journal_entry, class_name: "Core::Ledger::Models::JournalEntry", optional: true

--- a/app/domains/accounts/models/deposit_balance_rebuild_request.rb
+++ b/app/domains/accounts/models/deposit_balance_rebuild_request.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Models
+    class DepositBalanceRebuildRequest < ApplicationRecord
+      self.table_name = "deposit_balance_rebuild_requests"
+
+      REBUILD_TYPE_PROJECTION = "projection"
+      REBUILD_TYPES = [ REBUILD_TYPE_PROJECTION ].freeze
+
+      REASON_DRIFT_DETECTED = "drift_detected"
+      REASON_FORMULA_VERSION_CHANGE = "formula_version_change"
+      REASON_MANUAL_REBUILD = "manual_rebuild"
+      REASONS = [
+        REASON_DRIFT_DETECTED,
+        REASON_FORMULA_VERSION_CHANGE,
+        REASON_MANUAL_REBUILD
+      ].freeze
+
+      STATUS_REQUESTED = "requested"
+      STATUS_COMPLETED = "completed"
+      STATUSES = [ STATUS_REQUESTED, STATUS_COMPLETED ].freeze
+
+      belongs_to :deposit_account, class_name: "Accounts::Models::DepositAccount"
+      belongs_to :source_operational_event, class_name: "Core::OperationalEvents::Models::OperationalEvent", optional: true
+
+      validates :rebuild_type, presence: true, inclusion: { in: REBUILD_TYPES }
+      validates :reason, presence: true, inclusion: { in: REASONS }
+      validates :status, presence: true, inclusion: { in: STATUSES }
+      validates :requested_at, presence: true
+      validates :calculation_version,
+        numericality: { only_integer: true, greater_than: 0 }
+    end
+  end
+end

--- a/app/domains/accounts/queries/deposit_balance_projection_drift.rb
+++ b/app/domains/accounts/queries/deposit_balance_projection_drift.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Queries
+    class DepositBalanceProjectionDrift
+      Result = Data.define(
+        :deposit_account_id,
+        :projection,
+        :expected_ledger_balance_minor_units,
+        :expected_hold_balance_minor_units,
+        :expected_available_balance_minor_units,
+        :ledger_balance_drift_minor_units,
+        :hold_balance_drift_minor_units,
+        :available_balance_drift_minor_units,
+        :stale,
+        :calculation_version,
+        :expected_calculation_version,
+        :missing_projection,
+        :drifted
+      )
+
+      def self.call(deposit_account_id:, expected_calculation_version: Models::DepositAccountBalanceProjection::CURRENT_CALCULATION_VERSION)
+        new(
+          deposit_account_id: deposit_account_id,
+          expected_calculation_version: expected_calculation_version
+        ).call
+      end
+
+      def initialize(deposit_account_id:, expected_calculation_version:)
+        @deposit_account_id = deposit_account_id
+        @expected_calculation_version = expected_calculation_version
+      end
+
+      def call
+        Models::DepositAccount.find(deposit_account_id)
+
+        expected = Services::AvailableBalanceResolver.from_journal(deposit_account_id: deposit_account_id)
+        Result.new(
+          deposit_account_id: deposit_account_id,
+          projection: projection,
+          expected_ledger_balance_minor_units: expected.ledger_balance_minor_units,
+          expected_hold_balance_minor_units: expected.hold_balance_minor_units,
+          expected_available_balance_minor_units: expected.available_balance_minor_units,
+          ledger_balance_drift_minor_units: ledger_balance_drift(expected),
+          hold_balance_drift_minor_units: hold_balance_drift(expected),
+          available_balance_drift_minor_units: available_balance_drift(expected),
+          stale: projection&.stale? || false,
+          calculation_version: projection&.calculation_version,
+          expected_calculation_version: expected_calculation_version,
+          missing_projection: projection.nil?,
+          drifted: drifted?(expected)
+        )
+      end
+
+      private
+
+      attr_reader :deposit_account_id, :expected_calculation_version
+
+      def projection
+        @projection ||= Models::DepositAccountBalanceProjection.find_by(deposit_account_id: deposit_account_id)
+      end
+
+      def ledger_balance_drift(expected)
+        return expected.ledger_balance_minor_units if projection.nil?
+
+        projection.ledger_balance_minor_units - expected.ledger_balance_minor_units
+      end
+
+      def hold_balance_drift(expected)
+        return expected.hold_balance_minor_units if projection.nil?
+
+        projection.hold_balance_minor_units - expected.hold_balance_minor_units
+      end
+
+      def available_balance_drift(expected)
+        return expected.available_balance_minor_units if projection.nil?
+
+        projection.available_balance_minor_units - expected.available_balance_minor_units
+      end
+
+      def drifted?(expected)
+        return true if projection.nil?
+        return true if projection.stale?
+        return true if projection.calculation_version != expected_calculation_version
+
+        ledger_balance_drift(expected) != 0 ||
+          hold_balance_drift(expected) != 0 ||
+          available_balance_drift(expected) != 0
+      end
+    end
+  end
+end

--- a/app/domains/accounts/queries/deposit_balance_projection_health.rb
+++ b/app/domains/accounts/queries/deposit_balance_projection_health.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Queries
+    class DepositBalanceProjectionHealth
+      Result = Data.define(
+        :current_calculation_version,
+        :total_projection_count,
+        :stale_projection_count,
+        :projection_version_mismatch_count,
+        :pending_rebuild_request_count,
+        :completed_rebuild_request_count,
+        :stale_daily_snapshot_count,
+        :latest_snapshot_date,
+        :latest_snapshot_count,
+        :recent_rebuild_requests
+      )
+
+      def self.call
+        new.call
+      end
+
+      def call
+        Result.new(
+          current_calculation_version: current_calculation_version,
+          total_projection_count: projection_scope.count,
+          stale_projection_count: projection_scope.where(stale: true).count,
+          projection_version_mismatch_count: projection_scope.where.not(calculation_version: current_calculation_version).count,
+          pending_rebuild_request_count: rebuild_scope.where(status: Models::DepositBalanceRebuildRequest::STATUS_REQUESTED).count,
+          completed_rebuild_request_count: rebuild_scope.where(status: Models::DepositBalanceRebuildRequest::STATUS_COMPLETED).count,
+          stale_daily_snapshot_count: daily_snapshot_scope.where(stale: true).count,
+          latest_snapshot_date: latest_snapshot_date,
+          latest_snapshot_count: latest_snapshot_count,
+          recent_rebuild_requests: recent_rebuild_requests
+        )
+      end
+
+      private
+
+      def current_calculation_version
+        Models::DepositAccountBalanceProjection::CURRENT_CALCULATION_VERSION
+      end
+
+      def projection_scope
+        Models::DepositAccountBalanceProjection
+      end
+
+      def rebuild_scope
+        Models::DepositBalanceRebuildRequest
+      end
+
+      def daily_snapshot_scope
+        Reporting::Models::DailyBalanceSnapshot.where(
+          account_domain: Reporting::Models::DailyBalanceSnapshot::ACCOUNT_DOMAIN_DEPOSITS
+        )
+      end
+
+      def latest_snapshot_date
+        @latest_snapshot_date ||= daily_snapshot_scope.maximum(:as_of_date)
+      end
+
+      def latest_snapshot_count
+        return 0 if latest_snapshot_date.nil?
+
+        daily_snapshot_scope.where(as_of_date: latest_snapshot_date).count
+      end
+
+      def recent_rebuild_requests
+        rebuild_scope
+          .includes(:deposit_account)
+          .order(requested_at: :desc, id: :desc)
+          .limit(10)
+      end
+    end
+  end
+end

--- a/app/domains/accounts/services/available_balance_minor_units.rb
+++ b/app/domains/accounts/services/available_balance_minor_units.rb
@@ -2,13 +2,17 @@
 
 module Accounts
   module Services
-    # Ledger on 2110 for this deposit account (credits − debits) minus active holds (ADR-0004).
+    # Projection-backed current balance facade. Journal-derived methods remain explicit for rebuild/reconciliation.
     class AvailableBalanceMinorUnits
       def self.call(deposit_account_id:)
         AvailableBalanceResolver.call(deposit_account_id: deposit_account_id).available_balance_minor_units
       end
 
       def self.ledger_balance_minor_units(deposit_account_id:)
+        AvailableBalanceResolver.call(deposit_account_id: deposit_account_id).ledger_balance_minor_units
+      end
+
+      def self.journal_ledger_balance_minor_units(deposit_account_id:)
         AvailableBalanceResolver.journal_ledger_balance_minor_units(deposit_account_id: deposit_account_id)
       end
     end

--- a/app/domains/accounts/services/available_balance_minor_units.rb
+++ b/app/domains/accounts/services/available_balance_minor_units.rb
@@ -4,23 +4,12 @@ module Accounts
   module Services
     # Ledger on 2110 for this deposit account (credits − debits) minus active holds (ADR-0004).
     class AvailableBalanceMinorUnits
-      GL_DDA = "2110"
-
       def self.call(deposit_account_id:)
-        ledger = ledger_balance_minor_units(deposit_account_id: deposit_account_id)
-        held = Accounts::Models::Hold.where(deposit_account_id: deposit_account_id, status: Accounts::Models::Hold::STATUS_ACTIVE)
-          .sum(:amount_minor_units)
-        ledger - held
+        AvailableBalanceResolver.call(deposit_account_id: deposit_account_id).available_balance_minor_units
       end
 
       def self.ledger_balance_minor_units(deposit_account_id:)
-        dda = Core::Ledger::Models::GlAccount.find_by(account_number: GL_DDA)
-        return 0 if dda.nil?
-
-        lines = Core::Ledger::Models::JournalLine.where(gl_account_id: dda.id, deposit_account_id: deposit_account_id)
-        credits = lines.where(side: "credit").sum(:amount_minor_units)
-        debits = lines.where(side: "debit").sum(:amount_minor_units)
-        credits - debits
+        AvailableBalanceResolver.journal_ledger_balance_minor_units(deposit_account_id: deposit_account_id)
       end
     end
   end

--- a/app/domains/accounts/services/available_balance_resolver.rb
+++ b/app/domains/accounts/services/available_balance_resolver.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Services
+    class AvailableBalanceResolver
+      GL_DDA = "2110"
+
+      Result = Data.define(
+        :ledger_balance_minor_units,
+        :hold_balance_minor_units,
+        :available_balance_minor_units
+      )
+
+      def self.call(deposit_account_id:, ledger_balance_minor_units: nil)
+        new(
+          deposit_account_id: deposit_account_id,
+          ledger_balance_minor_units: ledger_balance_minor_units
+        ).call
+      end
+
+      def self.journal_ledger_balance_minor_units(deposit_account_id:)
+        dda = Core::Ledger::Models::GlAccount.find_by(account_number: GL_DDA)
+        return 0 if dda.nil?
+
+        lines = Core::Ledger::Models::JournalLine.where(gl_account_id: dda.id, deposit_account_id: deposit_account_id)
+        credits = lines.where(side: "credit").sum(:amount_minor_units)
+        debits = lines.where(side: "debit").sum(:amount_minor_units)
+        credits - debits
+      end
+
+      def initialize(deposit_account_id:, ledger_balance_minor_units:)
+        @deposit_account_id = deposit_account_id
+        @ledger_balance_minor_units = ledger_balance_minor_units
+      end
+
+      def call
+        ledger = ledger_balance_minor_units || self.class.journal_ledger_balance_minor_units(deposit_account_id: deposit_account_id)
+        hold = hold_balance_minor_units
+        Result.new(
+          ledger_balance_minor_units: ledger,
+          hold_balance_minor_units: hold,
+          available_balance_minor_units: ledger - hold
+        )
+      end
+
+      private
+
+      attr_reader :deposit_account_id, :ledger_balance_minor_units
+
+      def hold_balance_minor_units
+        Accounts::Models::Hold.active_for_account(deposit_account_id).sum(:amount_minor_units)
+      end
+    end
+  end
+end

--- a/app/domains/accounts/services/available_balance_resolver.rb
+++ b/app/domains/accounts/services/available_balance_resolver.rb
@@ -18,6 +18,11 @@ module Accounts
         ).call
       end
 
+      def self.from_journal(deposit_account_id:)
+        ledger = journal_ledger_balance_minor_units(deposit_account_id: deposit_account_id)
+        new(deposit_account_id: deposit_account_id, ledger_balance_minor_units: ledger).call
+      end
+
       def self.journal_ledger_balance_minor_units(deposit_account_id:)
         dda = Core::Ledger::Models::GlAccount.find_by(account_number: GL_DDA)
         return 0 if dda.nil?
@@ -34,8 +39,10 @@ module Accounts
       end
 
       def call
+        return projection_result if ledger_balance_minor_units.nil? && projection.present?
+
         ledger = ledger_balance_minor_units || self.class.journal_ledger_balance_minor_units(deposit_account_id: deposit_account_id)
-        hold = hold_balance_minor_units
+        hold = active_hold_balance_minor_units
         Result.new(
           ledger_balance_minor_units: ledger,
           hold_balance_minor_units: hold,
@@ -47,7 +54,19 @@ module Accounts
 
       attr_reader :deposit_account_id, :ledger_balance_minor_units
 
-      def hold_balance_minor_units
+      def projection
+        @projection ||= Accounts::Models::DepositAccountBalanceProjection.find_by(deposit_account_id: deposit_account_id)
+      end
+
+      def projection_result
+        Result.new(
+          ledger_balance_minor_units: projection.ledger_balance_minor_units,
+          hold_balance_minor_units: projection.hold_balance_minor_units,
+          available_balance_minor_units: projection.available_balance_minor_units
+        )
+      end
+
+      def active_hold_balance_minor_units
         Accounts::Models::Hold.active_for_account(deposit_account_id).sum(:amount_minor_units)
       end
     end

--- a/app/domains/accounts/services/deposit_balance_projector.rb
+++ b/app/domains/accounts/services/deposit_balance_projector.rb
@@ -9,19 +9,76 @@ module Accounts
         new(journal_entry: journal_entry).apply!
       end
 
+      def self.refresh_available_balance!(deposit_account_id:, operational_event: nil, as_of_business_date: nil)
+        projection, created = projection_for(deposit_account_id)
+        if created
+          rebuild_projection!(
+            projection,
+            journal_entry: nil,
+            operational_event: operational_event,
+            as_of_business_date: as_of_business_date
+          )
+        else
+          refresh_projection!(
+            projection,
+            operational_event: operational_event,
+            as_of_business_date: as_of_business_date
+          )
+        end
+      end
+
       def initialize(journal_entry:)
         @journal_entry = journal_entry
       end
 
       def apply!
         deltas_by_account_id.map do |deposit_account_id, ledger_delta|
-          projection, created = projection_for(deposit_account_id)
+          projection, created = self.class.projection_for(deposit_account_id)
           if created
-            rebuild_projection!(projection)
+            self.class.rebuild_projection!(projection, journal_entry: journal_entry, operational_event: journal_entry.operational_event,
+              as_of_business_date: journal_entry.business_date)
           else
             update_projection!(projection, ledger_delta)
           end
         end
+      end
+
+      def self.projection_for(deposit_account_id)
+        projection = Models::DepositAccountBalanceProjection.lock.find_by(deposit_account_id: deposit_account_id)
+        return [ projection, false ] if projection
+
+        [ Models::DepositAccountBalanceProjection.create!(deposit_account_id: deposit_account_id), true ]
+      rescue ActiveRecord::RecordNotUnique
+        retry
+      end
+
+      def self.rebuild_projection!(projection, journal_entry: nil, operational_event: nil, as_of_business_date: nil)
+        resolved = AvailableBalanceResolver.call(deposit_account_id: projection.deposit_account_id)
+        projection.update!(
+          ledger_balance_minor_units: resolved.ledger_balance_minor_units,
+          hold_balance_minor_units: resolved.hold_balance_minor_units,
+          available_balance_minor_units: resolved.available_balance_minor_units,
+          last_journal_entry: journal_entry || projection.last_journal_entry,
+          last_operational_event: operational_event || projection.last_operational_event,
+          as_of_business_date: as_of_business_date || projection.as_of_business_date,
+          last_calculated_at: Time.current
+        )
+        projection
+      end
+
+      def self.refresh_projection!(projection, operational_event: nil, as_of_business_date: nil)
+        resolved = AvailableBalanceResolver.call(
+          deposit_account_id: projection.deposit_account_id,
+          ledger_balance_minor_units: projection.ledger_balance_minor_units
+        )
+        projection.update!(
+          hold_balance_minor_units: resolved.hold_balance_minor_units,
+          available_balance_minor_units: resolved.available_balance_minor_units,
+          last_operational_event: operational_event || projection.last_operational_event,
+          as_of_business_date: as_of_business_date || projection.as_of_business_date,
+          last_calculated_at: Time.current
+        )
+        projection
       end
 
       private
@@ -45,55 +102,22 @@ module Accounts
         line.side == "credit" ? line.amount_minor_units : -line.amount_minor_units
       end
 
-      def projection_for(deposit_account_id)
-        projection = Models::DepositAccountBalanceProjection.lock.find_by(deposit_account_id: deposit_account_id)
-        return [ projection, false ] if projection
-
-        [ Models::DepositAccountBalanceProjection.create!(deposit_account_id: deposit_account_id), true ]
-      rescue ActiveRecord::RecordNotUnique
-        retry
-      end
-
-      def rebuild_projection!(projection)
-        ledger = journal_ledger_balance_minor_units(projection.deposit_account_id)
-        hold = hold_balance_minor_units(projection.deposit_account_id)
-        projection.update!(
-          ledger_balance_minor_units: ledger,
-          hold_balance_minor_units: hold,
-          available_balance_minor_units: ledger - hold,
-          last_journal_entry: journal_entry,
-          last_operational_event: journal_entry.operational_event,
-          as_of_business_date: journal_entry.business_date,
-          last_calculated_at: Time.current
-        )
-        projection
-      end
-
       def update_projection!(projection, ledger_delta)
         ledger = projection.ledger_balance_minor_units + ledger_delta
-        hold = hold_balance_minor_units(projection.deposit_account_id)
+        resolved = AvailableBalanceResolver.call(
+          deposit_account_id: projection.deposit_account_id,
+          ledger_balance_minor_units: ledger
+        )
         projection.update!(
-          ledger_balance_minor_units: ledger,
-          hold_balance_minor_units: hold,
-          available_balance_minor_units: ledger - hold,
+          ledger_balance_minor_units: resolved.ledger_balance_minor_units,
+          hold_balance_minor_units: resolved.hold_balance_minor_units,
+          available_balance_minor_units: resolved.available_balance_minor_units,
           last_journal_entry: journal_entry,
           last_operational_event: journal_entry.operational_event,
           as_of_business_date: journal_entry.business_date,
           last_calculated_at: Time.current
         )
         projection
-      end
-
-      def journal_ledger_balance_minor_units(deposit_account_id)
-        dda = Core::Ledger::Models::GlAccount.find_by!(account_number: GL_DDA)
-        lines = Core::Ledger::Models::JournalLine.where(gl_account_id: dda.id, deposit_account_id: deposit_account_id)
-        credits = lines.where(side: "credit").sum(:amount_minor_units)
-        debits = lines.where(side: "debit").sum(:amount_minor_units)
-        credits - debits
-      end
-
-      def hold_balance_minor_units(deposit_account_id)
-        Models::Hold.active_for_account(deposit_account_id).sum(:amount_minor_units)
       end
     end
   end

--- a/app/domains/accounts/services/deposit_balance_projector.rb
+++ b/app/domains/accounts/services/deposit_balance_projector.rb
@@ -53,7 +53,7 @@ module Accounts
       end
 
       def self.rebuild_projection!(projection, journal_entry: nil, operational_event: nil, as_of_business_date: nil)
-        resolved = AvailableBalanceResolver.call(deposit_account_id: projection.deposit_account_id)
+        resolved = AvailableBalanceResolver.from_journal(deposit_account_id: projection.deposit_account_id)
         projection.update!(
           ledger_balance_minor_units: resolved.ledger_balance_minor_units,
           hold_balance_minor_units: resolved.hold_balance_minor_units,

--- a/app/domains/accounts/services/deposit_balance_projector.rb
+++ b/app/domains/accounts/services/deposit_balance_projector.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Services
+    class DepositBalanceProjector
+      GL_DDA = "2110"
+
+      def self.apply_journal_entry!(journal_entry:)
+        new(journal_entry: journal_entry).apply!
+      end
+
+      def initialize(journal_entry:)
+        @journal_entry = journal_entry
+      end
+
+      def apply!
+        deltas_by_account_id.map do |deposit_account_id, ledger_delta|
+          projection, created = projection_for(deposit_account_id)
+          if created
+            rebuild_projection!(projection)
+          else
+            update_projection!(projection, ledger_delta)
+          end
+        end
+      end
+
+      private
+
+      attr_reader :journal_entry
+
+      def deltas_by_account_id
+        @deltas_by_account_id ||= deposit_ledger_lines.each_with_object(Hash.new(0)) do |line, deltas|
+          deltas[line.deposit_account_id] += signed_amount(line)
+        end
+      end
+
+      def deposit_ledger_lines
+        @deposit_ledger_lines ||= journal_entry
+          .journal_lines
+          .includes(:gl_account)
+          .select { |line| line.deposit_account_id.present? && line.gl_account.account_number == GL_DDA }
+      end
+
+      def signed_amount(line)
+        line.side == "credit" ? line.amount_minor_units : -line.amount_minor_units
+      end
+
+      def projection_for(deposit_account_id)
+        projection = Models::DepositAccountBalanceProjection.lock.find_by(deposit_account_id: deposit_account_id)
+        return [ projection, false ] if projection
+
+        [ Models::DepositAccountBalanceProjection.create!(deposit_account_id: deposit_account_id), true ]
+      rescue ActiveRecord::RecordNotUnique
+        retry
+      end
+
+      def rebuild_projection!(projection)
+        ledger = journal_ledger_balance_minor_units(projection.deposit_account_id)
+        hold = hold_balance_minor_units(projection.deposit_account_id)
+        projection.update!(
+          ledger_balance_minor_units: ledger,
+          hold_balance_minor_units: hold,
+          available_balance_minor_units: ledger - hold,
+          last_journal_entry: journal_entry,
+          last_operational_event: journal_entry.operational_event,
+          as_of_business_date: journal_entry.business_date,
+          last_calculated_at: Time.current
+        )
+        projection
+      end
+
+      def update_projection!(projection, ledger_delta)
+        ledger = projection.ledger_balance_minor_units + ledger_delta
+        hold = hold_balance_minor_units(projection.deposit_account_id)
+        projection.update!(
+          ledger_balance_minor_units: ledger,
+          hold_balance_minor_units: hold,
+          available_balance_minor_units: ledger - hold,
+          last_journal_entry: journal_entry,
+          last_operational_event: journal_entry.operational_event,
+          as_of_business_date: journal_entry.business_date,
+          last_calculated_at: Time.current
+        )
+        projection
+      end
+
+      def journal_ledger_balance_minor_units(deposit_account_id)
+        dda = Core::Ledger::Models::GlAccount.find_by!(account_number: GL_DDA)
+        lines = Core::Ledger::Models::JournalLine.where(gl_account_id: dda.id, deposit_account_id: deposit_account_id)
+        credits = lines.where(side: "credit").sum(:amount_minor_units)
+        debits = lines.where(side: "debit").sum(:amount_minor_units)
+        credits - debits
+      end
+
+      def hold_balance_minor_units(deposit_account_id)
+        Models::Hold.active_for_account(deposit_account_id).sum(:amount_minor_units)
+      end
+    end
+  end
+end

--- a/app/domains/core/business_date/commands/close_business_date.rb
+++ b/app/domains/core/business_date/commands/close_business_date.rb
@@ -32,6 +32,8 @@ module Core
               raise Errors::EodNotReady.new("EOD readiness checks failed for #{closing_on.iso8601}", readiness)
             end
 
+            snapshot_result = Reporting::Commands::MaterializeDailyBalanceSnapshots.call(as_of_date: closing_on)
+
             next_on = closing_on + 1.day
             setting.update!(current_business_on: next_on)
 
@@ -44,7 +46,8 @@ module Core
             {
               setting: setting.reload,
               closed_on: closing_on,
-              previous_business_on: closing_on
+              previous_business_on: closing_on,
+              daily_balance_snapshots_materialized: snapshot_result.snapshots_materialized
             }
           end
         end

--- a/app/domains/core/posting/commands/post_event.rb
+++ b/app/domains/core/posting/commands/post_event.rb
@@ -63,6 +63,8 @@ module Core
               )
             end
 
+            Accounts::Services::DepositBalanceProjector.apply_journal_entry!(journal_entry: entry)
+
             ActiveRecord::Base.connection.execute("SET CONSTRAINTS ALL IMMEDIATE")
 
             batch.update!(status: "posted")

--- a/app/domains/deposits/queries/statement_activity.rb
+++ b/app/domains/deposits/queries/statement_activity.rb
@@ -23,7 +23,7 @@ module Deposits
         raise ArgumentError, "period_start_on must be on or before period_end_on" if start_on > end_on
 
         dda = Core::Ledger::Models::GlAccount.find_by(account_number: GL_DDA)
-        opening = dda ? ledger_balance_before(dda, account.id, start_on) : 0
+        opening = opening_ledger_balance(dda, account.id, start_on)
         ledger_lines = dda ? ledger_line_items(dda, account.id, start_on, end_on) : []
         no_gl_lines = no_gl_line_items(account.id, start_on, end_on)
 
@@ -49,12 +49,32 @@ module Deposits
           period_start_on: start_on,
           period_end_on: end_on,
           opening_ledger_balance_minor_units: opening,
-          closing_ledger_balance_minor_units: running,
+          closing_ledger_balance_minor_units: closing_ledger_balance(account.id, end_on, running),
           total_debits_minor_units: total_debits,
           total_credits_minor_units: total_credits,
           line_items: lines
         )
       end
+
+      def self.opening_ledger_balance(dda, deposit_account_id, start_on)
+        snapshot_balance = Reporting::Queries::DepositDailyBalanceSnapshot.ledger_balance_minor_units(
+          deposit_account_id: deposit_account_id,
+          as_of_date: start_on - 1.day
+        )
+        return snapshot_balance unless snapshot_balance.nil?
+        return 0 if dda.nil?
+
+        ledger_balance_before(dda, deposit_account_id, start_on)
+      end
+      private_class_method :opening_ledger_balance
+
+      def self.closing_ledger_balance(deposit_account_id, end_on, running_balance)
+        Reporting::Queries::DepositDailyBalanceSnapshot.ledger_balance_minor_units(
+          deposit_account_id: deposit_account_id,
+          as_of_date: end_on
+        ) || running_balance
+      end
+      private_class_method :closing_ledger_balance
 
       def self.ledger_balance_before(dda, deposit_account_id, before_date)
         scope = Core::Ledger::Models::JournalLine

--- a/app/domains/reporting/commands/mark_daily_balance_snapshots_stale_for_version.rb
+++ b/app/domains/reporting/commands/mark_daily_balance_snapshots_stale_for_version.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Reporting
+  module Commands
+    class MarkDailyBalanceSnapshotsStaleForVersion
+      Result = Data.define(:expected_calculation_version, :marked_count)
+
+      def self.call(expected_calculation_version: Accounts::Models::DepositAccountBalanceProjection::CURRENT_CALCULATION_VERSION)
+        new(expected_calculation_version: expected_calculation_version).call
+      end
+
+      def initialize(expected_calculation_version:)
+        @expected_calculation_version = expected_calculation_version
+      end
+
+      def call
+        count = stale_scope.update_all(
+          stale: true,
+          stale_from_date: Arel.sql("as_of_date"),
+          updated_at: Time.current
+        )
+
+        Result.new(expected_calculation_version: expected_calculation_version, marked_count: count)
+      end
+
+      private
+
+      attr_reader :expected_calculation_version
+
+      def stale_scope
+        Models::DailyBalanceSnapshot
+          .where(stale: false)
+          .where.not(calculation_version: expected_calculation_version)
+      end
+    end
+  end
+end

--- a/app/domains/reporting/commands/materialize_daily_balance_snapshots.rb
+++ b/app/domains/reporting/commands/materialize_daily_balance_snapshots.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Reporting
+  module Commands
+    class MaterializeDailyBalanceSnapshots
+      Result = Data.define(:as_of_date, :snapshots_materialized)
+
+      def self.call(as_of_date:, source: Models::DailyBalanceSnapshot::SOURCE_CURRENT_PROJECTION)
+        new(as_of_date: as_of_date, source: source).call
+      end
+
+      def initialize(as_of_date:, source:)
+        @as_of_date = Date.iso8601(as_of_date.to_s)
+        @source = source
+      end
+
+      def call
+        count = 0
+        Models::DailyBalanceSnapshot.transaction do
+          deposit_projections.find_each do |projection|
+            materialize_projection!(projection)
+            count += 1
+          end
+        end
+
+        Result.new(as_of_date: as_of_date, snapshots_materialized: count)
+      end
+
+      private
+
+      attr_reader :as_of_date, :source
+
+      def deposit_projections
+        Accounts::Models::DepositAccountBalanceProjection.order(:deposit_account_id)
+      end
+
+      def materialize_projection!(projection)
+        snapshot = Models::DailyBalanceSnapshot.find_or_initialize_by(
+          account_domain: Models::DailyBalanceSnapshot::ACCOUNT_DOMAIN_DEPOSITS,
+          account_id: projection.deposit_account_id,
+          as_of_date: as_of_date
+        )
+        snapshot.assign_attributes(
+          account_type: Models::DailyBalanceSnapshot::ACCOUNT_TYPE_DEPOSIT_ACCOUNT,
+          ledger_balance_minor_units: projection.ledger_balance_minor_units,
+          hold_balance_minor_units: projection.hold_balance_minor_units,
+          available_balance_minor_units: projection.available_balance_minor_units,
+          collected_balance_minor_units: projection.collected_balance_minor_units,
+          source: source,
+          calculation_version: projection.calculation_version
+        )
+        snapshot.save!
+        snapshot
+      end
+    end
+  end
+end

--- a/app/domains/reporting/commands/materialize_daily_balance_snapshots.rb
+++ b/app/domains/reporting/commands/materialize_daily_balance_snapshots.rb
@@ -14,13 +14,18 @@ module Reporting
 
       Result = Data.define(:as_of_date, :snapshots_materialized)
 
-      def self.call(as_of_date:, source: Models::DailyBalanceSnapshot::SOURCE_CURRENT_PROJECTION)
-        new(as_of_date: as_of_date, source: source).call
+      def self.call(
+        as_of_date:,
+        source: Models::DailyBalanceSnapshot::SOURCE_CURRENT_PROJECTION,
+        expected_calculation_version: Accounts::Models::DepositAccountBalanceProjection::CURRENT_CALCULATION_VERSION
+      )
+        new(as_of_date: as_of_date, source: source, expected_calculation_version: expected_calculation_version).call
       end
 
-      def initialize(as_of_date:, source:)
+      def initialize(as_of_date:, source:, expected_calculation_version:)
         @as_of_date = Date.iso8601(as_of_date.to_s)
         @source = source
+        @expected_calculation_version = expected_calculation_version
       end
 
       def call
@@ -39,7 +44,7 @@ module Reporting
 
       private
 
-      attr_reader :as_of_date, :source
+      attr_reader :as_of_date, :source, :expected_calculation_version
 
       def deposit_accounts
         Accounts::Models::DepositAccount
@@ -53,7 +58,10 @@ module Reporting
       end
 
       def assert_projection_current!(account)
-        drift = Accounts::Queries::DepositBalanceProjectionDrift.call(deposit_account_id: account.id)
+        drift = Accounts::Queries::DepositBalanceProjectionDrift.call(
+          deposit_account_id: account.id,
+          expected_calculation_version: expected_calculation_version
+        )
         raise ProjectionDriftDetected, drift if drift.drifted
       end
 
@@ -61,7 +69,9 @@ module Reporting
         snapshot = Models::DailyBalanceSnapshot.find_or_initialize_by(
           account_domain: Models::DailyBalanceSnapshot::ACCOUNT_DOMAIN_DEPOSITS,
           account_id: projection.deposit_account_id,
-          as_of_date: as_of_date
+          as_of_date: as_of_date,
+          source: source,
+          calculation_version: projection.calculation_version
         )
         snapshot.assign_attributes(
           account_type: Models::DailyBalanceSnapshot::ACCOUNT_TYPE_DEPOSIT_ACCOUNT,
@@ -69,8 +79,8 @@ module Reporting
           hold_balance_minor_units: projection.hold_balance_minor_units,
           available_balance_minor_units: projection.available_balance_minor_units,
           collected_balance_minor_units: projection.collected_balance_minor_units,
-          source: source,
-          calculation_version: projection.calculation_version
+          stale: false,
+          stale_from_date: nil
         )
         snapshot.save!
         snapshot

--- a/app/domains/reporting/commands/materialize_daily_balance_snapshots.rb
+++ b/app/domains/reporting/commands/materialize_daily_balance_snapshots.rb
@@ -3,6 +3,15 @@
 module Reporting
   module Commands
     class MaterializeDailyBalanceSnapshots
+      class ProjectionDriftDetected < StandardError
+        attr_reader :drift
+
+        def initialize(drift)
+          @drift = drift
+          super("deposit balance projection drift detected for deposit_account_id=#{drift.deposit_account_id}")
+        end
+      end
+
       Result = Data.define(:as_of_date, :snapshots_materialized)
 
       def self.call(as_of_date:, source: Models::DailyBalanceSnapshot::SOURCE_CURRENT_PROJECTION)
@@ -17,8 +26,10 @@ module Reporting
       def call
         count = 0
         Models::DailyBalanceSnapshot.transaction do
-          deposit_projections.find_each do |projection|
-            materialize_projection!(projection)
+          deposit_accounts.find_each do |account|
+            projection = projection_for(account)
+            assert_projection_current!(account)
+            materialize_projection!(projection.reload)
             count += 1
           end
         end
@@ -30,8 +41,20 @@ module Reporting
 
       attr_reader :as_of_date, :source
 
-      def deposit_projections
-        Accounts::Models::DepositAccountBalanceProjection.order(:deposit_account_id)
+      def deposit_accounts
+        Accounts::Models::DepositAccount
+          .where(status: Accounts::Models::DepositAccount::STATUS_OPEN)
+          .order(:id)
+      end
+
+      def projection_for(account)
+        account.deposit_account_balance_projection ||
+          Accounts::Commands::RebuildDepositBalanceProjection.call(deposit_account_id: account.id)
+      end
+
+      def assert_projection_current!(account)
+        drift = Accounts::Queries::DepositBalanceProjectionDrift.call(deposit_account_id: account.id)
+        raise ProjectionDriftDetected, drift if drift.drifted
       end
 
       def materialize_projection!(projection)

--- a/app/domains/reporting/models/daily_balance_snapshot.rb
+++ b/app/domains/reporting/models/daily_balance_snapshot.rb
@@ -6,9 +6,15 @@ module Reporting
       self.table_name = "daily_balance_snapshots"
 
       ACCOUNT_DOMAIN_DEPOSITS = "deposits"
+      ACCOUNT_DOMAIN_LOANS = "loans"
       ACCOUNT_TYPE_DEPOSIT_ACCOUNT = "deposit_account"
+      ACCOUNT_TYPE_LOAN_ACCOUNT = "loan_account"
       SOURCE_CURRENT_PROJECTION = "current_projection"
-      ACCOUNT_DOMAINS = [ ACCOUNT_DOMAIN_DEPOSITS ].freeze
+      ACCOUNT_DOMAINS = [ ACCOUNT_DOMAIN_DEPOSITS, ACCOUNT_DOMAIN_LOANS ].freeze
+      ACCOUNT_TYPES_BY_DOMAIN = {
+        ACCOUNT_DOMAIN_DEPOSITS => ACCOUNT_TYPE_DEPOSIT_ACCOUNT,
+        ACCOUNT_DOMAIN_LOANS => ACCOUNT_TYPE_LOAN_ACCOUNT
+      }.freeze
       SOURCES = [ SOURCE_CURRENT_PROJECTION ].freeze
 
       validates :account_domain, :as_of_date, :source, presence: true
@@ -26,6 +32,17 @@ module Reporting
         numericality: { only_integer: true, greater_than: 0 }
       validates :account_id,
         uniqueness: { scope: [ :account_domain, :as_of_date ] }
+      validate :account_type_matches_account_domain
+
+      private
+
+      def account_type_matches_account_domain
+        expected = ACCOUNT_TYPES_BY_DOMAIN[account_domain]
+        return if expected.nil?
+        return if account_type == expected
+
+        errors.add(:account_type, "must be #{expected} for #{account_domain} snapshots")
+      end
     end
   end
 end

--- a/app/domains/reporting/models/daily_balance_snapshot.rb
+++ b/app/domains/reporting/models/daily_balance_snapshot.rb
@@ -31,7 +31,7 @@ module Reporting
       validates :calculation_version,
         numericality: { only_integer: true, greater_than: 0 }
       validates :account_id,
-        uniqueness: { scope: [ :account_domain, :as_of_date ] }
+        uniqueness: { scope: [ :account_domain, :as_of_date, :source, :calculation_version ] }
       validate :account_type_matches_account_domain
 
       private

--- a/app/domains/reporting/models/daily_balance_snapshot.rb
+++ b/app/domains/reporting/models/daily_balance_snapshot.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Reporting
+  module Models
+    class DailyBalanceSnapshot < ApplicationRecord
+      self.table_name = "daily_balance_snapshots"
+
+      ACCOUNT_DOMAIN_DEPOSITS = "deposits"
+      ACCOUNT_TYPE_DEPOSIT_ACCOUNT = "deposit_account"
+      SOURCE_CURRENT_PROJECTION = "current_projection"
+      ACCOUNT_DOMAINS = [ ACCOUNT_DOMAIN_DEPOSITS ].freeze
+      SOURCES = [ SOURCE_CURRENT_PROJECTION ].freeze
+
+      validates :account_domain, :as_of_date, :source, presence: true
+      validates :account_domain, inclusion: { in: ACCOUNT_DOMAINS }
+      validates :source, inclusion: { in: SOURCES }
+      validates :account_id, numericality: { only_integer: true, greater_than: 0 }
+      validates :ledger_balance_minor_units, :available_balance_minor_units,
+        numericality: { only_integer: true }
+      validates :hold_balance_minor_units,
+        numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+      validates :collected_balance_minor_units,
+        numericality: { only_integer: true },
+        allow_nil: true
+      validates :calculation_version,
+        numericality: { only_integer: true, greater_than: 0 }
+      validates :account_id,
+        uniqueness: { scope: [ :account_domain, :as_of_date ] }
+    end
+  end
+end

--- a/app/domains/reporting/queries/deposit_daily_balance_snapshot.rb
+++ b/app/domains/reporting/queries/deposit_daily_balance_snapshot.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Reporting
+  module Queries
+    class DepositDailyBalanceSnapshot
+      def self.find(deposit_account_id:, as_of_date:)
+        Models::DailyBalanceSnapshot.find_by(
+          account_domain: Models::DailyBalanceSnapshot::ACCOUNT_DOMAIN_DEPOSITS,
+          account_id: deposit_account_id,
+          as_of_date: as_of_date.to_date
+        )
+      end
+
+      def self.ledger_balance_minor_units(deposit_account_id:, as_of_date:)
+        find(deposit_account_id: deposit_account_id, as_of_date: as_of_date)&.ledger_balance_minor_units
+      end
+    end
+  end
+end

--- a/app/views/ops/balance_projections/_daily_snapshots.html.erb
+++ b/app/views/ops/balance_projections/_daily_snapshots.html.erb
@@ -1,0 +1,30 @@
+<% if daily_snapshots.any? %>
+  <div class="overflow-x-auto">
+    <table class="min-w-full divide-y divide-slate-200 text-sm">
+      <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+        <tr>
+          <th class="px-5 py-3">Date</th>
+          <th class="px-5 py-3 text-right">Ledger</th>
+          <th class="px-5 py-3 text-right">Available</th>
+          <th class="px-5 py-3">Source</th>
+          <th class="px-5 py-3">Version</th>
+          <th class="px-5 py-3">Status</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-slate-100">
+        <% daily_snapshots.each do |snapshot| %>
+          <tr>
+            <td class="px-5 py-4"><%= snapshot.as_of_date.iso8601 %></td>
+            <td class="px-5 py-4 text-right"><%= ops_money(snapshot.ledger_balance_minor_units, signed: true) %></td>
+            <td class="px-5 py-4 text-right"><%= ops_money(snapshot.available_balance_minor_units, signed: true) %></td>
+            <td class="px-5 py-4"><%= snapshot.source.humanize %></td>
+            <td class="px-5 py-4"><%= snapshot.calculation_version %></td>
+            <td class="px-5 py-4"><%= ops_status_badge(snapshot.stale? ? "stale" : "current") %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% else %>
+  <div class="p-5 text-sm text-slate-600">No daily snapshots recorded.</div>
+<% end %>

--- a/app/views/ops/balance_projections/_rebuild_requests.html.erb
+++ b/app/views/ops/balance_projections/_rebuild_requests.html.erb
@@ -1,0 +1,30 @@
+<% if rebuild_requests.any? %>
+  <div class="overflow-x-auto">
+    <table class="min-w-full divide-y divide-slate-200 text-sm">
+      <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+        <tr>
+          <th class="px-5 py-3">Request</th>
+          <th class="px-5 py-3">Account</th>
+          <th class="px-5 py-3">Reason</th>
+          <th class="px-5 py-3">Status</th>
+          <th class="px-5 py-3">Version</th>
+          <th class="px-5 py-3">Requested</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-slate-100">
+        <% rebuild_requests.each do |request| %>
+          <tr>
+            <td class="px-5 py-4">#<%= request.id %></td>
+            <td class="px-5 py-4"><%= request.deposit_account&.account_number || "##{request.deposit_account_id}" %></td>
+            <td class="px-5 py-4"><%= request.reason.humanize %></td>
+            <td class="px-5 py-4"><%= ops_status_badge(request.status) %></td>
+            <td class="px-5 py-4"><%= request.calculation_version %></td>
+            <td class="px-5 py-4"><%= ops_time(request.requested_at) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% else %>
+  <div class="p-5 text-sm text-slate-600">No rebuild evidence recorded.</div>
+<% end %>

--- a/app/views/ops/balance_projections/bulk_repair.html.erb
+++ b/app/views/ops/balance_projections/bulk_repair.html.erb
@@ -1,0 +1,42 @@
+<% content_for :title, "Balance Projection Bulk Repair - BankCORE" %>
+
+<section>
+  <h1 class="text-3xl font-semibold">Bulk balance repair</h1>
+  <p class="mt-2 text-slate-600">Preview counts before running version and stale repair actions. Operations reconciliation capability is required.</p>
+  <p class="mt-2"><%= link_to "Back to balance health", ops_balance_projections_path, class: "text-sm font-medium text-slate-700 underline" %></p>
+</section>
+
+<% if @error_message.present? %>
+  <section class="mt-6 rounded border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+    <%= @error_message %>
+  </section>
+<% end %>
+
+<section class="mt-8 grid gap-4 md:grid-cols-3">
+  <%= render "ops/eod/readiness_card", label: "Version mismatches", value: @health.projection_version_mismatch_count, state: @health.projection_version_mismatch_count.zero? %>
+  <%= render "ops/eod/readiness_card", label: "Stale projections", value: @health.stale_projection_count, state: @health.stale_projection_count.zero? %>
+  <%= render "ops/eod/readiness_card", label: "Stale snapshots", value: @health.stale_daily_snapshot_count, state: @health.stale_daily_snapshot_count.zero? %>
+</section>
+
+<section class="mt-8 rounded border border-slate-200 bg-white p-5 shadow-sm">
+  <h2 class="text-xl font-semibold">Run bulk action</h2>
+  <p class="mt-1 text-sm text-slate-600">Use small batches for rebuild execution. Marking stale records evidence; rebuilding repairs stale projections.</p>
+  <%= form_with url: ops_balance_projection_bulk_repair_path, method: :post, scope: :bulk_repair, class: "mt-4 space-y-4" do |form| %>
+    <div>
+      <%= form.label :action_type, "Action", class: "block text-sm font-medium text-slate-700" %>
+      <%= form.select :action_type,
+        [
+          [ "Mark projection version mismatches stale", "mark_projection_versions" ],
+          [ "Mark daily snapshot version mismatches stale", "mark_snapshot_versions" ],
+          [ "Rebuild stale projections", "rebuild_stale_projections" ]
+        ],
+        {},
+        class: "mt-1 rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
+      <%= form.label :limit, "Batch limit for rebuilds", class: "block text-sm font-medium text-slate-700" %>
+      <%= form.number_field :limit, value: 25, min: 1, max: 200, class: "mt-1 rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <%= form.submit "Run bulk action", class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+  <% end %>
+</section>

--- a/app/views/ops/balance_projections/index.html.erb
+++ b/app/views/ops/balance_projections/index.html.erb
@@ -1,0 +1,84 @@
+<% content_for :title, "Balance Projections - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">Balance projection health</h1>
+    <p class="mt-2 text-slate-600">Read projection drift, rebuild evidence, and daily snapshot health before operational repair.</p>
+  </div>
+  <%= link_to "Bulk repair", ops_balance_projection_bulk_repair_path, class: "rounded border border-slate-300 bg-white px-4 py-2 font-medium text-slate-700" %>
+</section>
+
+<section class="mt-8 grid gap-4 md:grid-cols-3">
+  <%= render "ops/eod/readiness_card", label: "Stale projections", value: @health.stale_projection_count, state: @health.stale_projection_count.zero? %>
+  <%= render "ops/eod/readiness_card", label: "Version mismatches", value: @health.projection_version_mismatch_count, state: @health.projection_version_mismatch_count.zero? %>
+  <%= render "ops/eod/readiness_card", label: "Pending rebuilds", value: @health.pending_rebuild_request_count, state: @health.pending_rebuild_request_count.zero? %>
+  <%= render "ops/eod/readiness_card", label: "Stale daily snapshots", value: @health.stale_daily_snapshot_count, state: @health.stale_daily_snapshot_count.zero? %>
+  <%= render "ops/eod/readiness_card", label: "Latest snapshot date", value: @health.latest_snapshot_date&.iso8601 || "None", state: @health.latest_snapshot_date.present? %>
+  <%= render "ops/eod/readiness_card", label: "Latest snapshot rows", value: @health.latest_snapshot_count, state: true %>
+</section>
+
+<section class="mt-8 rounded border border-slate-200 bg-white p-5 shadow-sm">
+  <h2 class="text-xl font-semibold">Account lookup</h2>
+  <p class="mt-1 text-sm text-slate-600">Search by deposit account id or account number to inspect one projection.</p>
+  <%= form_with url: ops_balance_projections_path, method: :get, class: "mt-4 flex gap-3" do |form| %>
+    <%= form.text_field :account, value: params[:account], placeholder: "Account id or number", class: "w-full rounded border border-slate-300 px-3 py-2" %>
+    <%= form.submit "Lookup", class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+  <% end %>
+</section>
+
+<% if @account_error.present? %>
+  <section class="mt-6 rounded border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+    <%= @account_error %>
+  </section>
+<% elsif @account.present? %>
+  <section class="mt-8 rounded border border-slate-200 bg-white shadow-sm">
+    <div class="border-b border-slate-200 px-5 py-4">
+      <h2 class="text-xl font-semibold">Account <%= @account.account_number %></h2>
+      <p class="mt-1 text-sm text-slate-600">Projection and drift evidence for account #<%= @account.id %>.</p>
+    </div>
+    <div class="grid gap-4 p-5 md:grid-cols-3">
+      <div class="rounded border border-slate-200 p-4">
+        <div class="text-sm text-slate-500">Ledger</div>
+        <div class="mt-1 text-2xl font-semibold"><%= ops_money(@projection&.ledger_balance_minor_units || 0, signed: true) %></div>
+      </div>
+      <div class="rounded border border-slate-200 p-4">
+        <div class="text-sm text-slate-500">Available</div>
+        <div class="mt-1 text-2xl font-semibold"><%= ops_money(@projection&.available_balance_minor_units || 0, signed: true) %></div>
+      </div>
+      <div class="rounded border border-slate-200 p-4">
+        <div class="text-sm text-slate-500">Drift status</div>
+        <div class="mt-2"><%= ops_status_badge(@drift.drifted ? "drifted" : "current") %></div>
+      </div>
+    </div>
+    <div class="border-t border-slate-200 p-5">
+      <h3 class="font-semibold">Single-account controls</h3>
+      <p class="mt-1 text-sm text-slate-600">Ops reconciliation capability is required. Actions affect only this account.</p>
+      <div class="mt-4 flex flex-wrap gap-3">
+        <%= button_to "Mark stale", ops_mark_stale_balance_projection_path(@account), method: :post, class: "rounded border border-amber-300 bg-amber-50 px-4 py-2 font-medium text-amber-900" %>
+        <%= button_to "Rebuild projection", ops_rebuild_balance_projection_path(@account), method: :post, class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
+      </div>
+    </div>
+  </section>
+
+  <section class="mt-8 grid gap-6 lg:grid-cols-2">
+    <div class="rounded border border-slate-200 bg-white shadow-sm">
+      <div class="border-b border-slate-200 px-5 py-4">
+        <h3 class="font-semibold">Rebuild evidence</h3>
+      </div>
+      <%= render "rebuild_requests", rebuild_requests: @rebuild_requests %>
+    </div>
+    <div class="rounded border border-slate-200 bg-white shadow-sm">
+      <div class="border-b border-slate-200 px-5 py-4">
+        <h3 class="font-semibold">Daily snapshots</h3>
+      </div>
+      <%= render "daily_snapshots", daily_snapshots: @daily_snapshots %>
+    </div>
+  </section>
+<% end %>
+
+<section class="mt-8 rounded border border-slate-200 bg-white shadow-sm">
+  <div class="border-b border-slate-200 px-5 py-4">
+    <h2 class="text-xl font-semibold">Recent rebuild evidence</h2>
+  </div>
+  <%= render "rebuild_requests", rebuild_requests: @health.recent_rebuild_requests %>
+</section>

--- a/app/views/ops/business_date_closes/new.html.erb
+++ b/app/views/ops/business_date_closes/new.html.erb
@@ -29,6 +29,23 @@
     <%= render "ops/eod/readiness_card", label: "Posting day closed", value: @readiness[:posting_day_closed] ? "Yes" : "No", state: !@readiness[:posting_day_closed] %>
   </section>
 
+  <% if @balance_projection_health.present? %>
+    <section class="mt-8 rounded border border-slate-200 bg-white p-5 shadow-sm">
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <h2 class="text-xl font-semibold">Balance projection health</h2>
+          <p class="mt-1 text-sm text-slate-600">Projection and snapshot health before close snapshot materialization.</p>
+        </div>
+        <%= link_to "Open balance health", ops_balance_projections_path, class: "rounded border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700" %>
+      </div>
+      <div class="mt-5 grid gap-4 md:grid-cols-3">
+        <%= render "ops/eod/readiness_card", label: "Stale projections", value: @balance_projection_health.stale_projection_count, state: @balance_projection_health.stale_projection_count.zero? %>
+        <%= render "ops/eod/readiness_card", label: "Version mismatches", value: @balance_projection_health.projection_version_mismatch_count, state: @balance_projection_health.projection_version_mismatch_count.zero? %>
+        <%= render "ops/eod/readiness_card", label: "Pending rebuilds", value: @balance_projection_health.pending_rebuild_request_count, state: @balance_projection_health.pending_rebuild_request_count.zero? %>
+      </div>
+    </section>
+  <% end %>
+
   <section class="mt-8 rounded border border-slate-200 bg-white p-5 shadow-sm">
     <h2 class="text-xl font-semibold">Confirmation</h2>
     <% if @readiness[:eod_ready] %>

--- a/app/views/ops/dashboard/index.html.erb
+++ b/app/views/ops/dashboard/index.html.erb
@@ -38,6 +38,11 @@
     <p class="mt-2 text-sm text-slate-600">Preview and run monthly fees or statement generation.</p>
   <% end %>
 
+  <%= link_to ops_balance_projections_path, class: "rounded border border-slate-200 bg-white p-5 shadow-sm hover:border-slate-400" do %>
+    <h2 class="font-semibold">Balance projections</h2>
+    <p class="mt-2 text-sm text-slate-600">Review projection drift, rebuild evidence, and daily snapshot health.</p>
+  <% end %>
+
   <%= link_to ops_new_ach_receipt_ingestion_path, class: "rounded border border-slate-200 bg-white p-5 shadow-sm hover:border-slate-400" do %>
     <h2 class="font-semibold">ACH receipt ingestion</h2>
     <p class="mt-2 text-sm text-slate-600">Upload structured ACH credit receipt input and review item outcomes.</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,17 @@ Rails.application.routes.draw do
     get "engine_runs", to: "engine_runs#index", as: :engine_runs
     get "engine_runs/:engine/new", to: "engine_runs#new", as: :new_engine_run
     post "engine_runs/:engine", to: "engine_runs#create", as: :engine_run
+    get "balance_projections", to: "balance_projections#index", as: :balance_projections
+    post "balance_projections/:deposit_account_id/mark_stale",
+      to: "balance_projections#mark_stale",
+      as: :mark_stale_balance_projection
+    post "balance_projections/:deposit_account_id/rebuild",
+      to: "balance_projections#rebuild",
+      as: :rebuild_balance_projection
+    get "balance_projections/bulk_repair",
+      to: "balance_projections#bulk_repair",
+      as: :balance_projection_bulk_repair
+    post "balance_projections/bulk_repair", to: "balance_projections#create_bulk_repair"
     get "ach_receipt_ingestions/new", to: "ach_receipt_ingestions#new", as: :new_ach_receipt_ingestion
     post "ach_receipt_ingestions", to: "ach_receipt_ingestions#create", as: :ach_receipt_ingestions
     resources :teller_variances, only: [ :index ] do

--- a/db/migrate/20260502215000_create_deposit_account_balance_projections.rb
+++ b/db/migrate/20260502215000_create_deposit_account_balance_projections.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class CreateDepositAccountBalanceProjections < ActiveRecord::Migration[8.1]
+  def change
+    create_table :deposit_account_balance_projections do |t|
+      t.references :deposit_account,
+        null: false,
+        foreign_key: true,
+        index: { unique: true, name: "idx_deposit_balance_proj_account_unique" }
+      t.bigint :ledger_balance_minor_units, null: false, default: 0
+      t.bigint :hold_balance_minor_units, null: false, default: 0
+      t.bigint :available_balance_minor_units, null: false, default: 0
+      t.bigint :collected_balance_minor_units
+      t.references :last_journal_entry,
+        foreign_key: { to_table: :journal_entries },
+        index: { name: "idx_deposit_balance_proj_last_journal_entry" }
+      t.references :last_operational_event,
+        foreign_key: { to_table: :operational_events },
+        index: { name: "idx_deposit_balance_proj_last_operational_event" }
+      t.date :as_of_business_date
+      t.datetime :last_calculated_at
+      t.boolean :stale, null: false, default: false
+      t.date :stale_from_date
+      t.integer :calculation_version, null: false, default: 1
+      t.timestamps
+    end
+
+    add_index :deposit_account_balance_projections,
+      [ :stale, :stale_from_date ],
+      name: "idx_deposit_balance_proj_stale_from_date"
+    add_index :deposit_account_balance_projections,
+      :as_of_business_date,
+      name: "idx_deposit_balance_proj_as_of_business_date"
+
+    add_check_constraint :deposit_account_balance_projections,
+      "hold_balance_minor_units >= 0",
+      name: "chk_deposit_balance_proj_hold_non_negative"
+    add_check_constraint :deposit_account_balance_projections,
+      "calculation_version > 0",
+      name: "chk_deposit_balance_proj_calculation_version_positive"
+  end
+end

--- a/db/migrate/20260502220000_create_daily_balance_snapshots.rb
+++ b/db/migrate/20260502220000_create_daily_balance_snapshots.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class CreateDailyBalanceSnapshots < ActiveRecord::Migration[8.1]
+  def change
+    create_table :daily_balance_snapshots do |t|
+      t.string :account_domain, null: false
+      t.bigint :account_id, null: false
+      t.string :account_type
+      t.date :as_of_date, null: false
+      t.bigint :ledger_balance_minor_units, null: false
+      t.bigint :hold_balance_minor_units, null: false, default: 0
+      t.bigint :available_balance_minor_units, null: false
+      t.bigint :collected_balance_minor_units
+      t.string :source, null: false
+      t.integer :calculation_version, null: false
+      t.timestamps
+    end
+
+    add_index :daily_balance_snapshots,
+      [ :account_domain, :account_id, :as_of_date ],
+      unique: true,
+      name: "idx_daily_balance_snapshots_account_date"
+    add_index :daily_balance_snapshots,
+      [ :account_domain, :as_of_date ],
+      name: "idx_daily_balance_snapshots_domain_date"
+    add_index :daily_balance_snapshots,
+      :as_of_date,
+      name: "idx_daily_balance_snapshots_as_of_date"
+
+    add_check_constraint :daily_balance_snapshots,
+      "hold_balance_minor_units >= 0",
+      name: "chk_daily_balance_snapshots_hold_non_negative"
+    add_check_constraint :daily_balance_snapshots,
+      "calculation_version > 0",
+      name: "chk_daily_balance_snapshots_calc_version_positive"
+  end
+end

--- a/db/migrate/20260502221000_create_deposit_balance_rebuild_requests.rb
+++ b/db/migrate/20260502221000_create_deposit_balance_rebuild_requests.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class CreateDepositBalanceRebuildRequests < ActiveRecord::Migration[8.1]
+  def change
+    create_table :deposit_balance_rebuild_requests do |t|
+      t.references :deposit_account, null: false, foreign_key: true, index: { name: "idx_deposit_balance_rebuild_requests_account" }
+      t.string :rebuild_type, null: false
+      t.string :reason, null: false
+      t.string :status, null: false
+      t.date :rebuild_from_date
+      t.date :rebuild_through_date
+      t.references :source_operational_event,
+        foreign_key: { to_table: :operational_events },
+        index: { name: "idx_deposit_balance_rebuild_requests_source_event" }
+      t.integer :calculation_version, null: false
+      t.datetime :requested_at, null: false
+      t.datetime :processed_at
+      t.timestamps
+    end
+
+    add_index :deposit_balance_rebuild_requests,
+      [ :status, :requested_at ],
+      name: "idx_deposit_balance_rebuild_requests_status_requested"
+    add_index :deposit_balance_rebuild_requests,
+      [ :deposit_account_id, :status ],
+      name: "idx_deposit_balance_rebuild_requests_account_status"
+    add_check_constraint :deposit_balance_rebuild_requests,
+      "calculation_version > 0",
+      name: "chk_deposit_balance_rebuild_requests_calc_version_positive"
+  end
+end

--- a/db/migrate/20260502222000_harden_daily_balance_snapshot_versioning.rb
+++ b/db/migrate/20260502222000_harden_daily_balance_snapshot_versioning.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class HardenDailyBalanceSnapshotVersioning < ActiveRecord::Migration[8.1]
+  def change
+    remove_index :daily_balance_snapshots, name: "idx_daily_balance_snapshots_account_date"
+
+    add_column :daily_balance_snapshots, :stale, :boolean, null: false, default: false
+    add_column :daily_balance_snapshots, :stale_from_date, :date
+
+    add_index :daily_balance_snapshots,
+      [ :account_domain, :account_id, :as_of_date, :source, :calculation_version ],
+      unique: true,
+      name: "idx_daily_balance_snapshots_account_date_source_version"
+    add_index :daily_balance_snapshots,
+      [ :stale, :stale_from_date ],
+      name: "idx_daily_balance_snapshots_stale_from_date"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -547,6 +547,8 @@ CREATE TABLE public.daily_balance_snapshots (
     calculation_version integer NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
+    stale boolean DEFAULT false NOT NULL,
+    stale_from_date date,
     CONSTRAINT chk_daily_balance_snapshots_calc_version_positive CHECK ((calculation_version > 0)),
     CONSTRAINT chk_daily_balance_snapshots_hold_non_negative CHECK ((hold_balance_minor_units >= 0))
 );
@@ -762,6 +764,47 @@ CREATE SEQUENCE public.deposit_accounts_id_seq
 --
 
 ALTER SEQUENCE public.deposit_accounts_id_seq OWNED BY public.deposit_accounts.id;
+
+
+--
+-- Name: deposit_balance_rebuild_requests; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.deposit_balance_rebuild_requests (
+    id bigint NOT NULL,
+    deposit_account_id bigint NOT NULL,
+    rebuild_type character varying NOT NULL,
+    reason character varying NOT NULL,
+    status character varying NOT NULL,
+    rebuild_from_date date,
+    rebuild_through_date date,
+    source_operational_event_id bigint,
+    calculation_version integer NOT NULL,
+    requested_at timestamp(6) without time zone NOT NULL,
+    processed_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    CONSTRAINT chk_deposit_balance_rebuild_requests_calc_version_positive CHECK ((calculation_version > 0))
+);
+
+
+--
+-- Name: deposit_balance_rebuild_requests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.deposit_balance_rebuild_requests_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: deposit_balance_rebuild_requests_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.deposit_balance_rebuild_requests_id_seq OWNED BY public.deposit_balance_rebuild_requests.id;
 
 
 --
@@ -1833,6 +1876,13 @@ ALTER TABLE ONLY public.deposit_accounts ALTER COLUMN id SET DEFAULT nextval('pu
 
 
 --
+-- Name: deposit_balance_rebuild_requests id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.deposit_balance_rebuild_requests ALTER COLUMN id SET DEFAULT nextval('public.deposit_balance_rebuild_requests_id_seq'::regclass);
+
+
+--
 -- Name: deposit_product_fee_rules id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -2137,6 +2187,14 @@ ALTER TABLE ONLY public.deposit_accounts
 
 
 --
+-- Name: deposit_balance_rebuild_requests deposit_balance_rebuild_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.deposit_balance_rebuild_requests
+    ADD CONSTRAINT deposit_balance_rebuild_requests_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: deposit_product_fee_rules deposit_product_fee_rules_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2393,10 +2451,10 @@ CREATE INDEX idx_cash_movements_external_shipment_reference ON public.cash_movem
 
 
 --
--- Name: idx_daily_balance_snapshots_account_date; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_daily_balance_snapshots_account_date_source_version; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX idx_daily_balance_snapshots_account_date ON public.daily_balance_snapshots USING btree (account_domain, account_id, as_of_date);
+CREATE UNIQUE INDEX idx_daily_balance_snapshots_account_date_source_version ON public.daily_balance_snapshots USING btree (account_domain, account_id, as_of_date, source, calculation_version);
 
 
 --
@@ -2411,6 +2469,13 @@ CREATE INDEX idx_daily_balance_snapshots_as_of_date ON public.daily_balance_snap
 --
 
 CREATE INDEX idx_daily_balance_snapshots_domain_date ON public.daily_balance_snapshots USING btree (account_domain, as_of_date);
+
+
+--
+-- Name: idx_daily_balance_snapshots_stale_from_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_daily_balance_snapshots_stale_from_date ON public.daily_balance_snapshots USING btree (stale, stale_from_date);
 
 
 --
@@ -2460,6 +2525,34 @@ CREATE INDEX idx_deposit_balance_proj_last_operational_event ON public.deposit_a
 --
 
 CREATE INDEX idx_deposit_balance_proj_stale_from_date ON public.deposit_account_balance_projections USING btree (stale, stale_from_date);
+
+
+--
+-- Name: idx_deposit_balance_rebuild_requests_account; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_deposit_balance_rebuild_requests_account ON public.deposit_balance_rebuild_requests USING btree (deposit_account_id);
+
+
+--
+-- Name: idx_deposit_balance_rebuild_requests_account_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_deposit_balance_rebuild_requests_account_status ON public.deposit_balance_rebuild_requests USING btree (deposit_account_id, status);
+
+
+--
+-- Name: idx_deposit_balance_rebuild_requests_source_event; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_deposit_balance_rebuild_requests_source_event ON public.deposit_balance_rebuild_requests USING btree (source_operational_event_id);
+
+
+--
+-- Name: idx_deposit_balance_rebuild_requests_status_requested; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_deposit_balance_rebuild_requests_status_requested ON public.deposit_balance_rebuild_requests USING btree (status, requested_at);
 
 
 --
@@ -3626,11 +3719,27 @@ ALTER TABLE ONLY public.cash_balances
 
 
 --
+-- Name: deposit_balance_rebuild_requests fk_rails_7bf5a65c95; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.deposit_balance_rebuild_requests
+    ADD CONSTRAINT fk_rails_7bf5a65c95 FOREIGN KEY (deposit_account_id) REFERENCES public.deposit_accounts(id);
+
+
+--
 -- Name: journal_entries fk_rails_7f9a73cda9; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.journal_entries
     ADD CONSTRAINT fk_rails_7f9a73cda9 FOREIGN KEY (operational_event_id) REFERENCES public.operational_events(id);
+
+
+--
+-- Name: deposit_balance_rebuild_requests fk_rails_7fb3d9c729; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.deposit_balance_rebuild_requests
+    ADD CONSTRAINT fk_rails_7fb3d9c729 FOREIGN KEY (source_operational_event_id) REFERENCES public.operational_events(id);
 
 
 --
@@ -3944,6 +4053,8 @@ ALTER TABLE ONLY public.operational_events
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260502222000'),
+('20260502221000'),
 ('20260502220000'),
 ('20260502215000'),
 ('20260502160000'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -530,6 +530,50 @@ ALTER SEQUENCE public.core_business_date_settings_id_seq OWNED BY public.core_bu
 
 
 --
+-- Name: deposit_account_balance_projections; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.deposit_account_balance_projections (
+    id bigint NOT NULL,
+    deposit_account_id bigint NOT NULL,
+    ledger_balance_minor_units bigint DEFAULT 0 NOT NULL,
+    hold_balance_minor_units bigint DEFAULT 0 NOT NULL,
+    available_balance_minor_units bigint DEFAULT 0 NOT NULL,
+    collected_balance_minor_units bigint,
+    last_journal_entry_id bigint,
+    last_operational_event_id bigint,
+    as_of_business_date date,
+    last_calculated_at timestamp(6) without time zone,
+    stale boolean DEFAULT false NOT NULL,
+    stale_from_date date,
+    calculation_version integer DEFAULT 1 NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    CONSTRAINT chk_deposit_balance_proj_calculation_version_positive CHECK ((calculation_version > 0)),
+    CONSTRAINT chk_deposit_balance_proj_hold_non_negative CHECK ((hold_balance_minor_units >= 0))
+);
+
+
+--
+-- Name: deposit_account_balance_projections_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.deposit_account_balance_projections_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: deposit_account_balance_projections_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.deposit_account_balance_projections_id_seq OWNED BY public.deposit_account_balance_projections.id;
+
+
+--
 -- Name: deposit_account_number_allocations; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1705,6 +1749,13 @@ ALTER TABLE ONLY public.core_business_date_settings ALTER COLUMN id SET DEFAULT 
 
 
 --
+-- Name: deposit_account_balance_projections id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.deposit_account_balance_projections ALTER COLUMN id SET DEFAULT nextval('public.deposit_account_balance_projections_id_seq'::regclass);
+
+
+--
 -- Name: deposit_account_number_allocations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1986,6 +2037,14 @@ ALTER TABLE ONLY public.core_business_date_close_events
 
 ALTER TABLE ONLY public.core_business_date_settings
     ADD CONSTRAINT core_business_date_settings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: deposit_account_balance_projections deposit_account_balance_projections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.deposit_account_balance_projections
+    ADD CONSTRAINT deposit_account_balance_projections_pkey PRIMARY KEY (id);
 
 
 --
@@ -2288,6 +2347,41 @@ CREATE UNIQUE INDEX idx_dap_maintenance_audits_idempotency ON public.deposit_acc
 --
 
 CREATE INDEX idx_dap_maintenance_audits_on_relationship_id ON public.deposit_account_party_maintenance_audits USING btree (deposit_account_party_id);
+
+
+--
+-- Name: idx_deposit_balance_proj_account_unique; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_deposit_balance_proj_account_unique ON public.deposit_account_balance_projections USING btree (deposit_account_id);
+
+
+--
+-- Name: idx_deposit_balance_proj_as_of_business_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_deposit_balance_proj_as_of_business_date ON public.deposit_account_balance_projections USING btree (as_of_business_date);
+
+
+--
+-- Name: idx_deposit_balance_proj_last_journal_entry; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_deposit_balance_proj_last_journal_entry ON public.deposit_account_balance_projections USING btree (last_journal_entry_id);
+
+
+--
+-- Name: idx_deposit_balance_proj_last_operational_event; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_deposit_balance_proj_last_operational_event ON public.deposit_account_balance_projections USING btree (last_operational_event_id);
+
+
+--
+-- Name: idx_deposit_balance_proj_stale_from_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_deposit_balance_proj_stale_from_date ON public.deposit_account_balance_projections USING btree (stale, stale_from_date);
 
 
 --
@@ -3470,6 +3564,14 @@ ALTER TABLE ONLY public.deposit_product_statement_profiles
 
 
 --
+-- Name: deposit_account_balance_projections fk_rails_863cf2fee9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.deposit_account_balance_projections
+    ADD CONSTRAINT fk_rails_863cf2fee9 FOREIGN KEY (last_operational_event_id) REFERENCES public.operational_events(id);
+
+
+--
 -- Name: teller_sessions fk_rails_86b8203f6d; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -3483,6 +3585,14 @@ ALTER TABLE ONLY public.teller_sessions
 
 ALTER TABLE ONLY public.teller_sessions
     ADD CONSTRAINT fk_rails_896b8b6be7 FOREIGN KEY (operating_unit_id) REFERENCES public.operating_units(id);
+
+
+--
+-- Name: deposit_account_balance_projections fk_rails_8a9a42a884; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.deposit_account_balance_projections
+    ADD CONSTRAINT fk_rails_8a9a42a884 FOREIGN KEY (last_journal_entry_id) REFERENCES public.journal_entries(id);
 
 
 --
@@ -3587,6 +3697,14 @@ ALTER TABLE ONLY public.cash_locations
 
 ALTER TABLE ONLY public.cash_movements
     ADD CONSTRAINT fk_rails_accd708689 FOREIGN KEY (operational_event_id) REFERENCES public.operational_events(id);
+
+
+--
+-- Name: deposit_account_balance_projections fk_rails_b59f66f0ab; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.deposit_account_balance_projections
+    ADD CONSTRAINT fk_rails_b59f66f0ab FOREIGN KEY (deposit_account_id) REFERENCES public.deposit_accounts(id);
 
 
 --
@@ -3748,6 +3866,7 @@ ALTER TABLE ONLY public.operational_events
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260502215000'),
 ('20260502160000'),
 ('20260430120000'),
 ('20260429223000'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -530,6 +530,48 @@ ALTER SEQUENCE public.core_business_date_settings_id_seq OWNED BY public.core_bu
 
 
 --
+-- Name: daily_balance_snapshots; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.daily_balance_snapshots (
+    id bigint NOT NULL,
+    account_domain character varying NOT NULL,
+    account_id bigint NOT NULL,
+    account_type character varying,
+    as_of_date date NOT NULL,
+    ledger_balance_minor_units bigint NOT NULL,
+    hold_balance_minor_units bigint DEFAULT 0 NOT NULL,
+    available_balance_minor_units bigint NOT NULL,
+    collected_balance_minor_units bigint,
+    source character varying NOT NULL,
+    calculation_version integer NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    CONSTRAINT chk_daily_balance_snapshots_calc_version_positive CHECK ((calculation_version > 0)),
+    CONSTRAINT chk_daily_balance_snapshots_hold_non_negative CHECK ((hold_balance_minor_units >= 0))
+);
+
+
+--
+-- Name: daily_balance_snapshots_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.daily_balance_snapshots_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: daily_balance_snapshots_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.daily_balance_snapshots_id_seq OWNED BY public.daily_balance_snapshots.id;
+
+
+--
 -- Name: deposit_account_balance_projections; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1749,6 +1791,13 @@ ALTER TABLE ONLY public.core_business_date_settings ALTER COLUMN id SET DEFAULT 
 
 
 --
+-- Name: daily_balance_snapshots id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.daily_balance_snapshots ALTER COLUMN id SET DEFAULT nextval('public.daily_balance_snapshots_id_seq'::regclass);
+
+
+--
 -- Name: deposit_account_balance_projections id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -2037,6 +2086,14 @@ ALTER TABLE ONLY public.core_business_date_close_events
 
 ALTER TABLE ONLY public.core_business_date_settings
     ADD CONSTRAINT core_business_date_settings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: daily_balance_snapshots daily_balance_snapshots_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.daily_balance_snapshots
+    ADD CONSTRAINT daily_balance_snapshots_pkey PRIMARY KEY (id);
 
 
 --
@@ -2333,6 +2390,27 @@ CREATE UNIQUE INDEX idx_active_cash_drawer_identity ON public.cash_locations USI
 --
 
 CREATE INDEX idx_cash_movements_external_shipment_reference ON public.cash_movements USING btree (external_source, shipment_reference);
+
+
+--
+-- Name: idx_daily_balance_snapshots_account_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_daily_balance_snapshots_account_date ON public.daily_balance_snapshots USING btree (account_domain, account_id, as_of_date);
+
+
+--
+-- Name: idx_daily_balance_snapshots_as_of_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_daily_balance_snapshots_as_of_date ON public.daily_balance_snapshots USING btree (as_of_date);
+
+
+--
+-- Name: idx_daily_balance_snapshots_domain_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_daily_balance_snapshots_domain_date ON public.daily_balance_snapshots USING btree (account_domain, as_of_date);
 
 
 --
@@ -3866,6 +3944,7 @@ ALTER TABLE ONLY public.operational_events
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260502220000'),
 ('20260502215000'),
 ('20260502160000'),
 ('20260430120000'),

--- a/docs/adr/0004-account-balance-model.md
+++ b/docs/adr/0004-account-balance-model.md
@@ -334,7 +334,7 @@ This addendum closes [roadmap §12 “Available balance”](../roadmap.md): **co
 
 2. **Materialized projection (allowed, not default)** — §4.2–4.3 still apply: a stored **available** (or ledger) projection **may** be introduced for performance if it remains **derivable from posted journals + holds**, **rebuildable**, and **read-side only**—never authoritative for GL truth.
 
-3. **When to introduce projection** — Require a **dedicated ADR** (or major addendum) that specifies storage, **every invalidation path** (e.g. `PostEvent`, hold place/release, and any command that changes effective holds or policy), reconciliation/rebuild jobs, and **explicit product triggers** (e.g. p95/p99 authorization latency SLOs breached, or hot-account / high-QPS channel requirements). Do not add projection speculatively before metrics justify it.
+3. **When to introduce projection** — Require a **dedicated ADR** (or major addendum) that specifies storage, **every invalidation path** (e.g. `PostEvent`, hold place/release, and any command that changes effective holds or policy), reconciliation/rebuild jobs, and **explicit product triggers** (e.g. p95/p99 authorization latency SLOs breached, or hot-account / high-QPS channel requirements). Do not add projection speculatively before metrics justify it. The proposed implementation contract is [ADR-0038](0038-account-balance-projections-and-daily-snapshots.md).
 
 4. **Performance before projection** — Prefer query and index tuning (e.g. composite index on `journal_lines` matching the ledger filter for **2110** + `deposit_account_id`) and bounded read patterns; treat snapshot / running-balance patterns as **separate** ADRs when compute-on-read is no longer sufficient.
 
@@ -346,6 +346,7 @@ This addendum closes [roadmap §12 “Available balance”](../roadmap.md): **co
 * ADR-0002: Operational Event Model  
 * ADR-0003: Posting & Journal Architecture  
 * ADR-0013: Holds, available balance, and servicing operational events
+* ADR-0038: Account balance projections and daily snapshots
 
 ---
 

--- a/docs/adr/0038-account-balance-projections-and-daily-snapshots.md
+++ b/docs/adr/0038-account-balance-projections-and-daily-snapshots.md
@@ -159,6 +159,15 @@ collected_balance_minor_units
 
 Loan rows may later use loan-specific components. The design must preserve a clear component schema/version rather than storing one generic ambiguous `balance`.
 
+The implemented Reporting contract reserves account metadata for both current and future account domains:
+
+| Account domain | Account type | Component owner | Implementation status |
+| --- | --- | --- | --- |
+| `deposits` | `deposit_account` | `Accounts` projection + `Deposits` consumers | Implemented in this slice. |
+| `loans` | `loan_account` | Future `Loans` projection and servicing rules | Reserved only; no loan servicing implementation. |
+
+`daily_balance_snapshots` may identify future loan rows by domain/type, but BankCORE must not create production loan snapshots until a `Loans` implementation defines the loan projection components, calculation version, rebuild rules, and posting/servicing consumers. Deposit snapshot fields remain explicit in this slice; loan-specific principal, interest, escrow, fee, delinquency, and payoff components require a follow-up Loans ADR or ADR addendum before use.
+
 ---
 
 ## 8. EOD integration
@@ -269,6 +278,16 @@ payoff_balance_minor_units
 ```
 
 Those semantics belong to `Loans`; daily snapshots should carry typed/versioned components so ADB-style deposit calculations and loan payoff calculations do not share one formula.
+
+The reserved Reporting identity would be:
+
+```text
+account_domain = loans
+account_type   = loan_account
+account_id     = <future loan account id>
+```
+
+This identity is not enough to produce a loan balance. A future `Loans` slice must define the projection owner, component schema, materializer, reconciliation method, and consumer rules before any loan snapshot rows are used operationally.
 
 ---
 

--- a/docs/adr/0038-account-balance-projections-and-daily-snapshots.md
+++ b/docs/adr/0038-account-balance-projections-and-daily-snapshots.md
@@ -204,6 +204,16 @@ Required services for implementation:
 
 Reconciliation must report drift. Automatic correction should be an explicit rebuild command, not a silent side effect of ordinary reads.
 
+Implementation hardening:
+
+- `Accounts::Queries::DepositBalanceProjectionDrift` remains a read-only report.
+- `Accounts::Commands::MarkDepositBalanceProjectionStale` is the explicit drift response: it marks the projection stale and creates `deposit_balance_rebuild_requests` evidence.
+- `Accounts::Commands::RebuildDepositBalanceProjection` repairs the projection and records completed rebuild evidence.
+- `Accounts::Commands::MarkDepositBalanceProjectionsStaleForVersion` marks projections stale when their `calculation_version` no longer matches the active formula version.
+- New deposit accounts create a zero-balance projection during account opening; first posting and EOD materialization still retain create-under-lock fallbacks for legacy/missing rows.
+- `Reporting::Commands::MarkDailyBalanceSnapshotsStaleForVersion` marks historical snapshots stale when their formula version is no longer current.
+- `daily_balance_snapshots` are idempotent by account domain, account id, date, source, and calculation version so a future formula version can materialize a distinct row instead of overwriting historical evidence.
+
 ---
 
 ## 10. Worked examples

--- a/docs/adr/0038-account-balance-projections-and-daily-snapshots.md
+++ b/docs/adr/0038-account-balance-projections-and-daily-snapshots.md
@@ -1,0 +1,327 @@
+# ADR-0038: Account balance projections and daily snapshots
+
+**Status:** Proposed  
+**Date:** 2026-05-02  
+**Decision Type:** Balance read model, EOD snapshot, and loan-ready projection architecture  
+**Aligns with:** [ADR-0003](0003-posting-journal-architecture.md), [ADR-0004](0004-account-balance-model.md), [ADR-0012](0012-posting-rule-registry-and-journal-subledger.md), [ADR-0018](0018-business-date-close-and-posting-invariant.md), [ADR-0024](0024-customer-visible-history-and-statements.md), [module catalog](../architecture/bankcore-module-catalog.md)
+
+---
+
+## 1. Context
+
+BankCORE currently computes deposit ledger and available balances from posted journal lines and active holds. This is correct for the current slice because the journal remains the authoritative financial record and there is no separate balance table that can drift from accounting truth.
+
+As transaction volume grows, repeated journal aggregation becomes a poor fit for teller balance display, authorization checks, EOD processing, interest, average daily balance, and reporting. ADR-0004 already permits materialized ledger, available, collected, and daily balance projections when they remain derivable, rebuildable, and read-side only.
+
+BankCORE also needs a pattern that can extend to loans. Loan balances will not share the same components as deposits: principal, accrued interest, fees, escrow, delinquency, and payoff views need different semantics. The shared design should be a projection and snapshot contract, not one ambiguous balance table.
+
+---
+
+## 2. Decision
+
+Adopt a phased account balance architecture:
+
+```text
+Journal remains financial truth
+        ↓
+Domain-owned current balance projection
+        ↓
+Reporting-owned daily balance snapshots
+        ↓
+Interest, ADB, statements, reporting
+```
+
+The projection may become authoritative for fast operational reads after implemented, but it is never authoritative for accounting truth. The journal and applicable operational records remain the rebuild source.
+
+For the first implementation:
+
+- **Deposits first:** `Accounts` owns the current deposit account balance projection because account identity, holds, restrictions, and authorization-facing balances are account state.
+- **Reporting snapshots:** `Reporting` owns daily balance snapshots and materialization services, per the module catalog.
+- **Loan ready:** future `Loans` services define loan-specific projection components; `Reporting` snapshots must support account-domain/type metadata so loan rows can be added without forcing deposits and loans into one balance formula.
+
+---
+
+## 3. Ownership
+
+| Concern | Owner | Rule |
+| --- | --- | --- |
+| Journal entries and lines | `Core::Ledger` / `Core::Posting` | Source of financial truth. |
+| Deposit current projection | `Accounts` | Rebuildable operational read model for deposit account balances. |
+| Deposit availability formula | `Accounts` now, future `Limits` if policy becomes broader | Must be centralized in a resolver, not controllers. |
+| Daily balance snapshots | `Reporting` | Read-side historical projection and extract basis. |
+| Deposit statements and deposit interest consumers | `Deposits` | Consume projections/snapshots; do not mutate ledger truth. |
+| Future loan balance components | `Loans` | Loan-specific servicing projection semantics. |
+
+---
+
+## 4. Deposit current projection
+
+Add an `Accounts`-owned table in a later implementation slice:
+
+```text
+deposit_account_balance_projections
+```
+
+Required fields:
+
+```text
+deposit_account_id
+ledger_balance_minor_units
+hold_balance_minor_units
+available_balance_minor_units
+collected_balance_minor_units
+last_journal_entry_id
+last_operational_event_id
+as_of_business_date
+last_calculated_at
+stale
+stale_from_date
+calculation_version
+created_at
+updated_at
+```
+
+Initial formula:
+
+```text
+available_balance = ledger_balance - active_holds
+```
+
+`collected_balance_minor_units` remains nullable or omitted until a funds-availability model exists.
+
+---
+
+## 5. Transactional update rule
+
+Projection updates must happen in the same database transaction as posting. The invariant is:
+
+```text
+Either journal + projection both update,
+or neither update.
+```
+
+`Core::Posting::Commands::PostEvent` should create the posting batch, journal entry, and journal lines, then call a centralized `Accounts` projection updater before commit. Posting rule modules must not update projections directly.
+
+Projection update steps for deposit-affecting entries:
+
+1. Identify journal lines for deposit subledger GL `2110` with `deposit_account_id`.
+2. Lock the projection row for each affected account.
+3. Apply signed ledger delta:
+   - credit `2110` increases deposit ledger balance;
+   - debit `2110` decreases deposit ledger balance.
+4. Recompute hold total and available balance through the resolver.
+5. Store last journal entry, operational event, business date, calculation version, and timestamp.
+
+If projection update fails, the posting transaction must roll back.
+
+---
+
+## 6. Hold and availability invalidation
+
+Holds change available balance without changing ledger balance. Hold lifecycle commands must update or refresh the projection inside the same transaction that changes hold state:
+
+- `Accounts::Commands::PlaceHold`
+- `Accounts::Commands::ReleaseHold`
+- future hold expiration processing
+
+Availability must be calculated by one resolver. Controllers, teller previews, and authorization checks must not embed alternate formulas.
+
+Future formula inputs may include account restrictions, collected funds rules, overdraft limits, channel-specific authorization holds, or product policy. Such formula changes require a `calculation_version` bump and rebuild/reconciliation plan.
+
+---
+
+## 7. Daily balance snapshots
+
+Add a `Reporting`-owned daily snapshot model in a later implementation slice.
+
+Logical contract:
+
+```text
+account_domain
+account_type
+account_id
+as_of_date
+balance_components
+source
+calculation_version
+created_at
+updated_at
+```
+
+For the deposit slice, explicit fields are preferred:
+
+```text
+ledger_balance_minor_units
+hold_balance_minor_units
+available_balance_minor_units
+collected_balance_minor_units
+```
+
+Loan rows may later use loan-specific components. The design must preserve a clear component schema/version rather than storing one generic ambiguous `balance`.
+
+---
+
+## 8. EOD integration
+
+Normal business-date close should materialize daily snapshots before advancing the open business date:
+
+1. EOD readiness passes.
+2. Select accounts requiring snapshots for the closing date.
+3. Copy current projection values into daily snapshots.
+4. Carry forward missing calendar dates where required.
+5. Run reconciliation checks or record snapshot materialization evidence.
+6. Advance the business date.
+
+If required snapshots cannot be materialized, close should fail rather than advancing with incomplete historical balance data.
+
+This ADR does not introduce backdated posting, day reopen, or closed-day mutation. ADR-0018 open-day posting remains in force.
+
+---
+
+## 9. Rebuild and reconciliation
+
+Every projection must be rebuildable from authoritative data:
+
+- posted `journal_lines` for ledger truth;
+- active and historical hold records for availability inputs;
+- explicit policy/configuration state used by the resolver.
+
+Required services for implementation:
+
+- rebuild one deposit projection from journal and hold truth;
+- detect drift between projection and journal-derived truth;
+- mark stale projections or snapshots when formulas change;
+- record rebuild evidence and calculation version.
+
+Reconciliation must report drift. Automatic correction should be an explicit rebuild command, not a silent side effect of ordinary reads.
+
+---
+
+## 10. Worked examples
+
+### 10.1 Deposit posting
+
+Input event:
+
+```json
+{
+  "event_type": "deposit.accepted",
+  "source_account_id": 42,
+  "amount_minor_units": 10000,
+  "currency": "USD"
+}
+```
+
+Posting outline:
+
+```text
+Dr 1110 Cash                         100.00
+Cr 2110 Customer DDA, account 42      100.00
+```
+
+Projection effect:
+
+```text
+ledger_balance_minor_units += 10000
+hold_balance_minor_units = active holds sum
+available_balance_minor_units = ledger - active holds
+last_operational_event_id = deposit event id
+last_journal_entry_id = created journal entry id
+```
+
+### 10.2 Hold placement
+
+Input event:
+
+```json
+{
+  "event_type": "hold.placed",
+  "source_account_id": 42,
+  "amount_minor_units": 2500,
+  "currency": "USD"
+}
+```
+
+Posting outline:
+
+```text
+No GL posting.
+```
+
+Projection effect:
+
+```text
+ledger_balance_minor_units unchanged
+hold_balance_minor_units += 2500
+available_balance_minor_units = ledger - active holds
+last_operational_event_id = hold event id
+```
+
+### 10.3 Future loan payment
+
+Loan projections will follow the same contract, but not the same components. A future loan payment might update:
+
+```text
+principal_balance_minor_units
+interest_due_minor_units
+fees_due_minor_units
+payoff_balance_minor_units
+```
+
+Those semantics belong to `Loans`; daily snapshots should carry typed/versioned components so ADB-style deposit calculations and loan payoff calculations do not share one formula.
+
+---
+
+## 11. Non-goals
+
+- Implementing the projection tables in this ADR-only slice.
+- Replacing journal truth with projection truth.
+- Backdated posting, day reopen, or closed-day mutation.
+- Full Reg CC collected funds logic.
+- Loan servicing implementation.
+- Caching average daily balance as a standing account field.
+
+---
+
+## 12. Consequences
+
+**Positive**
+
+- Faster teller, branch, and authorization reads once implemented.
+- Cheaper EOD: daily snapshots become copy/materialization operations for most accounts.
+- Clear historical basis for statements, ADB, interest, and reporting.
+- Rebuild and reconciliation rules are explicit.
+- Loan balances can adopt the same pattern without sharing deposit-specific math.
+
+**Negative**
+
+- More moving parts than compute-on-read.
+- Requires disciplined invalidation paths for posting, holds, policy changes, and future correction flows.
+- Requires reconciliation and rebuild operations before projections can be trusted for operational reads.
+- EOD close gains another consistency dependency.
+
+---
+
+## 13. Implementation sequence
+
+1. Add deposit current projection schema and model.
+2. Add an `Accounts` projection updater called transactionally from `PostEvent`.
+3. Refactor available-balance math into a resolver.
+4. Refresh projection values from hold lifecycle commands.
+5. Migrate teller, branch, and authorization reads to projection-backed services.
+6. Add rebuild and reconciliation services.
+7. Add `Reporting` daily snapshots and materialization.
+8. Integrate snapshot materialization into business-date close.
+9. Move closed-period statement and future interest/ADB consumers to daily snapshots.
+10. Extend the pattern to loans in a separate `Loans` implementation slice.
+
+---
+
+## 14. Related documents
+
+- [ADR-0003: Posting & journal architecture](0003-posting-journal-architecture.md)
+- [ADR-0004: Account & balance model](0004-account-balance-model.md)
+- [ADR-0012: Posting rule registry and journal subledger](0012-posting-rule-registry-and-journal-subledger.md)
+- [ADR-0018: Business date close and open-day posting invariant](0018-business-date-close-and-posting-invariant.md)
+- [ADR-0024: Customer-visible history and statements](0024-customer-visible-history-and-statements.md)
+- [BankCORE module catalog](../architecture/bankcore-module-catalog.md)

--- a/test/domains/accounts/deposit_account_balance_projection_test.rb
+++ b/test/domains/accounts/deposit_account_balance_projection_test.rb
@@ -119,6 +119,73 @@ class AccountsDepositAccountBalanceProjectionTest < ActiveSupport::TestCase
     assert_equal 5_000, Accounts::Services::AvailableBalanceMinorUnits.call(deposit_account_id: @account.id)
   end
 
+  test "projection drift query reports differences without correcting them" do
+    fund_account!(5_000)
+    projection = @account.deposit_account_balance_projection
+    projection.update!(
+      ledger_balance_minor_units: 4_000,
+      hold_balance_minor_units: 250,
+      available_balance_minor_units: 3_750,
+      stale: true,
+      stale_from_date: Date.new(2026, 5, 1)
+    )
+
+    drift = Accounts::Queries::DepositBalanceProjectionDrift.call(deposit_account_id: @account.id)
+
+    assert drift.drifted
+    assert drift.stale
+    assert_equal 5_000, drift.expected_ledger_balance_minor_units
+    assert_equal 0, drift.expected_hold_balance_minor_units
+    assert_equal 5_000, drift.expected_available_balance_minor_units
+    assert_equal(-1_000, drift.ledger_balance_drift_minor_units)
+    assert_equal 250, drift.hold_balance_drift_minor_units
+    assert_equal(-1_250, drift.available_balance_drift_minor_units)
+    assert_equal 4_000, projection.reload.ledger_balance_minor_units
+  end
+
+  test "rebuild command repairs projection from journal and hold truth" do
+    fund_account!(5_000)
+    place_hold!(amount: 1_500, key: "projection-rebuild-hold")
+    projection = @account.deposit_account_balance_projection
+    projection.update!(
+      ledger_balance_minor_units: 4_000,
+      hold_balance_minor_units: 250,
+      available_balance_minor_units: 3_750,
+      stale: true,
+      stale_from_date: Date.new(2026, 5, 1),
+      calculation_version: 2
+    )
+
+    rebuilt = Accounts::Commands::RebuildDepositBalanceProjection.call(
+      deposit_account_id: @account.id,
+      calculation_version: Accounts::Models::DepositAccountBalanceProjection::CURRENT_CALCULATION_VERSION
+    )
+
+    assert_equal 5_000, rebuilt.ledger_balance_minor_units
+    assert_equal 1_500, rebuilt.hold_balance_minor_units
+    assert_equal 3_500, rebuilt.available_balance_minor_units
+    assert_not rebuilt.stale
+    assert_nil rebuilt.stale_from_date
+    assert_equal 1, rebuilt.calculation_version
+    assert_equal Date.new(2026, 5, 2), rebuilt.as_of_business_date
+
+    drift = Accounts::Queries::DepositBalanceProjectionDrift.call(deposit_account_id: @account.id)
+    assert_not drift.drifted
+  end
+
+  test "rebuild command creates a missing projection" do
+    fund_account!(5_000)
+    @account.deposit_account_balance_projection.destroy!
+
+    rebuilt = Accounts::Commands::RebuildDepositBalanceProjection.call(deposit_account_id: @account.id)
+
+    assert_equal @account.id, rebuilt.deposit_account_id
+    assert_equal 5_000, rebuilt.ledger_balance_minor_units
+    assert_equal 0, rebuilt.hold_balance_minor_units
+    assert_equal 5_000, rebuilt.available_balance_minor_units
+    assert_equal Date.new(2026, 5, 2), rebuilt.as_of_business_date
+  end
+
   private
 
   def fund_account!(amount)

--- a/test/domains/accounts/deposit_account_balance_projection_test.rb
+++ b/test/domains/accounts/deposit_account_balance_projection_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AccountsDepositAccountBalanceProjectionTest < ActiveSupport::TestCase
+  setup do
+    Core::BusinessDate::Models::BusinessDateSetting.delete_all
+    Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.new(2026, 5, 2))
+    party = Party::Commands::CreateParty.call(party_type: "individual", first_name: "Balance", last_name: "Projection")
+    @account = Accounts::Commands::OpenAccount.call(party_record_id: party.id)
+  end
+
+  test "stores one projection per deposit account with default zero balances" do
+    projection = Accounts::Models::DepositAccountBalanceProjection.create!(deposit_account: @account)
+
+    assert_equal 0, projection.ledger_balance_minor_units
+    assert_equal 0, projection.hold_balance_minor_units
+    assert_equal 0, projection.available_balance_minor_units
+    assert_equal 1, projection.calculation_version
+    assert_not projection.stale
+    assert_equal projection, @account.reload.deposit_account_balance_projection
+  end
+
+  test "allows negative ledger and available balances but not negative hold totals" do
+    projection = Accounts::Models::DepositAccountBalanceProjection.new(
+      deposit_account: @account,
+      ledger_balance_minor_units: -1_00,
+      hold_balance_minor_units: -1,
+      available_balance_minor_units: -1_00
+    )
+
+    assert_not projection.valid?
+    assert_includes projection.errors[:hold_balance_minor_units], "must be greater than or equal to 0"
+
+    projection.hold_balance_minor_units = 0
+    assert projection.valid?
+  end
+
+  test "requires a positive calculation version" do
+    projection = Accounts::Models::DepositAccountBalanceProjection.new(
+      deposit_account: @account,
+      calculation_version: 0
+    )
+
+    assert_not projection.valid?
+    assert_includes projection.errors[:calculation_version], "must be greater than 0"
+  end
+
+  test "enforces uniqueness by deposit account" do
+    Accounts::Models::DepositAccountBalanceProjection.create!(deposit_account: @account)
+
+    duplicate = Accounts::Models::DepositAccountBalanceProjection.new(deposit_account: @account)
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:deposit_account], "has already been taken"
+  end
+end

--- a/test/domains/accounts/deposit_account_balance_projection_test.rb
+++ b/test/domains/accounts/deposit_account_balance_projection_test.rb
@@ -4,6 +4,7 @@ require "test_helper"
 
 class AccountsDepositAccountBalanceProjectionTest < ActiveSupport::TestCase
   setup do
+    BankCore::Seeds::GlCoa.seed!
     Core::BusinessDate::Models::BusinessDateSetting.delete_all
     Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.new(2026, 5, 2))
     party = Party::Commands::CreateParty.call(party_type: "individual", first_name: "Balance", last_name: "Projection")
@@ -52,5 +53,74 @@ class AccountsDepositAccountBalanceProjectionTest < ActiveSupport::TestCase
     duplicate = Accounts::Models::DepositAccountBalanceProjection.new(deposit_account: @account)
     assert_not duplicate.valid?
     assert_includes duplicate.errors[:deposit_account], "has already been taken"
+  end
+
+  test "place hold refreshes projection available balance" do
+    fund_account!(5_000)
+
+    result = place_hold!(amount: 1_500, key: "projection-place-hold")
+
+    projection = @account.deposit_account_balance_projection.reload
+    assert_equal 5_000, projection.ledger_balance_minor_units
+    assert_equal 1_500, projection.hold_balance_minor_units
+    assert_equal 3_500, projection.available_balance_minor_units
+    assert_equal result.fetch(:event).id, projection.last_operational_event_id
+  end
+
+  test "release hold refreshes projection available balance" do
+    fund_account!(5_000)
+    hold = place_hold!(amount: 1_500, key: "projection-release-place").fetch(:hold)
+
+    result = Accounts::Commands::ReleaseHold.call(
+      hold_id: hold.id,
+      channel: "api",
+      idempotency_key: "projection-release-hold"
+    )
+
+    projection = @account.deposit_account_balance_projection.reload
+    assert_equal 5_000, projection.ledger_balance_minor_units
+    assert_equal 0, projection.hold_balance_minor_units
+    assert_equal 5_000, projection.available_balance_minor_units
+    assert_equal result.fetch(:event).id, projection.last_operational_event_id
+  end
+
+  test "expire due holds refreshes projection available balance" do
+    fund_account!(5_000)
+    place_hold!(amount: 1_500, key: "projection-expire-hold", expires_on: Date.new(2026, 5, 2))
+
+    result = Accounts::Commands::ExpireDueHolds.call(as_of: Date.new(2026, 5, 2)).sole
+
+    projection = @account.deposit_account_balance_projection.reload
+    assert_equal 5_000, projection.ledger_balance_minor_units
+    assert_equal 0, projection.hold_balance_minor_units
+    assert_equal 5_000, projection.available_balance_minor_units
+    assert_equal result.fetch(:event).id, projection.last_operational_event_id
+  end
+
+  private
+
+  def fund_account!(amount)
+    event = Core::OperationalEvents::Commands::RecordEvent.call(
+      event_type: "deposit.accepted",
+      channel: "batch",
+      idempotency_key: "projection-fund-#{SecureRandom.hex(4)}",
+      amount_minor_units: amount,
+      currency: "USD",
+      source_account_id: @account.id
+    ).fetch(:event)
+    Core::Posting::Commands::PostEvent.call(operational_event_id: event.id)
+  end
+
+  def place_hold!(amount:, key:, expires_on: Date.new(2026, 5, 5))
+    Accounts::Commands::PlaceHold.call(
+      deposit_account_id: @account.id,
+      amount_minor_units: amount,
+      currency: "USD",
+      channel: "api",
+      idempotency_key: key,
+      hold_type: Accounts::Models::Hold::HOLD_TYPE_ADMINISTRATIVE,
+      reason_code: Accounts::Models::Hold::REASON_MANUAL_REVIEW,
+      expires_on: expires_on
+    )
   end
 end

--- a/test/domains/accounts/deposit_account_balance_projection_test.rb
+++ b/test/domains/accounts/deposit_account_balance_projection_test.rb
@@ -12,7 +12,7 @@ class AccountsDepositAccountBalanceProjectionTest < ActiveSupport::TestCase
   end
 
   test "stores one projection per deposit account with default zero balances" do
-    projection = Accounts::Models::DepositAccountBalanceProjection.create!(deposit_account: @account)
+    projection = @account.deposit_account_balance_projection
 
     assert_equal 0, projection.ledger_balance_minor_units
     assert_equal 0, projection.hold_balance_minor_units
@@ -23,6 +23,7 @@ class AccountsDepositAccountBalanceProjectionTest < ActiveSupport::TestCase
   end
 
   test "allows negative ledger and available balances but not negative hold totals" do
+    @account.deposit_account_balance_projection.destroy!
     projection = Accounts::Models::DepositAccountBalanceProjection.new(
       deposit_account: @account,
       ledger_balance_minor_units: -1_00,
@@ -48,8 +49,6 @@ class AccountsDepositAccountBalanceProjectionTest < ActiveSupport::TestCase
   end
 
   test "enforces uniqueness by deposit account" do
-    Accounts::Models::DepositAccountBalanceProjection.create!(deposit_account: @account)
-
     duplicate = Accounts::Models::DepositAccountBalanceProjection.new(deposit_account: @account)
     assert_not duplicate.valid?
     assert_includes duplicate.errors[:deposit_account], "has already been taken"
@@ -143,6 +142,22 @@ class AccountsDepositAccountBalanceProjectionTest < ActiveSupport::TestCase
     assert_equal 4_000, projection.reload.ledger_balance_minor_units
   end
 
+  test "stale marking command records rebuild evidence for projection drift" do
+    fund_account!(5_000)
+    projection = @account.deposit_account_balance_projection
+    projection.update!(ledger_balance_minor_units: 4_000, available_balance_minor_units: 4_000)
+
+    result = Accounts::Commands::MarkDepositBalanceProjectionStale.call(deposit_account_id: @account.id)
+
+    assert result.fetch(:drift).drifted
+    assert result.fetch(:projection).stale
+    request = result.fetch(:rebuild_request)
+    assert_equal @account.id, request.deposit_account_id
+    assert_equal Accounts::Models::DepositBalanceRebuildRequest::STATUS_REQUESTED, request.status
+    assert_equal Accounts::Models::DepositBalanceRebuildRequest::REASON_DRIFT_DETECTED, request.reason
+    assert_equal Accounts::Models::DepositBalanceRebuildRequest::REBUILD_TYPE_PROJECTION, request.rebuild_type
+  end
+
   test "rebuild command repairs projection from journal and hold truth" do
     fund_account!(5_000)
     place_hold!(amount: 1_500, key: "projection-rebuild-hold")
@@ -171,6 +186,9 @@ class AccountsDepositAccountBalanceProjectionTest < ActiveSupport::TestCase
 
     drift = Accounts::Queries::DepositBalanceProjectionDrift.call(deposit_account_id: @account.id)
     assert_not drift.drifted
+    request = Accounts::Models::DepositBalanceRebuildRequest.order(:id).last
+    assert_equal Accounts::Models::DepositBalanceRebuildRequest::STATUS_COMPLETED, request.status
+    assert_equal Accounts::Models::DepositBalanceRebuildRequest::REASON_MANUAL_REBUILD, request.reason
   end
 
   test "rebuild command creates a missing projection" do
@@ -184,6 +202,20 @@ class AccountsDepositAccountBalanceProjectionTest < ActiveSupport::TestCase
     assert_equal 0, rebuilt.hold_balance_minor_units
     assert_equal 5_000, rebuilt.available_balance_minor_units
     assert_equal Date.new(2026, 5, 2), rebuilt.as_of_business_date
+  end
+
+  test "formula version marking stales old projections and records rebuild evidence" do
+    projection = @account.deposit_account_balance_projection
+    projection.update!(calculation_version: 99, stale: false)
+
+    result = Accounts::Commands::MarkDepositBalanceProjectionsStaleForVersion.call(expected_calculation_version: 1)
+
+    assert_equal 1, result.marked_count
+    assert_equal 1, result.rebuild_requests_created
+    assert @account.deposit_account_balance_projection.reload.stale
+    request = Accounts::Models::DepositBalanceRebuildRequest.sole
+    assert_equal Accounts::Models::DepositBalanceRebuildRequest::REASON_FORMULA_VERSION_CHANGE, request.reason
+    assert_equal Accounts::Models::DepositBalanceRebuildRequest::STATUS_REQUESTED, request.status
   end
 
   private

--- a/test/domains/accounts/deposit_account_balance_projection_test.rb
+++ b/test/domains/accounts/deposit_account_balance_projection_test.rb
@@ -97,6 +97,28 @@ class AccountsDepositAccountBalanceProjectionTest < ActiveSupport::TestCase
     assert_equal result.fetch(:event).id, projection.last_operational_event_id
   end
 
+  test "available balance facade reads projection while preserving journal truth method" do
+    fund_account!(5_000)
+    projection = @account.deposit_account_balance_projection
+    projection.update!(
+      ledger_balance_minor_units: 4_000,
+      hold_balance_minor_units: 750,
+      available_balance_minor_units: 3_250
+    )
+
+    assert_equal 4_000, Accounts::Services::AvailableBalanceMinorUnits.ledger_balance_minor_units(deposit_account_id: @account.id)
+    assert_equal 3_250, Accounts::Services::AvailableBalanceMinorUnits.call(deposit_account_id: @account.id)
+    assert_equal 5_000, Accounts::Services::AvailableBalanceMinorUnits.journal_ledger_balance_minor_units(deposit_account_id: @account.id)
+  end
+
+  test "available balance facade falls back to journal when projection is missing" do
+    fund_account!(5_000)
+    @account.deposit_account_balance_projection.destroy!
+
+    assert_equal 5_000, Accounts::Services::AvailableBalanceMinorUnits.ledger_balance_minor_units(deposit_account_id: @account.id)
+    assert_equal 5_000, Accounts::Services::AvailableBalanceMinorUnits.call(deposit_account_id: @account.id)
+  end
+
   private
 
   def fund_account!(amount)

--- a/test/domains/accounts/open_account_test.rb
+++ b/test/domains/accounts/open_account_test.rb
@@ -26,6 +26,12 @@ class AccountsOpenAccountTest < ActiveSupport::TestCase
     assert_equal Accounts::Models::DepositAccountParty::STATUS_ACTIVE, row.status
     assert_equal Date.new(2026, 4, 21), row.effective_on
     assert_nil row.ended_on
+    projection = account.deposit_account_balance_projection
+    assert_equal 0, projection.ledger_balance_minor_units
+    assert_equal 0, projection.hold_balance_minor_units
+    assert_equal 0, projection.available_balance_minor_units
+    assert_equal Date.new(2026, 4, 21), projection.as_of_business_date
+    assert_equal Accounts::Models::DepositAccountBalanceProjection::CURRENT_CALCULATION_VERSION, projection.calculation_version
   end
 
   test "uses explicit effective_on when provided" do

--- a/test/domains/accounts/queries/deposit_account_profile_test.rb
+++ b/test/domains/accounts/queries/deposit_account_profile_test.rb
@@ -35,6 +35,22 @@ class DepositAccountProfileTest < ActiveSupport::TestCase
     assert_equal Date.new(2026, 9, 2), result.current_business_date
   end
 
+  test "returns projection-backed current balances" do
+    party = create_party!("Projected", "Balance")
+    account = Accounts::Commands::OpenAccount.call(party_record_id: party.id, deposit_product_id: @product.id)
+    fund_account!(account, amount: 10_000)
+    account.deposit_account_balance_projection.update!(
+      ledger_balance_minor_units: 9_000,
+      hold_balance_minor_units: 2_000,
+      available_balance_minor_units: 7_000
+    )
+
+    result = Accounts::Queries::DepositAccountProfile.call(deposit_account_id: account.id)
+
+    assert_equal 9_000, result.ledger_balance_minor_units
+    assert_equal 7_000, result.available_balance_minor_units
+  end
+
   private
 
   def create_party!(first_name, last_name)

--- a/test/domains/core/business_date/close_business_date_test.rb
+++ b/test/domains/core/business_date/close_business_date_test.rb
@@ -4,6 +4,8 @@ require "test_helper"
 
 class CoreBusinessDateCloseBusinessDateTest < ActiveSupport::TestCase
   setup do
+    BankCore::Seeds::GlCoa.seed!
+    BankCore::Seeds::DepositProducts.seed!
     Core::BusinessDate::Models::BusinessDateSetting.delete_all
     Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.new(2026, 3, 1))
     @operator = Workspace::Models::Operator.create!(role: "supervisor", display_name: "Business Date Supervisor", active: true)
@@ -15,6 +17,37 @@ class CoreBusinessDateCloseBusinessDateTest < ActiveSupport::TestCase
     assert_equal Date.new(2026, 3, 1), result[:closed_on]
     ev = Core::BusinessDate::Models::BusinessDateCloseEvent.sole
     assert_equal @operator.id, ev.closed_by_operator_id
+  end
+
+  test "close materializes daily balance snapshots before advancing business date" do
+    account = open_account!
+    fund_account!(account, amount: 5_000)
+
+    result = Core::BusinessDate::Commands::CloseBusinessDate.call(closed_by_operator_id: @operator.id)
+
+    assert_equal 1, result[:daily_balance_snapshots_materialized]
+    snapshot = Reporting::Models::DailyBalanceSnapshot.find_by!(
+      account_domain: Reporting::Models::DailyBalanceSnapshot::ACCOUNT_DOMAIN_DEPOSITS,
+      account_id: account.id,
+      as_of_date: Date.new(2026, 3, 1)
+    )
+    assert_equal 5_000, snapshot.ledger_balance_minor_units
+    assert_equal 5_000, snapshot.available_balance_minor_units
+    assert_equal Date.new(2026, 3, 2), result[:setting].current_business_on
+  end
+
+  test "close does not advance when snapshot materialization detects projection drift" do
+    account = open_account!
+    fund_account!(account, amount: 5_000)
+    account.deposit_account_balance_projection.update!(stale: true, stale_from_date: Date.new(2026, 3, 1))
+
+    assert_raises(Reporting::Commands::MaterializeDailyBalanceSnapshots::ProjectionDriftDetected) do
+      Core::BusinessDate::Commands::CloseBusinessDate.call(closed_by_operator_id: @operator.id)
+    end
+
+    assert_equal Date.new(2026, 3, 1), Core::BusinessDate::Models::BusinessDateSetting.first.current_business_on
+    assert_equal 0, Core::BusinessDate::Models::BusinessDateCloseEvent.count
+    assert_equal 0, Reporting::Models::DailyBalanceSnapshot.count
   end
 
   test "close raises when a teller session is still open" do
@@ -32,5 +65,28 @@ class CoreBusinessDateCloseBusinessDateTest < ActiveSupport::TestCase
         business_date: Date.new(2026, 2, 1)
       )
     end
+  end
+
+  private
+
+  def open_account!
+    party = Party::Commands::CreateParty.call(
+      party_type: "individual",
+      first_name: "Close",
+      last_name: "Snapshot"
+    )
+    Accounts::Commands::OpenAccount.call(party_record_id: party.id)
+  end
+
+  def fund_account!(account, amount:)
+    event = Core::OperationalEvents::Commands::RecordEvent.call(
+      event_type: "deposit.accepted",
+      channel: "batch",
+      idempotency_key: "close-snapshot-fund-#{SecureRandom.hex(4)}",
+      amount_minor_units: amount,
+      currency: "USD",
+      source_account_id: account.id
+    ).fetch(:event)
+    Core::Posting::Commands::PostEvent.call(operational_event_id: event.id)
   end
 end

--- a/test/domains/core/posting/post_event_test.rb
+++ b/test/domains/core/posting/post_event_test.rb
@@ -33,6 +33,14 @@ class CorePostingPostEventTest < ActiveSupport::TestCase
     credit = lines.find_by(side: "credit")
     assert_equal Core::Ledger::Models::GlAccount.find_by!(account_number: "2110").id, credit.gl_account_id
     assert_equal @account.id, credit.deposit_account_id
+
+    projection = @account.deposit_account_balance_projection
+    assert_equal 12_34, projection.ledger_balance_minor_units
+    assert_equal 12_34, projection.available_balance_minor_units
+    assert_equal entry.id, projection.last_journal_entry_id
+    assert_equal ev.id, projection.last_operational_event_id
+    assert_equal Date.new(2026, 4, 22), projection.as_of_business_date
+    assert projection.last_calculated_at
   end
 
   test "second post is idempotent" do
@@ -101,6 +109,7 @@ class CorePostingPostEventTest < ActiveSupport::TestCase
     assert_equal @account.id, dr.deposit_account_id
     assert_equal "4510", cr.gl_account.account_number
     assert_nil cr.deposit_account_id
+    assert_equal 24_500, @account.deposit_account_balance_projection.reload.ledger_balance_minor_units
   end
 
   test "posts fee.waived as Dr 4510 Cr 2110" do
@@ -130,6 +139,63 @@ class CorePostingPostEventTest < ActiveSupport::TestCase
     assert_equal "4510", dr.gl_account.account_number
     assert_equal "2110", cr.gl_account.account_number
     assert_equal @account.id, cr.deposit_account_id
+    assert_equal 30_000, @account.deposit_account_balance_projection.reload.ledger_balance_minor_units
+  end
+
+  test "updates projections for both sides of a transfer" do
+    destination_party = Party::Commands::CreateParty.call(party_type: "individual", first_name: "Dest", last_name: "Projection")
+    destination = Accounts::Commands::OpenAccount.call(party_record_id: destination_party.id)
+    fund_account!(10_000)
+    transfer = Core::OperationalEvents::Commands::RecordEvent.call(
+      event_type: "transfer.completed",
+      channel: "batch",
+      idempotency_key: "transfer-projection-#{SecureRandom.hex(4)}",
+      amount_minor_units: 2_500,
+      currency: "USD",
+      source_account_id: @account.id,
+      destination_account_id: destination.id
+    )[:event]
+
+    Core::Posting::Commands::PostEvent.call(operational_event_id: transfer.id)
+
+    assert_equal 7_500, @account.deposit_account_balance_projection.reload.ledger_balance_minor_units
+    assert_equal 2_500, destination.deposit_account_balance_projection.reload.ledger_balance_minor_units
+  end
+
+  test "recalculates available balance using active holds when posting updates projection" do
+    Accounts::Models::Hold.create!(
+      deposit_account: @account,
+      amount_minor_units: 300,
+      currency: "USD",
+      status: Accounts::Models::Hold::STATUS_ACTIVE,
+      hold_type: Accounts::Models::Hold::HOLD_TYPE_ADMINISTRATIVE,
+      reason_code: Accounts::Models::Hold::REASON_MANUAL_REVIEW,
+      expires_on: Date.new(2026, 4, 25)
+    )
+
+    ev = create_pending_event!(amount: 1_000)
+    Core::Posting::Commands::PostEvent.call(operational_event_id: ev.id)
+
+    projection = @account.deposit_account_balance_projection.reload
+    assert_equal 1_000, projection.ledger_balance_minor_units
+    assert_equal 300, projection.hold_balance_minor_units
+    assert_equal 700, projection.available_balance_minor_units
+  end
+
+  test "posting reversal updates deposit balance projection with mirrored 2110 lines" do
+    ev = create_pending_event!(amount: 1_200)
+    Core::Posting::Commands::PostEvent.call(operational_event_id: ev.id)
+    reversal = Core::OperationalEvents::Commands::RecordReversal.call(
+      original_operational_event_id: ev.id,
+      channel: "api",
+      idempotency_key: "projection-reversal-#{SecureRandom.hex(4)}"
+    )[:event]
+
+    Core::Posting::Commands::PostEvent.call(operational_event_id: reversal.id)
+
+    projection = @account.deposit_account_balance_projection.reload
+    assert_equal 0, projection.ledger_balance_minor_units
+    assert_equal reversal.id, projection.last_operational_event_id
   end
 
   test "posts cash shipment received as Dr 1110 Cr 1130" do
@@ -179,6 +245,7 @@ class CorePostingPostEventTest < ActiveSupport::TestCase
     assert_equal "debit", lines.first.side
     assert_equal "1130", lines.second.gl_account.account_number
     assert_equal "credit", lines.second.side
+    assert_nil @account.reload.deposit_account_balance_projection
   end
 
   private

--- a/test/domains/core/posting/post_event_test.rb
+++ b/test/domains/core/posting/post_event_test.rb
@@ -64,6 +64,29 @@ class CorePostingPostEventTest < ActiveSupport::TestCase
     assert_equal 0, ev.posting_batches.count
   end
 
+  test "rolls back journal lines when projection update fails after line creation" do
+    ev = create_pending_event!(amount: 300)
+    original_projector = Accounts::Services::DepositBalanceProjector.method(:apply_journal_entry!)
+    Accounts::Services::DepositBalanceProjector.define_singleton_method(:apply_journal_entry!) do |journal_entry:|
+      raise "projection failure"
+    end
+
+    begin
+      assert_raises(RuntimeError) do
+        Core::Posting::Commands::PostEvent.call(operational_event_id: ev.id)
+      end
+    ensure
+      Accounts::Services::DepositBalanceProjector.define_singleton_method(:apply_journal_entry!) do |journal_entry:|
+        original_projector.call(journal_entry: journal_entry)
+      end
+    end
+
+    assert_equal "pending", ev.reload.status
+    assert_equal 0, ev.posting_batches.count
+    assert_equal 0, Core::Ledger::Models::JournalEntry.joins(:posting_batch).where(posting_batches: { operational_event_id: ev.id }).count
+    assert_equal 0, @account.deposit_account_balance_projection.reload.ledger_balance_minor_units
+  end
+
   test "not found raises" do
     assert_raises(Core::Posting::Commands::PostEvent::NotFound) do
       Core::Posting::Commands::PostEvent.call(operational_event_id: 0)
@@ -245,7 +268,9 @@ class CorePostingPostEventTest < ActiveSupport::TestCase
     assert_equal "debit", lines.first.side
     assert_equal "1130", lines.second.gl_account.account_number
     assert_equal "credit", lines.second.side
-    assert_nil @account.reload.deposit_account_balance_projection
+    projection = @account.reload.deposit_account_balance_projection
+    assert_equal 0, projection.ledger_balance_minor_units
+    assert_nil projection.last_journal_entry_id
   end
 
   private

--- a/test/domains/deposits/generate_deposit_statements_test.rb
+++ b/test/domains/deposits/generate_deposit_statements_test.rb
@@ -32,6 +32,22 @@ class DepositsGenerateDepositStatementsTest < ActiveSupport::TestCase
     assert_equal [ "deposit.accepted" ], statement.line_items.map { |line| line.fetch("event_type") }
   end
 
+  test "generated statement uses daily snapshots for closed-period balances" do
+    snapshot!(account: @account, as_of_date: Date.new(2026, 3, 31), ledger: 1_000)
+    fund_account!(@account, 5_000)
+    snapshot!(account: @account, as_of_date: Date.new(2026, 4, 30), ledger: 6_000)
+
+    result = Deposits::Commands::GenerateDepositStatements.call(
+      business_date: Date.new(2026, 5, 1),
+      deposit_product_id: @product.id
+    )
+
+    statement = Deposits::Models::DepositStatement.find(result.outcomes.sole.fetch(:deposit_statement_id))
+    assert_equal 1_000, statement.opening_ledger_balance_minor_units
+    assert_equal 6_000, statement.closing_ledger_balance_minor_units
+    assert_equal 5_000, statement.total_credits_minor_units
+  end
+
   test "rerun is idempotent and reports already generated" do
     fund_account!(@account, 5_000)
 
@@ -125,5 +141,19 @@ class DepositsGenerateDepositStatementsTest < ActiveSupport::TestCase
     )[:event]
     Core::Posting::Commands::PostEvent.call(operational_event_id: event.id)
     event.reload
+  end
+
+  def snapshot!(account:, as_of_date:, ledger:)
+    Reporting::Models::DailyBalanceSnapshot.create!(
+      account_domain: Reporting::Models::DailyBalanceSnapshot::ACCOUNT_DOMAIN_DEPOSITS,
+      account_id: account.id,
+      account_type: Reporting::Models::DailyBalanceSnapshot::ACCOUNT_TYPE_DEPOSIT_ACCOUNT,
+      as_of_date: as_of_date,
+      ledger_balance_minor_units: ledger,
+      hold_balance_minor_units: 0,
+      available_balance_minor_units: ledger,
+      source: Reporting::Models::DailyBalanceSnapshot::SOURCE_CURRENT_PROJECTION,
+      calculation_version: Accounts::Models::DepositAccountBalanceProjection::CURRENT_CALCULATION_VERSION
+    )
   end
 end

--- a/test/domains/deposits/statement_activity_test.rb
+++ b/test/domains/deposits/statement_activity_test.rb
@@ -97,6 +97,25 @@ class DepositsStatementActivityTest < ActiveSupport::TestCase
     assert servicing.all? { |line| line.fetch(:running_ledger_balance_minor_units).nil? }
   end
 
+  test "uses daily snapshots for closed-period opening and closing balances" do
+    snapshot!(account: @account, as_of_date: Date.new(2026, 3, 31), ledger: 1_000)
+
+    set_business_date(Date.new(2026, 4, 15))
+    post_event!(record_event!("deposit.accepted", amount: 5_000, source_account_id: @account.id))
+    snapshot!(account: @account, as_of_date: Date.new(2026, 4, 30), ledger: 6_000)
+
+    result = Deposits::Queries::StatementActivity.call(
+      deposit_account_id: @account.id,
+      period_start_on: Date.new(2026, 4, 1),
+      period_end_on: Date.new(2026, 4, 30)
+    )
+
+    assert_equal 1_000, result.opening_ledger_balance_minor_units
+    assert_equal 6_000, result.closing_ledger_balance_minor_units
+    assert_equal 5_000, result.total_credits_minor_units
+    assert_equal 6_000, result.line_items.sole.fetch(:running_ledger_balance_minor_units)
+  end
+
   private
 
   def set_business_date(date)
@@ -137,5 +156,19 @@ class DepositsStatementActivityTest < ActiveSupport::TestCase
   def post_event!(event)
     Core::Posting::Commands::PostEvent.call(operational_event_id: event.id)
     event.reload
+  end
+
+  def snapshot!(account:, as_of_date:, ledger:)
+    Reporting::Models::DailyBalanceSnapshot.create!(
+      account_domain: Reporting::Models::DailyBalanceSnapshot::ACCOUNT_DOMAIN_DEPOSITS,
+      account_id: account.id,
+      account_type: Reporting::Models::DailyBalanceSnapshot::ACCOUNT_TYPE_DEPOSIT_ACCOUNT,
+      as_of_date: as_of_date,
+      ledger_balance_minor_units: ledger,
+      hold_balance_minor_units: 0,
+      available_balance_minor_units: ledger,
+      source: Reporting::Models::DailyBalanceSnapshot::SOURCE_CURRENT_PROJECTION,
+      calculation_version: Accounts::Models::DepositAccountBalanceProjection::CURRENT_CALCULATION_VERSION
+    )
   end
 end

--- a/test/domains/reporting/daily_balance_snapshot_test.rb
+++ b/test/domains/reporting/daily_balance_snapshot_test.rb
@@ -58,6 +58,30 @@ class ReportingDailyBalanceSnapshotTest < ActiveSupport::TestCase
     assert_equal Accounts::Models::DepositAccountBalanceProjection::CURRENT_CALCULATION_VERSION, snapshot.calculation_version
   end
 
+  test "materialization creates missing zero balance projection for open accounts" do
+    assert_nil @account.deposit_account_balance_projection
+
+    result = Reporting::Commands::MaterializeDailyBalanceSnapshots.call(as_of_date: Date.new(2026, 5, 2))
+
+    assert_equal 1, result.snapshots_materialized
+    assert_equal 0, @account.reload.deposit_account_balance_projection.ledger_balance_minor_units
+    snapshot = Reporting::Models::DailyBalanceSnapshot.find_by!(account_id: @account.id)
+    assert_equal 0, snapshot.ledger_balance_minor_units
+    assert_equal 0, snapshot.hold_balance_minor_units
+    assert_equal 0, snapshot.available_balance_minor_units
+  end
+
+  test "materialization refuses stale or drifted projections" do
+    fund_account!(5_000)
+    @account.deposit_account_balance_projection.update!(stale: true, stale_from_date: Date.new(2026, 5, 1))
+
+    assert_raises(Reporting::Commands::MaterializeDailyBalanceSnapshots::ProjectionDriftDetected) do
+      Reporting::Commands::MaterializeDailyBalanceSnapshots.call(as_of_date: Date.new(2026, 5, 2))
+    end
+
+    assert_equal 0, Reporting::Models::DailyBalanceSnapshot.count
+  end
+
   test "materialization is idempotent and refreshes existing snapshot values" do
     fund_account!(5_000)
     Reporting::Commands::MaterializeDailyBalanceSnapshots.call(as_of_date: Date.new(2026, 5, 2))

--- a/test/domains/reporting/daily_balance_snapshot_test.rb
+++ b/test/domains/reporting/daily_balance_snapshot_test.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ReportingDailyBalanceSnapshotTest < ActiveSupport::TestCase
+  setup do
+    BankCore::Seeds::GlCoa.seed!
+    Core::BusinessDate::Models::BusinessDateSetting.delete_all
+    Core::BusinessDate::Commands::SetBusinessDate.call(on: Date.new(2026, 5, 2))
+    party = Party::Commands::CreateParty.call(party_type: "individual", first_name: "Daily", last_name: "Snapshot")
+    @account = Accounts::Commands::OpenAccount.call(party_record_id: party.id)
+  end
+
+  test "validates daily snapshot shape" do
+    snapshot = Reporting::Models::DailyBalanceSnapshot.new(
+      account_domain: "unknown",
+      account_id: @account.id,
+      account_type: Reporting::Models::DailyBalanceSnapshot::ACCOUNT_TYPE_DEPOSIT_ACCOUNT,
+      as_of_date: Date.new(2026, 5, 2),
+      ledger_balance_minor_units: -1_00,
+      hold_balance_minor_units: -1,
+      available_balance_minor_units: -1_00,
+      source: "unknown",
+      calculation_version: 1
+    )
+
+    assert_not snapshot.valid?
+    assert_includes snapshot.errors[:account_domain], "is not included in the list"
+    assert_includes snapshot.errors[:source], "is not included in the list"
+    assert_includes snapshot.errors[:hold_balance_minor_units], "must be greater than or equal to 0"
+
+    snapshot.account_domain = Reporting::Models::DailyBalanceSnapshot::ACCOUNT_DOMAIN_DEPOSITS
+    snapshot.source = Reporting::Models::DailyBalanceSnapshot::SOURCE_CURRENT_PROJECTION
+    snapshot.hold_balance_minor_units = 0
+    assert snapshot.valid?
+  end
+
+  test "materializes deposit projections into daily balance snapshots" do
+    fund_account!(5_000)
+    place_hold!(amount: 1_500, key: "snapshot-hold")
+
+    result = Reporting::Commands::MaterializeDailyBalanceSnapshots.call(as_of_date: Date.new(2026, 5, 2))
+
+    assert_equal Date.new(2026, 5, 2), result.as_of_date
+    assert_equal 1, result.snapshots_materialized
+
+    snapshot = Reporting::Models::DailyBalanceSnapshot.find_by!(
+      account_domain: Reporting::Models::DailyBalanceSnapshot::ACCOUNT_DOMAIN_DEPOSITS,
+      account_id: @account.id,
+      as_of_date: Date.new(2026, 5, 2)
+    )
+    assert_equal Reporting::Models::DailyBalanceSnapshot::ACCOUNT_TYPE_DEPOSIT_ACCOUNT, snapshot.account_type
+    assert_equal 5_000, snapshot.ledger_balance_minor_units
+    assert_equal 1_500, snapshot.hold_balance_minor_units
+    assert_equal 3_500, snapshot.available_balance_minor_units
+    assert_nil snapshot.collected_balance_minor_units
+    assert_equal Reporting::Models::DailyBalanceSnapshot::SOURCE_CURRENT_PROJECTION, snapshot.source
+    assert_equal Accounts::Models::DepositAccountBalanceProjection::CURRENT_CALCULATION_VERSION, snapshot.calculation_version
+  end
+
+  test "materialization is idempotent and refreshes existing snapshot values" do
+    fund_account!(5_000)
+    Reporting::Commands::MaterializeDailyBalanceSnapshots.call(as_of_date: Date.new(2026, 5, 2))
+    snapshot = Reporting::Models::DailyBalanceSnapshot.find_by!(account_id: @account.id)
+    snapshot.update!(ledger_balance_minor_units: 1, available_balance_minor_units: 1)
+
+    result = Reporting::Commands::MaterializeDailyBalanceSnapshots.call(as_of_date: "2026-05-02")
+
+    assert_equal 1, result.snapshots_materialized
+    assert_equal 1, Reporting::Models::DailyBalanceSnapshot.where(account_id: @account.id).count
+    snapshot.reload
+    assert_equal 5_000, snapshot.ledger_balance_minor_units
+    assert_equal 5_000, snapshot.available_balance_minor_units
+  end
+
+  private
+
+  def fund_account!(amount)
+    event = Core::OperationalEvents::Commands::RecordEvent.call(
+      event_type: "deposit.accepted",
+      channel: "batch",
+      idempotency_key: "daily-snapshot-fund-#{SecureRandom.hex(4)}",
+      amount_minor_units: amount,
+      currency: "USD",
+      source_account_id: @account.id
+    ).fetch(:event)
+    Core::Posting::Commands::PostEvent.call(operational_event_id: event.id)
+  end
+
+  def place_hold!(amount:, key:)
+    Accounts::Commands::PlaceHold.call(
+      deposit_account_id: @account.id,
+      amount_minor_units: amount,
+      currency: "USD",
+      channel: "api",
+      idempotency_key: key,
+      hold_type: Accounts::Models::Hold::HOLD_TYPE_ADMINISTRATIVE,
+      reason_code: Accounts::Models::Hold::REASON_MANUAL_REVIEW,
+      expires_on: Date.new(2026, 5, 5)
+    )
+  end
+end

--- a/test/domains/reporting/daily_balance_snapshot_test.rb
+++ b/test/domains/reporting/daily_balance_snapshot_test.rb
@@ -35,6 +35,43 @@ class ReportingDailyBalanceSnapshotTest < ActiveSupport::TestCase
     assert snapshot.valid?
   end
 
+  test "reserves loan snapshot account metadata without implementing loans" do
+    snapshot = Reporting::Models::DailyBalanceSnapshot.new(
+      account_domain: Reporting::Models::DailyBalanceSnapshot::ACCOUNT_DOMAIN_LOANS,
+      account_id: 123,
+      account_type: Reporting::Models::DailyBalanceSnapshot::ACCOUNT_TYPE_DEPOSIT_ACCOUNT,
+      as_of_date: Date.new(2026, 5, 2),
+      ledger_balance_minor_units: -10_000,
+      hold_balance_minor_units: 0,
+      available_balance_minor_units: -10_000,
+      source: Reporting::Models::DailyBalanceSnapshot::SOURCE_CURRENT_PROJECTION,
+      calculation_version: 1
+    )
+
+    assert_not snapshot.valid?
+    assert_includes snapshot.errors[:account_type], "must be loan_account for loans snapshots"
+
+    snapshot.account_type = Reporting::Models::DailyBalanceSnapshot::ACCOUNT_TYPE_LOAN_ACCOUNT
+    assert snapshot.valid?
+  end
+
+  test "deposit snapshots must use deposit account metadata" do
+    snapshot = Reporting::Models::DailyBalanceSnapshot.new(
+      account_domain: Reporting::Models::DailyBalanceSnapshot::ACCOUNT_DOMAIN_DEPOSITS,
+      account_id: @account.id,
+      account_type: Reporting::Models::DailyBalanceSnapshot::ACCOUNT_TYPE_LOAN_ACCOUNT,
+      as_of_date: Date.new(2026, 5, 2),
+      ledger_balance_minor_units: 0,
+      hold_balance_minor_units: 0,
+      available_balance_minor_units: 0,
+      source: Reporting::Models::DailyBalanceSnapshot::SOURCE_CURRENT_PROJECTION,
+      calculation_version: 1
+    )
+
+    assert_not snapshot.valid?
+    assert_includes snapshot.errors[:account_type], "must be deposit_account for deposits snapshots"
+  end
+
   test "materializes deposit projections into daily balance snapshots" do
     fund_account!(5_000)
     place_hold!(amount: 1_500, key: "snapshot-hold")

--- a/test/domains/reporting/daily_balance_snapshot_test.rb
+++ b/test/domains/reporting/daily_balance_snapshot_test.rb
@@ -96,7 +96,8 @@ class ReportingDailyBalanceSnapshotTest < ActiveSupport::TestCase
   end
 
   test "materialization creates missing zero balance projection for open accounts" do
-    assert_nil @account.deposit_account_balance_projection
+    @account.deposit_account_balance_projection.destroy!
+    assert_nil @account.reload.deposit_account_balance_projection
 
     result = Reporting::Commands::MaterializeDailyBalanceSnapshots.call(as_of_date: Date.new(2026, 5, 2))
 
@@ -106,6 +107,25 @@ class ReportingDailyBalanceSnapshotTest < ActiveSupport::TestCase
     assert_equal 0, snapshot.ledger_balance_minor_units
     assert_equal 0, snapshot.hold_balance_minor_units
     assert_equal 0, snapshot.available_balance_minor_units
+  end
+
+  test "materialization keys snapshots by source and calculation version" do
+    fund_account!(5_000)
+    Reporting::Commands::MaterializeDailyBalanceSnapshots.call(as_of_date: Date.new(2026, 5, 2))
+    fund_account!(1_000)
+    projection = @account.deposit_account_balance_projection
+    projection.update!(
+      calculation_version: 2
+    )
+
+    Reporting::Commands::MaterializeDailyBalanceSnapshots.call(
+      as_of_date: Date.new(2026, 5, 2),
+      expected_calculation_version: 2
+    )
+
+    snapshots = Reporting::Models::DailyBalanceSnapshot.where(account_id: @account.id).order(:calculation_version)
+    assert_equal [ 1, 2 ], snapshots.map(&:calculation_version)
+    assert_equal [ 5_000, 6_000 ], snapshots.map(&:ledger_balance_minor_units)
   end
 
   test "materialization refuses stale or drifted projections" do
@@ -132,6 +152,20 @@ class ReportingDailyBalanceSnapshotTest < ActiveSupport::TestCase
     snapshot.reload
     assert_equal 5_000, snapshot.ledger_balance_minor_units
     assert_equal 5_000, snapshot.available_balance_minor_units
+  end
+
+  test "formula version marking stales old daily snapshots" do
+    fund_account!(5_000)
+    Reporting::Commands::MaterializeDailyBalanceSnapshots.call(as_of_date: Date.new(2026, 5, 2))
+    snapshot = Reporting::Models::DailyBalanceSnapshot.sole
+    snapshot.update!(calculation_version: 99)
+
+    result = Reporting::Commands::MarkDailyBalanceSnapshotsStaleForVersion.call(expected_calculation_version: 1)
+
+    assert_equal 1, result.marked_count
+    snapshot.reload
+    assert snapshot.stale
+    assert_equal snapshot.as_of_date, snapshot.stale_from_date
   end
 
   private

--- a/test/integration/ops_control_surfaces_test.rb
+++ b/test/integration/ops_control_surfaces_test.rb
@@ -18,10 +18,103 @@ class OpsControlSurfacesTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, "Business date close"
     assert_includes response.body, "EOD ready"
+    assert_includes response.body, "Balance projection health"
 
     post "/ops/business_date_close", params: { business_date: @business_date.iso8601 }
     assert_redirected_to "/ops/business_date_close"
     assert_equal @business_date + 1.day, Core::BusinessDate::Services::CurrentBusinessDate.call
+  end
+
+  test "balance projection health page is read-only by default" do
+    seed_fee_eligible_account!
+
+    internal_login!(username: "ops-controls")
+    get "/ops"
+    assert_response :success
+    assert_includes response.body, "Balance projections"
+
+    get "/ops/balance_projections"
+    assert_response :success
+    assert_includes response.body, "Balance projection health"
+    assert_includes response.body, "Stale projections"
+    assert_includes response.body, "Recent rebuild evidence"
+    assert_no_match(/Mark stale/, response.body)
+    assert_no_match(/Rebuild projection/, response.body)
+  end
+
+  test "balance projection account detail can mark stale and rebuild one account" do
+    account = seed_fee_eligible_account!
+    account.deposit_account_balance_projection.update!(
+      ledger_balance_minor_units: 1,
+      available_balance_minor_units: 1
+    )
+
+    internal_login!(username: "ops-controls")
+    get "/ops/balance_projections", params: { account: account.account_number }
+    assert_response :success
+    assert_includes response.body, account.account_number
+    assert_includes response.body, "Drifted"
+    assert_includes response.body, "Mark stale"
+
+    assert_difference -> { Accounts::Models::DepositBalanceRebuildRequest.where(status: "requested").count }, 1 do
+      post "/ops/balance_projections/#{account.id}/mark_stale"
+    end
+    assert_redirected_to "/ops/balance_projections?account=#{account.account_number}"
+    assert account.deposit_account_balance_projection.reload.stale
+
+    assert_difference -> { Accounts::Models::DepositBalanceRebuildRequest.where(status: "completed").count }, 1 do
+      post "/ops/balance_projections/#{account.id}/rebuild"
+    end
+    assert_redirected_to "/ops/balance_projections?account=#{account.account_number}"
+    assert_not account.deposit_account_balance_projection.reload.stale
+  end
+
+  test "balance projection repair actions require reconciliation capability" do
+    account = seed_fee_eligible_account!
+    create_operator_with_credential!(role: "admin", username: "ops-balance-admin")
+
+    internal_login!(username: "ops-balance-admin")
+    get "/ops/balance_projections"
+    assert_response :success
+
+    post "/ops/balance_projections/#{account.id}/mark_stale"
+    assert_response :forbidden
+  end
+
+  test "bulk balance repair marks version mismatches and rebuilds stale projections" do
+    account = seed_fee_eligible_account!
+    account.deposit_account_balance_projection.update!(calculation_version: 99, stale: false)
+    Reporting::Models::DailyBalanceSnapshot.create!(
+      account_domain: Reporting::Models::DailyBalanceSnapshot::ACCOUNT_DOMAIN_DEPOSITS,
+      account_id: account.id,
+      account_type: Reporting::Models::DailyBalanceSnapshot::ACCOUNT_TYPE_DEPOSIT_ACCOUNT,
+      as_of_date: @business_date,
+      ledger_balance_minor_units: 5_000,
+      hold_balance_minor_units: 0,
+      available_balance_minor_units: 5_000,
+      source: Reporting::Models::DailyBalanceSnapshot::SOURCE_CURRENT_PROJECTION,
+      calculation_version: 99
+    )
+
+    internal_login!(username: "ops-controls")
+    get "/ops/balance_projections/bulk_repair"
+    assert_response :success
+    assert_includes response.body, "Bulk balance repair"
+
+    post "/ops/balance_projections/bulk_repair",
+      params: { bulk_repair: { action_type: "mark_projection_versions", limit: 25 } }
+    assert_redirected_to "/ops/balance_projections/bulk_repair"
+    assert account.deposit_account_balance_projection.reload.stale
+
+    post "/ops/balance_projections/bulk_repair",
+      params: { bulk_repair: { action_type: "mark_snapshot_versions", limit: 25 } }
+    assert_redirected_to "/ops/balance_projections/bulk_repair"
+    assert Reporting::Models::DailyBalanceSnapshot.find_by!(account_id: account.id).stale
+
+    post "/ops/balance_projections/bulk_repair",
+      params: { bulk_repair: { action_type: "rebuild_stale_projections", limit: 25 } }
+    assert_redirected_to "/ops/balance_projections/bulk_repair"
+    assert_not account.deposit_account_balance_projection.reload.stale
   end
 
   test "monthly maintenance engine preview has no side effects and execute posts fees" do


### PR DESCRIPTION
## Summary
- Add Accounts-owned deposit balance projections, projection refresh/rebuild/drift controls, and projection-backed current balance reads.
- Add Reporting-owned daily balance snapshots, EOD materialization, statement balance consumption, and loan-ready snapshot metadata.
- Add Ops balance projection health and repair surfaces with tests for read-only evidence, single-account repair, and bulk controls.

## Test plan
- [x] docker compose run --rm web bin/rails test
- [x] docker compose run --rm web bin/rubocop


Made with [Cursor](https://cursor.com)