### PR TITLE
ADR-0042: Close-package drills, event search filters, Ops teller sessions

### DIFF
--- a/app/controllers/branch/operational_events_controller.rb
+++ b/app/controllers/branch/operational_events_controller.rb
@@ -4,7 +4,24 @@ module Branch
   class OperationalEventsController < ApplicationController
     def index
       @query_params = permitted_query_params
+      apply_branch_operating_unit_default!
+
+      if @query_params[:operating_unit_id].present?
+        begin
+          Organization::Services::ResolveOperatingUnit.assert_operator_scoped_to_operating_unit!(
+            operator: current_operator,
+            operating_unit_id: @query_params[:operating_unit_id]
+          )
+        rescue Organization::Services::ResolveOperatingUnit::NotAuthorized => e
+          @error_message = e.message
+          @event_search = nil
+          render :index, status: :unprocessable_entity
+          return
+        end
+      end
+
       @event_search = Core::OperationalEvents::Queries::ListOperationalEvents.call(**@query_params)
+      @scoped_operating_unit = Organization::Models::OperatingUnit.find_by(id: @query_params[:operating_unit_id]) if @query_params[:operating_unit_id].present?
     rescue Core::OperationalEvents::Queries::ListOperationalEvents::InvalidQuery => e
       @error_message = e.message
       @event_search = nil
@@ -25,6 +42,22 @@ module Branch
 
     private
 
+    def apply_branch_operating_unit_default!
+      @branch_events_show_all_units = ActiveModel::Type::Boolean.new.cast(params[:all_units])
+      if @branch_events_show_all_units
+        @query_params.delete(:operating_unit_id)
+        @branch_events_defaulted_operating_unit = nil
+        return
+      end
+
+      return if @query_params[:operating_unit_id].present?
+
+      if current_operating_unit.present?
+        @query_params[:operating_unit_id] = current_operating_unit.id
+        @branch_events_defaulted_operating_unit = current_operating_unit
+      end
+    end
+
     def load_event
       Core::OperationalEvents::Models::OperationalEvent.includes(
         :source_account,
@@ -32,6 +65,7 @@ module Branch
         :teller_session,
         :actor,
         :reversal_of_event,
+        :operating_unit,
         { posting_batches: :journal_entries }
       ).find(params[:id])
     end
@@ -40,11 +74,25 @@ module Branch
       p = params.permit(
         :business_date, :business_date_from, :business_date_to,
         :source_account_id, :destination_account_id, :status, :event_type, :channel, :actor_id,
-        :after_id, :limit
+        :operating_unit_id, :after_id, :limit,
+        event_type_in: []
       ).to_h.symbolize_keys
       p[:source_account_id] = p[:source_account_id].to_i if p[:source_account_id].present?
       p[:destination_account_id] = p[:destination_account_id].to_i if p[:destination_account_id].present?
       p[:actor_id] = p[:actor_id].to_i if p[:actor_id].present?
+      if p[:event_type_in].present?
+        p[:event_type_in] = Array.wrap(p[:event_type_in]).flat_map { |v| v.to_s.split(",") }.map(&:strip).reject(&:blank?)
+      else
+        p.delete(:event_type_in)
+      end
+      if p[:operating_unit_id].present?
+        ou = p[:operating_unit_id].to_i
+        if ou.positive?
+          p[:operating_unit_id] = ou
+        else
+          p.delete(:operating_unit_id)
+        end
+      end
       p
     end
   end

--- a/app/controllers/ops/cash_controller.rb
+++ b/app/controllers/ops/cash_controller.rb
@@ -8,6 +8,8 @@ module Ops
     before_action :require_cash_variance_approval!, only: :approve_variance
 
     def index
+      @reviewed_business_date = parse_reviewed_business_date_param
+      @from_close_package = ActiveModel::Type::Boolean.new.cast(params[:from_close_package])
       @approvals = Cash::Queries::PendingCashApprovals.call(operating_unit_id: current_operating_unit&.id)
       @summary = Cash::Queries::ReconciliationSummary.call(operating_unit_id: current_operating_unit&.id)
     end
@@ -41,6 +43,15 @@ module Ops
     end
 
     private
+
+    def parse_reviewed_business_date_param
+      raw = params[:reviewed_business_date].presence
+      return nil if raw.blank?
+
+      Date.iso8601(raw.to_s)
+    rescue ArgumentError, TypeError
+      nil
+    end
 
     def require_cash_position_view!
       require_cash_capability!(

--- a/app/controllers/ops/operational_events_controller.rb
+++ b/app/controllers/ops/operational_events_controller.rb
@@ -4,7 +4,22 @@ module Ops
   class OperationalEventsController < ApplicationController
     def index
       @query_params = permitted_query_params
+      if @query_params[:operating_unit_id].present?
+        begin
+          Organization::Services::ResolveOperatingUnit.assert_operator_scoped_to_operating_unit!(
+            operator: current_operator,
+            operating_unit_id: @query_params[:operating_unit_id]
+          )
+        rescue Organization::Services::ResolveOperatingUnit::NotAuthorized => e
+          @error_message = e.message
+          @event_search = nil
+          render :index, status: :unprocessable_entity
+          return
+        end
+      end
+
       @event_search = Core::OperationalEvents::Queries::ListOperationalEvents.call(**@query_params)
+      @scoped_operating_unit = Organization::Models::OperatingUnit.find_by(id: @query_params[:operating_unit_id]) if @query_params[:operating_unit_id].present?
     rescue Core::OperationalEvents::Queries::ListOperationalEvents::InvalidQuery => e
       @error_message = e.message
       @event_search = nil
@@ -32,13 +47,27 @@ module Ops
         :business_date, :business_date_from, :business_date_to,
         :source_account_id, :destination_account_id, :status, :event_type, :channel, :actor_id,
         :reference_id, :idempotency_key, :reversal_of_event_id,
-        :deposit_product_id, :product_code, :after_id, :limit
+        :deposit_product_id, :product_code, :operating_unit_id, :after_id, :limit,
+        event_type_in: []
       ).to_h.symbolize_keys
       p[:source_account_id] = p[:source_account_id].to_i if p[:source_account_id].present?
       p[:destination_account_id] = p[:destination_account_id].to_i if p[:destination_account_id].present?
       p[:actor_id] = p[:actor_id].to_i if p[:actor_id].present?
       p[:reversal_of_event_id] = p[:reversal_of_event_id].to_i if p[:reversal_of_event_id].present?
       p[:deposit_product_id] = p[:deposit_product_id].to_i if p[:deposit_product_id].present?
+      if p[:event_type_in].present?
+        p[:event_type_in] = Array.wrap(p[:event_type_in]).flat_map { |v| v.to_s.split(",") }.map(&:strip).reject(&:blank?)
+      else
+        p.delete(:event_type_in)
+      end
+      if p[:operating_unit_id].present?
+        ou = p[:operating_unit_id].to_i
+        if ou.positive?
+          p[:operating_unit_id] = ou
+        else
+          p.delete(:operating_unit_id)
+        end
+      end
       p
     end
   end

--- a/app/controllers/ops/teller_sessions_controller.rb
+++ b/app/controllers/ops/teller_sessions_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Ops
+  class TellerSessionsController < ApplicationController
+    def index
+      @sessions = Teller::Models::TellerSession
+        .where(status: [
+          Teller::Models::TellerSession::STATUS_OPEN,
+          Teller::Models::TellerSession::STATUS_PENDING_SUPERVISOR
+        ])
+        .includes(:operating_unit, :cash_location, :supervisor_operator)
+        .order(:opened_at, :id)
+    end
+
+    def show
+      @session = Teller::Models::TellerSession.includes(:operating_unit, :cash_location, :supervisor_operator).find(params[:id])
+      @primary_operator = primary_operator_for_session(@session)
+    end
+
+    private
+
+    def primary_operator_for_session(session)
+      Core::OperationalEvents::Models::OperationalEvent
+        .where(teller_session_id: session.id)
+        .where.not(actor_id: nil)
+        .includes(:actor)
+        .order(:id)
+        .first&.actor
+    end
+  end
+end

--- a/app/domains/core/operational_events/queries/list_operational_events.rb
+++ b/app/domains/core/operational_events/queries/list_operational_events.rb
@@ -10,6 +10,7 @@ module Core
         MAX_SPAN_DAYS = 31
         DEFAULT_LIMIT = 50
         MAX_LIMIT = 200
+        MAX_EVENT_TYPE_IN = 10
 
         # @return [Hash] :rows (Array<OperationalEvent>), :envelope (Hash), :next_after_id, :has_more
         def self.call(
@@ -20,6 +21,7 @@ module Core
           destination_account_id: nil,
           status: nil,
           event_type: nil,
+          event_type_in: nil,
           channel: nil,
           actor_id: nil,
           reference_id: nil,
@@ -27,6 +29,7 @@ module Core
           reversal_of_event_id: nil,
           deposit_product_id: nil,
           product_code: nil,
+          operating_unit_id: nil,
           after_id: nil,
           limit: nil
         )
@@ -46,6 +49,9 @@ module Core
           end
           raise InvalidQuery, "limit must be between 1 and #{MAX_LIMIT}" unless lim.between?(1, MAX_LIMIT)
 
+          normalized_event_type_in = normalize_event_type_in!(event_type_in)
+          raise InvalidQuery, "cannot combine event_type and event_type_in" if event_type.present? && normalized_event_type_in.present?
+
           scope = base_scope(
             from_date: from_date,
             to_date: to_date,
@@ -53,13 +59,15 @@ module Core
             destination_account_id: destination_account_id,
             status: status,
             event_type: event_type,
+            event_types: normalized_event_type_in,
             channel: channel,
             actor_id: actor_id,
             reference_id: reference_id,
             idempotency_key: idempotency_key,
             reversal_of_event_id: reversal_of_event_id,
             deposit_product_id: deposit_product_id,
-            product_code: product_code
+            product_code: product_code,
+            operating_unit_id: operating_unit_id
           )
 
           scope = scope.where("operational_events.id > ?", after_id.to_i) if after_id.present?
@@ -127,19 +135,37 @@ module Core
         end
         private_class_method :validate_range!
 
+        def self.normalize_event_type_in!(raw)
+          return nil if raw.blank?
+
+          values = Array.wrap(raw).flat_map { |v| v.to_s.split(",") }.map(&:strip).reject(&:blank?).uniq
+          return nil if values.empty?
+
+          raise InvalidQuery, "event_type_in must not exceed #{MAX_EVENT_TYPE_IN} values" if values.size > MAX_EVENT_TYPE_IN
+
+          values
+        end
+        private_class_method :normalize_event_type_in!
+
         def self.base_scope(from_date:, to_date:, source_account_id:, destination_account_id:, status:, event_type:,
-                            channel:, actor_id:, reference_id:, idempotency_key:, reversal_of_event_id:,
-                            deposit_product_id:, product_code:)
+                            event_types:, channel:, actor_id:, reference_id:, idempotency_key:, reversal_of_event_id:,
+                            deposit_product_id:, product_code:, operating_unit_id:)
           scope = Models::OperationalEvent.where(business_date: from_date..to_date)
           scope = scope.where(source_account_id: source_account_id.to_i) if source_account_id.present?
           scope = scope.where(destination_account_id: destination_account_id.to_i) if destination_account_id.present?
           scope = scope.where(status: status.to_s) if status.present?
-          scope = scope.where(event_type: event_type.to_s) if event_type.present?
+          if event_types.present?
+            scope = scope.where(event_type: event_types)
+          elsif event_type.present?
+            scope = scope.where(event_type: event_type.to_s)
+          end
           scope = scope.where(channel: channel.to_s) if channel.present?
           scope = scope.where(actor_id: actor_id.to_i) if actor_id.present?
           scope = scope.where(reference_id: reference_id.to_s) if reference_id.present?
           scope = scope.where(idempotency_key: idempotency_key.to_s) if idempotency_key.present?
           scope = scope.where(reversal_of_event_id: reversal_of_event_id.to_i) if reversal_of_event_id.present?
+          ou = operating_unit_id.to_i
+          scope = scope.where(operating_unit_id: ou) if ou.positive?
 
           account_ids = matching_deposit_account_ids(deposit_product_id: deposit_product_id, product_code: product_code)
           if account_ids.nil?

--- a/app/domains/organization/services/resolve_operating_unit.rb
+++ b/app/domains/organization/services/resolve_operating_unit.rb
@@ -18,6 +18,13 @@ module Organization
         DefaultOperatingUnit.branch!
       end
 
+      # Raises NotAuthorized if missing/inactive or operator has no capability scoped to the unit.
+      def self.assert_operator_scoped_to_operating_unit!(operator:, operating_unit_id:)
+        raise NotAuthorized, "operating unit required" if operating_unit_id.blank?
+
+        operating_unit_from_explicit(operator, operating_unit_id)
+      end
+
       def self.operating_unit_from_session(teller_session_id)
         return nil if teller_session_id.blank?
 

--- a/app/views/branch/dashboard/index.html.erb
+++ b/app/views/branch/dashboard/index.html.erb
@@ -12,6 +12,40 @@
   </div>
 </section>
 
+<% if current_business_date.present? %>
+  <section class="mt-8 rounded border border-slate-200 bg-white p-6 shadow-sm" aria-label="Business date status">
+    <h2 class="text-xl font-semibold text-slate-950">Today (business date)</h2>
+    <p class="mt-1 text-sm text-slate-600">Institution open processing day and branch situational snapshot (ADR-0042).</p>
+    <dl class="mt-4 grid gap-3 text-sm md:grid-cols-3">
+      <div>
+        <dt class="font-medium text-slate-500">Current business date</dt>
+        <dd class="text-lg font-semibold text-slate-950"><%= current_business_date.iso8601 %></dd>
+      </div>
+      <div>
+        <dt class="font-medium text-slate-500">Open sessions</dt>
+        <dd class="text-lg font-semibold text-slate-950"><%= @session_dashboard.open_sessions.size %></dd>
+      </div>
+      <div>
+        <dt class="font-medium text-slate-500">Pending supervisor</dt>
+        <dd class="text-lg font-semibold text-slate-950"><%= @session_dashboard.pending_supervisor_sessions.size %></dd>
+      </div>
+    </dl>
+    <div class="mt-4 flex flex-wrap gap-2 text-sm">
+      <% if branch_operator_can?(cap::OPERATIONAL_EVENT_VIEW) %>
+        <%= link_to "Branch events (#{current_business_date.iso8601})", branch_events_path(business_date: current_business_date.iso8601), class: "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 shadow-sm" %>
+      <% end %>
+      <% if branch_operator_can?(cap::CASH_POSITION_VIEW) %>
+        <%= link_to "Cash position", branch_cash_path, class: "rounded border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 shadow-sm" %>
+      <% end %>
+      <% if ops_access? %>
+        <%= link_to "Ops close package", ops_close_package_path, class: "rounded bg-slate-900 px-3 py-2 font-medium text-white shadow-sm" %>
+      <% else %>
+        <span class="rounded border border-slate-200 bg-slate-50 px-3 py-2 text-slate-600">Full institution close review requires Ops workspace access.</span>
+      <% end %>
+    </div>
+  </section>
+<% end %>
+
 <% csr_section = capture do %>
 <section id="csr" class="<%= section_spacing.call("csr") %>scroll-mt-8 rounded border border-slate-200 bg-white p-6 shadow-sm">
   <h2 class="text-xl font-semibold text-slate-950">CSR — customer servicing</h2>

--- a/app/views/branch/operational_events/index.html.erb
+++ b/app/views/branch/operational_events/index.html.erb
@@ -17,8 +17,38 @@
 
 <%= render "branch/shared/form_error", error_message: @error_message %>
 
+<section class="mt-6 rounded border border-slate-200 bg-white p-4 text-sm text-slate-800 shadow-sm">
+  <p class="font-medium text-slate-950">Active filters</p>
+  <% if @branch_events_show_all_units %>
+    <p class="mt-1 text-slate-600">Operating unit filter: <strong>all units</strong> (institution-wide listing).</p>
+  <% elsif @scoped_operating_unit.present? %>
+    <p class="mt-1">
+      Operating unit:
+      <strong><%= @scoped_operating_unit.code %> — <%= @scoped_operating_unit.name %></strong>
+      (id <%= @scoped_operating_unit.id %>)
+      <% if @branch_events_defaulted_operating_unit.present? %>
+        <span class="text-slate-600">— defaulted from your branch scope; use “Show all units” to widen.</span>
+      <% end %>
+    </p>
+  <% end %>
+  <% if @query_params[:business_date].present? %>
+    <p class="mt-1 text-slate-600">Business date: <strong><%= @query_params[:business_date] %></strong></p>
+  <% end %>
+  <% if @query_params[:event_type_in].present? %>
+    <p class="mt-1 text-slate-600">Event types (OR): <strong><%= Array.wrap(@query_params[:event_type_in]).join(", ") %></strong></p>
+  <% elsif @query_params[:event_type].present? %>
+    <p class="mt-1 text-slate-600">Event type: <strong><%= @query_params[:event_type] %></strong></p>
+  <% end %>
+  <% if @event_search %>
+    <p class="mt-1 text-slate-600">Results on this page: <strong><%= @event_search[:rows].size %></strong><%= @event_search[:has_more] ? " (more available)" : "" %>.</p>
+  <% end %>
+  <div class="mt-3">
+    <%= link_to "Show all units", branch_events_path(request.query_parameters.except(:operating_unit_id).merge(all_units: true)), class: "rounded border border-slate-300 bg-white px-3 py-1.5 font-medium text-slate-700" %>
+  </div>
+</section>
+
 <section class="mt-6 rounded border border-slate-200 bg-white p-5 shadow-sm">
-  <%= form_with url: branch_events_path, method: :get, class: "grid gap-4 md:grid-cols-4" do |form| %>
+  <%= form_with url: branch_events_path, method: :get, class: "grid gap-4 md:grid-cols-3 lg:grid-cols-6" do |form| %>
     <div>
       <%= form.label :business_date, class: "block text-sm font-medium text-slate-700" %>
       <%= form.text_field :business_date, value: @query_params&.fetch(:business_date, nil), placeholder: "YYYY-MM-DD", class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
@@ -28,10 +58,14 @@
       <%= form.text_field :event_type, value: @query_params&.fetch(:event_type, nil), class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
     </div>
     <div>
+      <%= form.label :operating_unit_id, "Operating unit id", class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :operating_unit_id, value: params[:operating_unit_id].presence || @query_params&.dig(:operating_unit_id), class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+    </div>
+    <div>
       <%= form.label :source_account_id, "Account id", class: "block text-sm font-medium text-slate-700" %>
       <%= form.text_field :source_account_id, value: @query_params&.fetch(:source_account_id, nil), class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
     </div>
-    <div class="self-end">
+    <div class="self-end lg:col-span-2">
       <%= form.submit "Search", class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
       <%= link_to "Clear filters", branch_events_path, class: "ml-2 rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
     </div>

--- a/app/views/branch/operational_events/show.html.erb
+++ b/app/views/branch/operational_events/show.html.erb
@@ -18,8 +18,30 @@
     <div><dt class="font-medium text-slate-500">Destination account</dt><dd><%= @event.destination_account_id || "None" %></dd></div>
     <div><dt class="font-medium text-slate-500">Amount</dt><dd><%= branch_money(@event.amount_minor_units) %> <%= @event.currency %></dd></div>
     <div><dt class="font-medium text-slate-500">Reference</dt><dd><%= @event.reference_id.presence || "None" %></dd></div>
+    <div><dt class="font-medium text-slate-500">Reversal of event id</dt><dd><%= @event.reversal_of_event_id || "None" %></dd></div>
+    <div><dt class="font-medium text-slate-500">Reversed by event id</dt><dd><%= @event.reversed_by_event_id || "None" %></dd></div>
     <div><dt class="font-medium text-slate-500">Teller session</dt><dd><%= @event.teller_session_id || "None" %></dd></div>
     <div><dt class="font-medium text-slate-500">Actor</dt><dd><%= @event.actor&.display_name || @event.actor_id || "None" %></dd></div>
+    <div>
+      <dt class="font-medium text-slate-500">Operating unit</dt>
+      <dd>
+        <% if @event.operating_unit.present? %>
+          <%= @event.operating_unit.code %> — <%= @event.operating_unit.name %> (id <%= @event.operating_unit.id %>)
+        <% else %>
+          None
+        <% end %>
+      </dd>
+    </div>
+    <% if @event.posting_batches.any? %>
+      <div class="md:col-span-2">
+        <dt class="font-medium text-slate-500">Posting batches / journal entries</dt>
+        <dd class="mt-1 text-slate-700">
+          Batches: <%= @event.posting_batches.map(&:id).join(", ") %> ·
+          Entries: <%= @event.posting_batches.flat_map(&:journal_entries).map(&:id).join(", ") %>
+          <span class="block text-xs text-slate-500">Full journal grid remains on Ops event detail.</span>
+        </dd>
+      </div>
+    <% end %>
     <% if @event.event_type == "check.deposit.accepted" && @event.payload.present? %>
       <div class="md:col-span-2">
         <dt class="font-medium text-slate-500">Check deposit items (payload)</dt>
@@ -29,6 +51,9 @@
   </dl>
 
   <div class="mt-6 flex flex-wrap gap-3">
+    <% if ops_access? %>
+      <%= link_to "View in Ops", ops_operational_event_path(@event), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
+    <% end %>
     <%= link_to "Trace receipt", branch_event_receipt_path(@event), class: "rounded border border-slate-300 px-4 py-2 font-medium text-slate-700" %>
     <% if @event.status == Core::OperationalEvents::Models::OperationalEvent::STATUS_PENDING %>
       <%= button_to "Post event", branch_event_post_path(@event), method: :post, class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>

--- a/app/views/ops/cash/index.html.erb
+++ b/app/views/ops/cash/index.html.erb
@@ -1,6 +1,18 @@
 <% content_for :title, "Cash Approvals - BankCORE" %>
 
-<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+<% if @reviewed_business_date.present? || @from_close_package %>
+  <section class="mt-6 rounded border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-800">
+    <p class="font-medium text-slate-950">Drill context</p>
+    <% if @reviewed_business_date.present? %>
+      <p class="mt-1">Reviewed business date from close package: <strong><%= @reviewed_business_date.iso8601 %></strong>.</p>
+    <% end %>
+    <% if @from_close_package %>
+      <p class="mt-1 text-slate-600">Opened from close-package pending cash movements warning. Pending lists reflect current approvals workload — compare counts to readiness when scopes align.</p>
+    <% end %>
+  </section>
+<% end %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end mt-8">
   <div>
     <h1 class="text-3xl font-semibold">Cash approvals</h1>
     <p class="mt-2 text-slate-600">Review pending vault movements and Cash-domain variances.</p>

--- a/app/views/ops/close_packages/show.html.erb
+++ b/app/views/ops/close_packages/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, "Close Package - BankCORE" %>
+<% bd = @business_date&.iso8601 %>
 
 <section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
   <div>
@@ -17,6 +18,7 @@
 <% if @error_message.present? %>
   <section class="mt-6 rounded border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"><%= @error_message %></section>
 <% elsif @readiness.present? %>
+  <% oe_status = Core::OperationalEvents::Models::OperationalEvent %>
   <% if @classification[:retrospective_only] %>
     <section class="mt-6 rounded border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-800">
       <p class="font-medium">Retrospective view</p>
@@ -24,13 +26,26 @@
     </section>
   <% end %>
 
+  <section class="mt-6 rounded border border-slate-200 bg-white px-4 py-3 text-sm text-slate-800 shadow-sm">
+    <p class="font-medium text-slate-950">Business date context</p>
+    <p class="mt-1 text-slate-600">
+      Reviewing <strong><%= bd %></strong>.
+      Current open business date (singleton) is <strong><%= @readiness[:current_business_on] %></strong>.
+      <% if @business_date.iso8601 == @readiness[:current_business_on].to_s %>
+        This is the <strong>current open</strong> processing day.
+      <% else %>
+        This day is <strong>historical</strong> relative to the open processing day.
+      <% end %>
+    </p>
+  </section>
+
   <section class="mt-8 rounded border border-slate-200 bg-white p-6 shadow-sm">
     <h2 class="text-xl font-semibold">Can we close?</h2>
     <p class="mt-2 text-sm text-slate-600">
       <% if @classification[:retrospective_only] %>
         Historical day — no live close action.
       <% elsif @readiness[:eod_ready] %>
-        Yes. EOD readiness checks pass for <%= @business_date.iso8601 %>.
+        Yes. EOD readiness checks pass for <%= bd %>.
       <% else %>
         No. Resolve blockers below before closing the business date.
       <% end %>
@@ -41,10 +56,18 @@
   </section>
 
   <section class="mt-8 grid gap-4 md:grid-cols-4">
-    <%= render "ops/eod/readiness_card", label: "Balanced", value: @readiness[:journal_totals_balanced] ? "Yes" : "No", state: @readiness[:journal_totals_balanced] %>
-    <%= render "ops/eod/readiness_card", label: "Open/pending sessions", value: @readiness[:open_teller_sessions_count], state: @readiness[:all_sessions_closed] %>
-    <%= render "ops/eod/readiness_card", label: "Pending events", value: @readiness[:pending_operational_events_count], state: @readiness[:pending_operational_events_count].to_i.zero? %>
-    <%= render "ops/eod/readiness_card", label: "Posting day closed", value: @readiness[:posting_day_closed] ? "Yes" : "No", state: !@readiness[:posting_day_closed] %>
+    <%= link_to ops_eod_path(business_date: bd), class: "block rounded border border-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-700" do %>
+      <%= render "ops/eod/readiness_card", label: "Balanced", value: @readiness[:journal_totals_balanced] ? "Yes" : "No", state: @readiness[:journal_totals_balanced] %>
+    <% end %>
+    <%= link_to ops_teller_sessions_path, class: "block rounded border border-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-700" do %>
+      <%= render "ops/eod/readiness_card", label: "Open/pending sessions", value: @readiness[:open_teller_sessions_count], state: @readiness[:all_sessions_closed] %>
+    <% end %>
+    <%= link_to ops_operational_events_path(business_date: bd, status: oe_status::STATUS_PENDING), class: "block rounded border border-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-700" do %>
+      <%= render "ops/eod/readiness_card", label: "Pending events", value: @readiness[:pending_operational_events_count], state: @readiness[:pending_operational_events_count].to_i.zero? %>
+    <% end %>
+    <div class="rounded border border-transparent">
+      <%= render "ops/eod/readiness_card", label: "Posting day closed", value: @readiness[:posting_day_closed] ? "Yes" : "No", state: !@readiness[:posting_day_closed] %>
+    </div>
   </section>
 
   <% if @classification[:blockers].any? %>
@@ -52,11 +75,27 @@
       <h2 class="text-xl font-semibold text-amber-950"><%= @classification[:retrospective_only] ? "Blockers (historical context)" : "Blockers" %></h2>
       <ul class="mt-3 list-disc space-y-2 pl-5 text-sm text-amber-950">
         <% @classification[:blockers].each do |b| %>
+          <% blocker_href = case b[:code].to_s
+            when "journal_imbalance" then ops_eod_path(business_date: bd)
+            when "pending_operational_events" then ops_operational_events_path(business_date: bd, status: oe_status::STATUS_PENDING)
+            when "open_teller_sessions" then ops_teller_sessions_path
+            else nil
+            end %>
           <li>
-            <span class="font-medium"><%= b[:code].to_s.humanize %>:</span>
-            <%= b[:label] %>
-            <% if b[:count] %>
-              <span class="text-amber-800">(<%= b[:count] %>)</span>
+            <% if blocker_href.present? %>
+              <%= link_to blocker_href, class: "font-medium text-amber-950 underline hover:text-amber-900" do %>
+                <span class="font-medium"><%= b[:code].to_s.humanize %>:</span>
+                <%= b[:label] %>
+                <% if b[:count] %>
+                  <span class="text-amber-800">(<%= b[:count] %>)</span>
+                <% end %>
+              <% end %>
+            <% else %>
+              <span class="font-medium"><%= b[:code].to_s.humanize %>:</span>
+              <%= b[:label] %>
+              <% if b[:count] %>
+                <span class="text-amber-800">(<%= b[:count] %>)</span>
+              <% end %>
             <% end %>
           </li>
         <% end %>
@@ -69,10 +108,26 @@
       <h2 class="text-xl font-semibold"><%= @classification[:retrospective_only] ? "Warnings (historical context)" : "Warnings" %></h2>
       <ul class="mt-3 list-disc space-y-2 pl-5 text-sm text-slate-700">
         <% @classification[:warnings].each do |w| %>
+          <% warn_href =
+               if w[:code].to_s == "pending_cash_movements"
+                 ops_cash_path(reviewed_business_date: bd, from_close_package: "1")
+               end %>
           <li>
-            <span class="font-medium"><%= w[:label] %></span>
-            <% if w[:count].to_i.positive? %>
-              <span class="text-slate-500">(<%= w[:count] %>)</span>
+            <% if warn_href.present? %>
+              <%= link_to warn_href, class: "font-medium text-slate-950 underline hover:text-slate-800" do %>
+                <%= w[:label] %>
+                <% if w[:count].to_i.positive? %>
+                  <span class="text-slate-500">(<%= w[:count] %>)</span>
+                <% end %>
+              <% end %>
+            <% else %>
+              <span class="font-medium"><%= w[:label] %></span>
+              <% if w[:count].to_i.positive? %>
+                <span class="text-slate-500">(<%= w[:count] %>)</span>
+              <% end %>
+              <% if w[:code].to_s == "unresolved_cash_variances" %>
+                <span class="mt-1 block text-xs text-slate-500">No drill target yet — landing list must match readiness semantics (ADR-0042).</span>
+              <% end %>
             <% end %>
           </li>
         <% end %>
@@ -97,6 +152,14 @@
     </section>
   <% end %>
 
+  <% bucket_drills = {
+    posted: ops_operational_events_path(business_date: bd, status: oe_status::STATUS_POSTED),
+    pending: ops_operational_events_path(business_date: bd, status: oe_status::STATUS_PENDING),
+    reversed: ops_operational_events_path(business_date: bd, event_type: "posting.reversal"),
+    overridden: ops_operational_events_path(business_date: bd, event_type_in: %w[override.requested override.approved]),
+    exception: ops_operational_events_path(business_date: bd, event_type: "overdraft.nsf_denied")
+  } %>
+
   <section class="mt-8 rounded border border-slate-200 bg-white shadow-sm">
     <div class="border-b border-slate-200 px-5 py-4">
       <h2 class="text-xl font-semibold">Classified evidence (primary buckets)</h2>
@@ -112,24 +175,39 @@
         exception: "Exceptions (e.g. NSF)"
       } %>
       <% @classification[:buckets].each do |key, data| %>
-        <div class="rounded border border-slate-100 bg-slate-50 p-4">
-          <p class="font-medium text-slate-950"><%= bucket_labels.fetch(key, key.to_s.humanize) %></p>
-          <p class="mt-2 text-2xl font-semibold"><%= data[:count] %></p>
-          <% ids = data[:operational_event_ids] || data[:hold_ids] %>
-          <% if ids.present? %>
-            <ul class="mt-2 space-y-1 text-xs text-slate-600">
-              <% ids.first(12).each do |id| %>
-                <li>
-                  <% if key == :held %>
-                    Hold #<%= id %>
-                  <% else %>
-                    <%= link_to "Event ##{id}", ops_operational_event_path(id), class: "text-slate-950 underline" %>
-                  <% end %>
-                </li>
-              <% end %>
-            </ul>
+        <% drill = bucket_drills[key] %>
+        <% bucket_inner = capture do %>
+          <div class="rounded border border-slate-100 bg-slate-50 p-4">
+            <p class="font-medium text-slate-950"><%= bucket_labels.fetch(key, key.to_s.humanize) %></p>
+            <p class="mt-2 text-2xl font-semibold"><%= data[:count] %></p>
+            <% if key == :held %>
+              <p class="mt-2 text-xs text-slate-500">Informational until Ops holds index ships (ADR-0042).</p>
+            <% elsif drill.present? %>
+              <p class="mt-2 text-xs text-slate-600">Drill to Ops event search with matching filters.</p>
+            <% end %>
+            <% ids = data[:operational_event_ids] || data[:hold_ids] %>
+            <% if ids.present? %>
+              <ul class="mt-2 space-y-1 text-xs text-slate-600">
+                <% ids.first(12).each do |id| %>
+                  <li>
+                    <% if key == :held %>
+                      Hold #<%= id %>
+                    <% else %>
+                      <%= link_to "Event ##{id}", ops_operational_event_path(id), class: "text-slate-950 underline" %>
+                    <% end %>
+                  </li>
+                <% end %>
+              </ul>
+            <% end %>
+          </div>
+        <% end %>
+        <% if drill.present? %>
+          <%= link_to drill, class: "block rounded border border-transparent text-inherit no-underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-700" do %>
+            <%= bucket_inner %>
           <% end %>
-        </div>
+        <% else %>
+          <%= bucket_inner %>
+        <% end %>
       <% end %>
     </div>
   </section>
@@ -141,7 +219,7 @@
   <section class="mt-8 rounded border border-slate-200 bg-white shadow-sm">
     <div class="border-b border-slate-200 px-5 py-4">
       <h2 class="text-xl font-semibold">Raw operational events</h2>
-      <p class="mt-1 text-sm text-slate-600">Full breakdown by status, channel, and event type for <%= @business_date.iso8601 %>.</p>
+      <p class="mt-1 text-sm text-slate-600">Full breakdown by status, channel, and event type for <%= bd %>.</p>
     </div>
     <div class="grid gap-4 p-5 text-sm md:grid-cols-4">
       <div>
@@ -156,43 +234,90 @@
         <% end %>
       </div>
       <div>
+        <% pc_href = ops_cash_path(reviewed_business_date: bd, from_close_package: "1") %>
         <p class="font-medium text-slate-500">Pending cash movements</p>
-        <p class="mt-1 text-lg font-semibold"><%= @readiness[:pending_cash_movements_count] %></p>
+        <p class="mt-1 text-lg font-semibold">
+          <%= link_to @readiness[:pending_cash_movements_count], pc_href, class: "text-slate-950 underline font-semibold" %>
+        </p>
       </div>
       <div>
         <p class="font-medium text-slate-500">Unresolved cash variances</p>
         <p class="mt-1 text-lg font-semibold"><%= @readiness[:unresolved_cash_variances_count] %></p>
+        <p class="mt-1 text-xs text-slate-500">Informational — no matching filtered drill yet.</p>
       </div>
     </div>
     <div class="grid gap-6 border-t border-slate-100 p-5 text-sm lg:grid-cols-3">
-      <% {
-        "By status" => @event_status_counts,
-        "By channel" => @event_channel_counts,
-        "By event type" => @event_type_counts
-      }.each do |label, counts| %>
-        <div>
-          <h3 class="font-semibold"><%= label %></h3>
-          <% if counts.any? %>
-            <dl class="mt-3 space-y-2">
-              <% counts.each do |key, count| %>
-                <div class="flex justify-between gap-3">
-                  <dt class="text-slate-600"><%= key.presence || "None" %></dt>
+      <div>
+        <h3 class="font-semibold">By status</h3>
+        <% if @event_status_counts.any? %>
+          <dl class="mt-3 space-y-2">
+            <% @event_status_counts.each do |key, count| %>
+              <div class="flex justify-between gap-3">
+                <% if key.present? %>
+                  <% href = ops_operational_events_path(business_date: bd, status: key) %>
+                  <dt class="text-slate-600"><%= link_to key, href, class: "text-slate-950 underline" %></dt>
+                  <dd class="font-medium"><%= link_to count, href, class: "text-slate-950 underline font-medium" %></dd>
+                <% else %>
+                  <dt class="text-slate-600">None</dt>
                   <dd class="font-medium"><%= count %></dd>
-                </div>
-              <% end %>
-            </dl>
-          <% else %>
-            <p class="mt-3 text-slate-600">No events.</p>
-          <% end %>
-        </div>
-      <% end %>
+                <% end %>
+              </div>
+            <% end %>
+          </dl>
+        <% else %>
+          <p class="mt-3 text-slate-600">No events.</p>
+        <% end %>
+      </div>
+      <div>
+        <h3 class="font-semibold">By channel</h3>
+        <% if @event_channel_counts.any? %>
+          <dl class="mt-3 space-y-2">
+            <% @event_channel_counts.each do |key, count| %>
+              <div class="flex justify-between gap-3">
+                <% if key.present? %>
+                  <% href = ops_operational_events_path(business_date: bd, channel: key) %>
+                  <dt class="text-slate-600"><%= link_to key, href, class: "text-slate-950 underline" %></dt>
+                  <dd class="font-medium"><%= link_to count, href, class: "text-slate-950 underline font-medium" %></dd>
+                <% else %>
+                  <dt class="text-slate-600">None</dt>
+                  <dd class="font-medium"><%= count %></dd>
+                <% end %>
+              </div>
+            <% end %>
+          </dl>
+        <% else %>
+          <p class="mt-3 text-slate-600">No events.</p>
+        <% end %>
+      </div>
+      <div>
+        <h3 class="font-semibold">By event type</h3>
+        <% if @event_type_counts.any? %>
+          <dl class="mt-3 space-y-2">
+            <% @event_type_counts.each do |key, count| %>
+              <div class="flex justify-between gap-3">
+                <% if key.present? %>
+                  <% href = ops_operational_events_path(business_date: bd, event_type: key) %>
+                  <dt class="text-slate-600"><%= link_to key, href, class: "text-slate-950 underline" %></dt>
+                  <dd class="font-medium"><%= link_to count, href, class: "text-slate-950 underline font-medium" %></dd>
+                <% else %>
+                  <dt class="text-slate-600">None</dt>
+                  <dd class="font-medium"><%= count %></dd>
+                <% end %>
+              </div>
+            <% end %>
+          </dl>
+        <% else %>
+          <p class="mt-3 text-slate-600">No events.</p>
+        <% end %>
+      </div>
     </div>
   </section>
 
   <section class="mt-8 grid gap-6 lg:grid-cols-2">
     <div class="rounded border border-slate-200 bg-white shadow-sm">
-      <div class="border-b border-slate-200 px-5 py-4">
+      <div class="border-b border-slate-200 px-5 py-4 flex flex-wrap items-center justify-between gap-3">
         <h2 class="text-xl font-semibold">Pending operational events</h2>
+        <%= link_to "View all pending", ops_operational_events_path(business_date: bd, status: oe_status::STATUS_PENDING), class: "text-sm font-medium text-slate-950 underline" %>
       </div>
       <% if @pending_events.any? %>
         <ul class="divide-y divide-slate-100">
@@ -209,14 +334,15 @@
     </div>
 
     <div class="rounded border border-slate-200 bg-white shadow-sm">
-      <div class="border-b border-slate-200 px-5 py-4">
+      <div class="border-b border-slate-200 px-5 py-4 flex flex-wrap items-center justify-between gap-3">
         <h2 class="text-xl font-semibold">Open or pending sessions</h2>
+        <%= link_to "Ops session queue", ops_teller_sessions_path, class: "text-sm font-medium text-slate-950 underline" %>
       </div>
       <% if @open_or_pending_sessions.any? %>
         <ul class="divide-y divide-slate-100">
           <% @open_or_pending_sessions.each do |session| %>
             <li class="px-5 py-4 text-sm">
-              <span class="font-medium">#<%= session.id %></span>
+              <%= link_to "##{session.id}", ops_teller_session_path(session), class: "font-medium text-slate-950 underline" %>
               <span class="text-slate-600"><%= session.status.humanize %> · <%= session.drawer_code.presence || "Default drawer" %></span>
             </li>
           <% end %>
@@ -249,9 +375,9 @@
     <h2 class="text-xl font-semibold">Close business date</h2>
     <% if @embedded_close_section %>
       <% if @readiness[:eod_ready] %>
-        <p class="mt-2 text-sm text-slate-600">This will close <%= @business_date.iso8601 %> and advance the singleton business date.</p>
+        <p class="mt-2 text-sm text-slate-600">This will close <%= bd %> and advance the singleton business date.</p>
         <%= form_with url: ops_business_date_close_path, method: :post, local: true, class: "mt-4" do %>
-          <%= hidden_field_tag :business_date, @business_date.iso8601 %>
+          <%= hidden_field_tag :business_date, bd %>
           <%= submit_tag "Close business date", class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
         <% end %>
       <% else %>
@@ -263,8 +389,8 @@
     <div class="mt-6 border-t border-slate-100 pt-4 text-sm text-slate-600">
       <p class="font-medium text-slate-800">Legacy pages</p>
       <ul class="mt-2 list-disc space-y-1 pl-5">
-        <li><%= link_to "EOD readiness (trial balance focus)", ops_eod_path(business_date: @business_date.iso8601), class: "text-slate-950 underline" %></li>
-        <li><%= link_to "Business date close (standalone)", ops_business_date_close_path(business_date: @business_date.iso8601), class: "text-slate-950 underline" %></li>
+        <li><%= link_to "EOD readiness (trial balance focus)", ops_eod_path(business_date: bd), class: "text-slate-950 underline" %></li>
+        <li><%= link_to "Business date close (standalone)", ops_business_date_close_path(business_date: bd), class: "text-slate-950 underline" %></li>
       </ul>
     </div>
   </section>

--- a/app/views/ops/operational_events/index.html.erb
+++ b/app/views/ops/operational_events/index.html.erb
@@ -13,6 +13,7 @@
       business_date_to: "Date to",
       status: "Status",
       event_type: "Event type",
+      operating_unit_id: "Operating unit id",
       channel: "Channel",
       source_account_id: "Source account id",
       destination_account_id: "Destination account id",
@@ -29,6 +30,27 @@
         <%= form.text_field field, value: params[field], class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
       </div>
     <% end %>
+
+    <div class="md:col-span-4">
+      <p class="text-sm font-medium text-slate-700">Event types (OR) — optional multi-select for drills</p>
+      <% preset_types = Array.wrap(params[:event_type_in]).reject(&:blank?) %>
+      <%= form.select :event_type_in,
+            options_for_select(
+              [
+                [ "override.requested", "override.requested" ],
+                [ "override.approved", "override.approved" ],
+                [ "posting.reversal", "posting.reversal" ],
+                [ "overdraft.nsf_denied", "overdraft.nsf_denied" ]
+              ],
+              preset_types
+            ),
+            {},
+            multiple: true,
+            name: "event_type_in[]",
+            class: "mt-1 min-h-[7rem] w-full max-w-xl rounded border border-slate-300 px-3 py-2",
+            size: 6 %>
+      <p class="mt-1 text-xs text-slate-500">Hold Ctrl/Cmd to select multiple. Leave empty when using single Event type above.</p>
+    </div>
 
     <div class="flex items-end gap-3 md:col-span-4">
       <%= form.submit "Search", class: "rounded bg-slate-900 px-4 py-2 font-medium text-white" %>
@@ -47,6 +69,21 @@
     Showing <%= envelope[:business_date_from].iso8601 %> to <%= envelope[:business_date_to].iso8601 %>.
     Current business date is <%= envelope[:current_business_on].iso8601 %>.
     Posting day closed: <%= envelope[:posting_day_closed] ? "yes" : "no" %>.
+    Results on this page: <%= @event_search[:rows].size %><%= @event_search[:has_more] ? " (more on next page)" : "" %>.
+    <% if @scoped_operating_unit.present? %>
+      Operating unit filter: <strong><%= @scoped_operating_unit.code %></strong> (id <%= @scoped_operating_unit.id %>).
+    <% end %>
+    <% if params[:event_type_in].present? %>
+      Event types (OR): <strong><%= Array.wrap(params[:event_type_in]).reject(&:blank?).join(", ") %></strong>.
+    <% elsif params[:event_type].present? %>
+      Event type: <strong><%= params[:event_type] %></strong>.
+    <% end %>
+    <% if params[:status].present? %>
+      Status: <strong><%= params[:status] %></strong>.
+    <% end %>
+    <% if params[:channel].present? %>
+      Channel: <strong><%= params[:channel] %></strong>.
+    <% end %>
   </section>
 
   <section class="mt-6 rounded border border-slate-200 bg-white shadow-sm">

--- a/app/views/ops/teller_sessions/index.html.erb
+++ b/app/views/ops/teller_sessions/index.html.erb
@@ -1,0 +1,42 @@
+<% content_for :title, "Ops Teller Sessions - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">Teller sessions</h1>
+    <p class="mt-2 text-slate-600">Open and pending-supervisor drawer sessions (institution-wide).</p>
+  </div>
+  <%= link_to "Close package", ops_close_package_path, class: "rounded border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700" %>
+</section>
+
+<section class="mt-8 rounded border border-slate-200 bg-white shadow-sm">
+  <% if @sessions.any? %>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-slate-200 text-sm">
+        <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+          <tr>
+            <th class="px-5 py-3">Session</th>
+            <th class="px-5 py-3">Status</th>
+            <th class="px-5 py-3">Drawer</th>
+            <th class="px-5 py-3">Operating unit</th>
+            <th class="px-5 py-3">Opened</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100">
+          <% @sessions.each do |session| %>
+            <tr class="hover:bg-slate-50">
+              <td class="px-5 py-4">
+                <%= link_to "##{session.id}", ops_teller_session_path(session), class: "font-semibold text-slate-950 underline" %>
+              </td>
+              <td class="px-5 py-4"><%= ops_status_badge(session.status) %></td>
+              <td class="px-5 py-4"><%= session.drawer_code.presence || "Default drawer" %></td>
+              <td class="px-5 py-4"><%= session.operating_unit&.code %> — <%= session.operating_unit&.name %></td>
+              <td class="px-5 py-4"><%= ops_time(session.opened_at) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <div class="px-5 py-8 text-sm text-slate-600">No open or pending-supervisor sessions.</div>
+  <% end %>
+</section>

--- a/app/views/ops/teller_sessions/show.html.erb
+++ b/app/views/ops/teller_sessions/show.html.erb
@@ -1,0 +1,70 @@
+<% content_for :title, "Teller Session ##{@session.id} - BankCORE" %>
+
+<section class="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+  <div>
+    <h1 class="text-3xl font-semibold">Teller session #<%= @session.id %></h1>
+    <p class="mt-2 text-slate-600"><%= @session.status.humanize %> · <%= @session.drawer_code.presence || "Default drawer" %></p>
+  </div>
+  <div class="flex flex-wrap gap-2">
+    <%= link_to "Session queue", ops_teller_sessions_path, class: "rounded border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700" %>
+    <%= link_to "Close package", ops_close_package_path, class: "rounded border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700" %>
+  </div>
+</section>
+
+<section class="mt-8 grid gap-4 md:grid-cols-3">
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Status</p>
+    <div class="mt-3"><%= ops_status_badge(@session.status) %></div>
+  </div>
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Operating unit</p>
+    <p class="mt-2 text-lg font-semibold"><%= @session.operating_unit&.code %> — <%= @session.operating_unit&.name %></p>
+  </div>
+  <div class="rounded border border-slate-200 bg-white p-5 shadow-sm">
+    <p class="text-sm font-medium text-slate-500">Cash location</p>
+    <p class="mt-2 text-lg font-semibold"><%= @session.cash_location&.name || "None" %></p>
+  </div>
+</section>
+
+<section class="mt-8 rounded border border-slate-200 bg-white shadow-sm">
+  <div class="border-b border-slate-200 px-5 py-4">
+    <h2 class="text-xl font-semibold">Operator &amp; timestamps</h2>
+  </div>
+  <dl class="grid gap-4 p-5 text-sm md:grid-cols-2">
+    <div>
+      <dt class="font-medium text-slate-500">Primary operator (from events)</dt>
+      <dd><%= @primary_operator&.display_name.presence || @primary_operator&.id || "Not attributed" %></dd>
+    </div>
+    <div>
+      <dt class="font-medium text-slate-500">Opened at</dt>
+      <dd><%= ops_time(@session.opened_at) %></dd>
+    </div>
+    <div>
+      <dt class="font-medium text-slate-500">Closed at</dt>
+      <dd><%= ops_time(@session.closed_at) %></dd>
+    </div>
+    <div>
+      <dt class="font-medium text-slate-500">Supervisor approval</dt>
+      <dd>
+        <% if @session.supervisor_approved_at.present? %>
+          <%= @session.supervisor_operator&.display_name.presence || "Supervisor ##{@session.supervisor_operator_id}" %>
+          at <%= ops_time(@session.supervisor_approved_at) %>
+        <% else %>
+          Not recorded
+        <% end %>
+      </dd>
+    </div>
+  </dl>
+</section>
+
+<section class="mt-8 rounded border border-slate-200 bg-white shadow-sm">
+  <div class="border-b border-slate-200 px-5 py-4">
+    <h2 class="text-xl font-semibold">Cash &amp; variance</h2>
+  </div>
+  <dl class="grid gap-4 p-5 text-sm md:grid-cols-2">
+    <div><dt class="font-medium text-slate-500">Opening cash</dt><dd><%= ops_money(@session.opening_cash_minor_units) %></dd></div>
+    <div><dt class="font-medium text-slate-500">Expected cash</dt><dd><%= ops_money(@session.expected_cash_minor_units) %></dd></div>
+    <div><dt class="font-medium text-slate-500">Actual cash</dt><dd><%= ops_money(@session.actual_cash_minor_units) %></dd></div>
+    <div><dt class="font-medium text-slate-500">Variance</dt><dd><%= ops_money(@session.variance_minor_units, signed: true) %></dd></div>
+  </dl>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,7 @@ Rails.application.routes.draw do
     resources :teller_variances, only: [ :index ] do
       post :approve, on: :member, action: :create
     end
+    resources :teller_sessions, only: %i[index show]
     get "cash", to: "cash#index", as: :cash
     post "cash/movements/:id/approve", to: "cash#approve_movement", as: :approve_cash_movement
     post "cash/variances/:id/approve", to: "cash#approve_variance", as: :approve_cash_variance

--- a/docs/adr/0042-business-date-monitoring-and-drilldown-surfaces.md
+++ b/docs/adr/0042-business-date-monitoring-and-drilldown-surfaces.md
@@ -1,6 +1,6 @@
 # ADR-0042: Business-date monitoring and drilldown surfaces
 
-**Status:** Proposed  
+**Status:** Accepted  
 **Date:** 2026-05-03  
 **Decision Type:** Internal workspace read model / monitoring surface / drilldown contract  
 **Aligns with:** [ADR-0016](0016-trial-balance-and-eod-readiness.md), [ADR-0018](0018-business-date-close-and-posting-invariant.md), [ADR-0025](0025-internal-workspace-ui.md), [ADR-0026](0026-branch-csr-servicing.md), [ADR-0031](0031-cash-inventory-and-management.md), [ADR-0032](0032-operating-units-and-branch-scope.md), [ADR-0037](0037-internal-staff-authorized-surfaces.md), [ADR-0038](0038-account-balance-projections-and-daily-snapshots.md), [ADR-0039](0039-teller-session-drawer-custody-projection.md), [ADR-0041](0041-close-package-and-eod-classification-taxonomy.md)
@@ -184,7 +184,7 @@ Examples:
   - time scope: session-lifecycle scoped
   - filters: session `status IN (open, pending_supervisor)`
   - aggregation: count of matching teller sessions
-  - drill target: teller-session queue or list with the same status filter
+  - drill target: `Ops::TellerSessionsController#index` with the same status filter (canonical Level 2 once implemented; see §4.6)
 
 - `pending_cash_movements_count`
   - owner: readiness or Cash-domain support query as applicable
@@ -214,6 +214,62 @@ BankCORE will use these time-scope categories:
   - examples: pending cash movements, unresolved cash variances, active holds where the primary question is whether the hold is active now
 
 When a metric mixes concerns, the metric definition must state which scope is primary and why.
+
+### 4.6 Implementation resolutions (binding)
+
+The following rules constrain HTML and shared-query work that implements this ADR. They do not change close policy, posting rules, or `eod_ready` composition.
+
+**Operational event listing (`ListOperationalEvents`)**
+
+- Extensions are **additive only**: default behavior, ordering, pagination, and single-`event_type` filtering remain unchanged when new params are omitted.
+- **`event_type_in`** (multi-value filter) uses repeated query parameters, for example  
+  `event_type_in[]=override.requested&event_type_in[]=override.approved`.
+- A request must **not** supply both **`event_type`** and **`event_type_in`**; respond with **`422 invalid_request`** (ambiguous drill semantics).
+- Normalize **`event_type_in`**: strip blanks, de-duplicate, cap at **10** types; if the normalized list is empty, treat the filter as **absent**.
+- Validation for **`event_type_in`** applies **only** when that param is supplied.
+- Callers include **Ops HTML**, **Branch HTML**, and **Teller JSON-backed** read paths. Do not tighten the shared query in ways that break existing account-activity or teller event listing behavior.
+- **Teller JSON** does not need to expose **`event_type_in`** in the first implementation slice unless explicitly chosen; controllers may continue permitting **`event_type`** only there.
+
+**Cash warning drills**
+
+- **`pending_cash_movements_count`** may drill to **`ops/cash`** when that screen already surfaces pending movements matching the metric intent.
+- **`unresolved_cash_variances_count`** remains **non-drillable** until a destination exposes the **same filtered record set** (reviewed business date and statuses) as the readiness count.
+- Do not make a warning **clickable** unless the landing screen explains the **same underlying record set** as the count (see §4.3 and §8.4).
+
+**Ops teller sessions**
+
+- **`Ops::TellerSessionsController#index`** is the canonical **Level 2** teller-session drill surface.
+- Default index filter: **`status IN (open, pending_supervisor)`**; default ordering: **`opened_at`**, then **`id`**.
+- **`#show`** should present at minimum: status, operator, operating unit, drawer code, cash location, `opened_at`, `closed_at`, `opening_cash_minor_units`, `expected_cash_minor_units`, `actual_cash_minor_units`, `variance_minor_units`, supervisor operator, and **`supervisor_approved_at`** (field names align to persisted columns as implemented).
+- Close-package session blockers and session lists link here once the controller exists.
+- **Same-page anchors** on the close package are **not** part of the long-term drill contract.
+
+**Held bucket**
+
+- The **`held`** bucket may remain **informational** (no Ops holds index) until after Ops teller-session pages ship; **event-backed** buckets and **raw** event breakdown drills take priority.
+- Revisit **`Ops::HoldsController#index`** after teller-session drills are canonical.
+
+**Branch `operating_unit_id` filtering**
+
+- When Branch event search applies **`operating_unit_id`**, the active scope must be **visible** in the UI; **no** hidden narrowing.
+- Provide **“Show all units”** (or equivalent) to clear the filter.
+- Branch-scoped views do **not** change institution-level **`eod_ready`** or close authority.
+
+**Explainability minimum**
+
+- Drill destinations must show the **reviewed business date** (when supplied by the drill) and **active filters** in visible copy, not only in form fields.
+- **Ops event search:** keep and reinforce the existing envelope/context line.
+- **Ops cash** and future Ops holds/session indexes: add a short **filter/context banner** when reached from close-package drills.
+
+**Authorization**
+
+- New Ops teller-session pages follow existing **`Ops::ApplicationController`** posture (e.g. **`require_ops_operator!`**). No extra capability gate unless product explicitly adds one.
+- If **`operating_unit_id`** is accepted on Ops or Branch event search, validate it against operating units the operator may legitimately scope (**no** arbitrary-ID probing).
+
+**Navigation**
+
+- For metrics backed by operational events, the default Level 2 landing remains **`ops/operational_events`** (§6.5).
+- For the **exception** classification bucket, the default drill is **`ops/operational_events`** with **`business_date`** and **`event_type=overdraft.nsf_denied`**. **`ops/exceptions`** remains a **workflow queue**, not the canonical Level 2 hub for that bucket count.
 
 ---
 
@@ -283,7 +339,7 @@ The following contract standardizes where Level 1 links should land.
 
 `open_teller_sessions_count` or `pending_supervisor` sessions
 
-- drill target: teller-session list filtered to open and pending-supervisor states
+- drill target: **`Ops::TellerSessionsController#index`** with default filter `status IN (open, pending_supervisor)` (ships in implementation Phase 3; until then, session blockers on the close package stay non-clickable rather than using anchor-only bridges as the long-term contract)
 - primary record: teller session
 - financial follow-up: expected cash, close attempt, variance approval evidence
 
@@ -297,13 +353,13 @@ The following contract standardizes where Level 1 links should land.
 
 `pending_cash_movements_count`
 
-- drill target: cash approvals list filtered to pending approvals
+- drill target: **`ops/cash`** when that screen already presents pending movements consistent with the readiness count
 - primary record: cash movement
 
 `unresolved_cash_variances_count`
 
-- drill target: cash reconciliation or variance review list
-- primary record: cash variance
+- drill target: **none** until a reconciliation or variance list exposes the **same** filtered record set as the readiness count for the reviewed business date (until then, display as informational only; see §4.6)
+- primary record: cash variance (conceptual)
 
 ### 6.3 Classification buckets from ADR-0041
 
@@ -321,16 +377,17 @@ The following contract standardizes where Level 1 links should land.
 
 `held`
 
-- drill target: hold index filtered to active holds relevant to the reviewed business date
+- drill target: hold index filtered to active holds relevant to the reviewed business date (**may remain informational** until an Ops holds index exists; §4.6)
 - if event-linked, hold detail should link back to the originating operational event
 
 `overridden`
 
-- drill target: Ops operational event search filtered to override event families
+- drill target: Ops operational event search with **`event_type_in`** covering `override.requested` and `override.approved` for the reviewed **`business_date`** (see §4.6); Ops search form multi-select for `event_type_in` is optional
 
 `exception`
 
-- drill target: Ops operational event search or exception queue filtered to abnormal event families such as `overdraft.nsf_denied`
+- drill target (default): Ops operational event search with **`business_date`** and **`event_type=overdraft.nsf_denied`**
+- **`ops/exceptions`** remains a workflow queue, **not** the canonical Level 2 hub for this bucket count
 
 ### 6.4 Raw breakdowns
 
@@ -372,15 +429,18 @@ Branch event detail may remain role-appropriate and action-oriented, but it shou
 
 ### 7.2 Teller-session detail
 
-Teller-session drilldown should explain:
+The canonical Level 3 surface for teller-session drills from the close package is **`Ops::TellerSessionsController#show`** (Level 2 is **`#index`** per §6.1).
 
-- operating unit
+It should explain at minimum:
+
+- status
 - operator
+- operating unit
+- drawer code and cash location
 - opened and closed timestamps
-- expected cash
-- actual cash
-- variance
-- supervisor approval state
+- **opening**, **expected**, and **actual** cash (minor units as persisted)
+- variance (minor units)
+- supervisor operator and **`supervisor_approved_at`**
 
 This truth path is teller-session and cash-control oriented, not journal-first.
 
@@ -428,10 +488,10 @@ The close package should stay institution-focused, not branch-themed.
 
 When a user drills from a summary number, the destination screen should make the number's definition legible.
 
-This may be as simple as showing:
+**Minimum (binding for implementation):** show **reviewed business date** (when supplied by the drill) and **active filters** in **visible copy**, not only embedded in form fields. Reinforce the Ops operational-event search envelope line; for **`ops/cash`** and future Ops holds or teller-session indexes reached from drills, add a short **filter/context banner**.
 
-- active filters
-- reviewed business date
+Additionally helpful:
+
 - record count
 - grouping dimension if grouped
 
@@ -444,25 +504,27 @@ Later slices may expose an explicit "Explain this number" action, but the minimu
 ### Phase 1: Make current business-date monitoring explicit
 
 - keep `ops/close_package` as canonical
-- add clearer current open-day language where needed
-- add branch-facing compact status panel linking to Ops close package
+- add clearer current open-day language where needed (reviewed date vs `current_business_on`)
+- add branch-facing compact status panel linking to Ops close package (and Branch events / cash as in §8.2)
 
-### Phase 2: Finish bucket drill links
+### Phase 2: Finish bucket drill links (event-backed first)
 
-- make close-package blocker, warning, and bucket counts clickable
-- standardize query params used by each link target
-- make raw status/channel/type counts link into event search
+- make **event-backed** classification buckets and **raw** status/channel/event-type breakdown counts clickable into **`ops/operational_events`** with standardized params (including **`event_type_in`** for the overridden bucket per §4.6)
+- **`pending_cash_movements_count`** may drill to **`ops/cash`** when consistent with the metric
+- **`unresolved_cash_variances_count`** and **`held`** remain **informational** until matching destinations exist (§4.6)
+- **session-related blockers** remain **non-clickable** until **`Ops::TellerSessionsController`** ships in Phase 3
 
-### Phase 3: Tighten record detail parity
+### Phase 3: Tighten record detail parity and canonical session drills
 
-- keep Ops event detail as canonical
-- improve Branch event detail where key trace fields are missing
-- add or improve native teller-session and Cash drill surfaces where counts currently dead-end
+- keep Ops event detail as canonical; improve Branch event detail where key trace fields are missing
+- ship **`Ops::TellerSessionsController#index`** and **`#show`** per §4.6 and §7.2; wire close-package session blockers and session lists to these routes
+- remove or ignore any temporary anchor-only bridges once session pages exist
+- revisit whether **`Ops::HoldsController#index`** is required immediately or can follow
 
 ### Phase 4: Strengthen scope-aware filtering
 
-- extend relevant event and support screens with better `operating_unit_id` filtering where the underlying records support it
-- preserve the distinction between operating-unit filtering and institution-level close authority
+- extend relevant event and support screens with **`operating_unit_id`** filtering where records support it; validate scope server-side (**no** arbitrary-ID probing per §4.6)
+- Branch: visible active scope and **“Show all units”** (or equivalent); preserve distinction between operating-unit filtering and institution-level close authority
 
 ### Phase 5: Optional later enhancements
 
@@ -510,5 +572,6 @@ Later slices may expose an explicit "Explain this number" action, but the minimu
 - Branch event index: `app/views/branch/operational_events/index.html.erb`
 - Branch event detail: `app/views/branch/operational_events/show.html.erb`
 - Ops exceptions: `app/views/ops/exceptions/index.html.erb`
+- Ops teller sessions: `app/controllers/ops/teller_sessions_controller.rb`, `app/views/ops/teller_sessions/index.html.erb`, `app/views/ops/teller_sessions/show.html.erb`
 - Branch cash position: `app/views/branch/cash/index.html.erb`
 - Ops cash monitoring: `app/views/ops/cash/index.html.erb`

--- a/test/domains/core/operational_events/list_operational_events_test.rb
+++ b/test/domains/core/operational_events/list_operational_events_test.rb
@@ -72,6 +72,41 @@ class CoreOperationalEventsListOperationalEventsTest < ActiveSupport::TestCase
     assert_equal 1, result[:rows].size
   end
 
+  test "filters by event_type_in" do
+    create_event!(event_type: "override.requested", idempotency_key: "o-req")
+    create_event!(event_type: "override.approved", idempotency_key: "o-app")
+    create_event!(event_type: "deposit.accepted", idempotency_key: "o-dep")
+
+    result = Core::OperationalEvents::Queries::ListOperationalEvents.call(
+      business_date: Date.new(2026, 5, 10),
+      event_type_in: %w[override.requested override.approved]
+    )
+    assert_equal [ "override.requested", "override.approved" ].to_set, result[:rows].map(&:event_type).to_set
+  end
+
+  test "rejects event_type combined with event_type_in" do
+    assert_raises(Core::OperationalEvents::Queries::ListOperationalEvents::InvalidQuery) do
+      Core::OperationalEvents::Queries::ListOperationalEvents.call(
+        event_type: "fee.assessed",
+        event_type_in: %w[override.requested]
+      )
+    end
+  end
+
+  test "filters by operating_unit_id" do
+    ev = record_deposit!(idem: "ou-filter", amount: 77)
+    ou_id = @session.operating_unit_id
+    assert ou_id.present?
+
+    result = Core::OperationalEvents::Queries::ListOperationalEvents.call(operating_unit_id: ou_id)
+    assert_equal [ ev.id ], result[:rows].map(&:id)
+
+    empty = Core::OperationalEvents::Queries::ListOperationalEvents.call(
+      operating_unit_id: ou_id + 99_999
+    )
+    assert_empty empty[:rows]
+  end
+
   test "filters by support search keys" do
     original = create_event!(
       event_type: "fee.assessed",

--- a/test/integration/ops/close_package_eod_test.rb
+++ b/test/integration/ops/close_package_eod_test.rb
@@ -15,6 +15,7 @@ class OpsClosePackageEodTest < ActionDispatch::IntegrationTest
     internal_login!(username: "ops-close-pkg")
     get ops_close_package_path
     assert_response :success
+    assert_includes response.body, "Business date context"
     assert_includes response.body, "Can we close?"
     assert_includes response.body, "Classified evidence (primary buckets)"
     assert_includes response.body, "Close business date"


### PR DESCRIPTION
## Summary

Implements the binding UI and query pieces from [ADR-0042](docs/adr/0042-business-date-monitoring-and-drilldown-surfaces.md) (Phases 1–4): business-date monitoring copy, close-package drill links into Ops operational events / EOD / cash / teller sessions, and scoped operational-event listing.

## What changed

- **Close package**: Reviewed vs open-day context; clickable readiness cards, blockers (sessions wired to Ops queue), warnings (pending cash only), classification buckets (held stays informational), raw breakdown rows, session rows linked to Ops detail.
- **ListOperationalEvents**: Optional `event_type_in` (422-style InvalidQuery if combined with `event_type`; normalized list capped at 10); optional `operating_unit_id`; additive defaults unchanged for existing callers.
- **Authorization**: `ResolveOperatingUnit.assert_operator_scoped_to_operating_unit!` guards OU filtering on Ops/Branch HTML event search.
- **Ops**: `Ops::TellerSessionsController` index/show; operational event search form gains OU field and optional multi-select for override drills; cash approvals banner when drilled from close package (`reviewed_business_date`, `from_close_package`).
- **Branch**: Dashboard "today" card with gated Ops close-package link; event search defaults scope to current OU with visible banner and "Show all units"; event detail shows reversal ids, operating unit, posting summary, and "View in Ops" when applicable.
- **ADR-0042**: §4.6 implementation resolutions and §11 file references updated.

## Intentionally not in this PR

- `Ops::HoldsController#index` and held-bucket drill (deferred).
- Clickable drill for unresolved cash variances until a list matches readiness semantics.
- Phase 5–6 (exports, saved views, materialized aggregates).

## How tested

`docker compose run --rm web bin/rails test` (full suite).

Made with [Cursor](https://cursor.com)