### PR TITLE
Support multi-check deposits

### DIFF
--- a/app/controllers/branch/check_deposits_controller.rb
+++ b/app/controllers/branch/check_deposits_controller.rb
@@ -9,13 +9,15 @@ module Branch
     end
 
     def create
-      @check_deposit = normalize_check_deposit_params(check_deposit_params)
+      @check_deposit = check_deposit_params
+      @check_deposit = normalize_check_deposit_params(@check_deposit)
       account_id = resolve_deposit_account_id(
         @check_deposit[:deposit_account_id],
         @check_deposit[:deposit_account_number]
       )
-      amount = @check_deposit[:amount_minor_units].to_i
-      payload = { "items" => [ build_payload_item(@check_deposit, amount) ] }
+      payload_items = build_payload_items(@check_deposit[:items])
+      amount = payload_items.sum { |item| item.fetch("amount_minor_units") }
+      payload = { "items" => payload_items }
 
       hold_minor = parse_hold_amount_minor_units(@check_deposit)
       hold_idem = resolved_hold_idempotency_key(@check_deposit, hold_minor)
@@ -66,9 +68,16 @@ module Branch
         "currency" => "USD",
         "teller_session_id" => params[:teller_session_id],
         "idempotency_key" => default_idempotency_key(prefix),
-        "identity_kind" => "reference",
-        "identity_value" => "",
-        "classification" => "",
+        "items" => [
+          {
+            "amount" => money_amount_display(params[:amount], fallback_minor_units: params[:amount_minor_units]),
+            "amount_minor_units" => params[:amount_minor_units],
+            "routing_number" => "",
+            "account_number" => "",
+            "check_serial_number" => "",
+            "classification" => ""
+          }
+        ],
         "hold_amount" => "",
         "hold_amount_minor_units" => params[:hold_amount_minor_units],
         "hold_idempotency_key" => "",
@@ -78,23 +87,16 @@ module Branch
 
     def check_deposit_params
       params.require(:check_deposit).permit(
-        :deposit_account_id, :deposit_account_number, :amount, :amount_minor_units, :currency, :teller_session_id,
-        :idempotency_key, :identity_kind, :identity_value, :classification, :hold_amount, :hold_amount_minor_units,
-        :hold_idempotency_key, :hold_expires_on
+        :deposit_account_id, :deposit_account_number, :currency, :teller_session_id,
+        :idempotency_key, :hold_amount, :hold_amount_minor_units, :hold_idempotency_key, :hold_expires_on,
+        items: %i[amount amount_minor_units routing_number account_number check_serial_number classification]
       ).to_h.symbolize_keys
     end
 
     def normalize_check_deposit_params(attrs)
       attrs[:currency] = attrs[:currency].presence || "USD"
       attrs[:idempotency_key] = attrs[:idempotency_key].presence || default_idempotency_key("branch-check-deposit")
-      attrs[:identity_kind] = attrs[:identity_kind].to_s == "serial" ? "serial" : "reference"
-      attrs[:amount] = money_amount_display(attrs[:amount], fallback_minor_units: attrs[:amount_minor_units])
-      attrs[:amount_minor_units] = normalize_money_amount_minor_units(
-        attrs[:amount],
-        fallback_minor_units: attrs[:amount_minor_units]
-      )
-      cls = attrs[:classification].to_s.strip
-      attrs[:classification] = cls if %w[on_us transit unknown].include?(cls)
+      attrs[:items] = normalize_check_deposit_items(attrs[:items])
 
       attrs[:hold_amount] = money_amount_display(
         attrs[:hold_amount],
@@ -103,18 +105,57 @@ module Branch
       attrs
     end
 
-    def build_payload_item(attrs, amount_minor_units)
-      raw_val = attrs[:identity_value].to_s.strip
-      raise ArgumentError, "check reference or serial is required" if raw_val.blank?
+    def normalize_check_deposit_items(raw_items)
+      items = Array(raw_items).filter_map do |raw_item|
+        item = raw_item.respond_to?(:to_h) ? raw_item.to_h.symbolize_keys : {}
+        next if blank_check_deposit_item?(item)
 
-      item = { "amount_minor_units" => amount_minor_units }
-      if attrs[:identity_kind] == "serial"
-        item["serial_number"] = raw_val
-      else
-        item["item_reference"] = raw_val
+        amount = money_amount_display(item[:amount], fallback_minor_units: item[:amount_minor_units])
+        normalized = {
+          "amount" => amount,
+          "amount_minor_units" => normalize_money_amount_minor_units(
+            amount,
+            fallback_minor_units: item[:amount_minor_units]
+          ),
+          "routing_number" => item[:routing_number].to_s.strip,
+          "account_number" => item[:account_number].to_s.strip,
+          "check_serial_number" => item[:check_serial_number].to_s.strip
+        }
+        cls = item[:classification].to_s.strip
+        normalized["classification"] = cls if %w[on_us transit unknown].include?(cls)
+        normalized
       end
-      item["classification"] = attrs[:classification] if attrs[:classification].present?
-      item
+      if items.blank?
+        raise ArgumentError, "at least one check item is required"
+      end
+
+      items
+    end
+
+    def blank_check_deposit_item?(item)
+      %i[amount amount_minor_units routing_number account_number check_serial_number classification].all? do |key|
+        item[key].blank?
+      end
+    end
+
+    def build_payload_items(items)
+      items.map.with_index do |item, idx|
+        routing_number = item["routing_number"].to_s.strip
+        account_number = item["account_number"].to_s.strip
+        check_serial_number = item["check_serial_number"].to_s.strip
+        if [ routing_number, account_number, check_serial_number ].any?(&:blank?)
+          raise ArgumentError, "check item #{idx + 1} requires routing number, account number, and check serial number"
+        end
+
+        payload_item = {
+          "amount_minor_units" => item.fetch("amount_minor_units").to_i,
+          "routing_number" => routing_number,
+          "account_number" => account_number,
+          "check_serial_number" => check_serial_number
+        }
+        payload_item["classification"] = item["classification"] if item["classification"].present?
+        payload_item
+      end
     end
 
     def parse_hold_amount_minor_units(attrs)

--- a/app/controllers/teller/operational_events_controller.rb
+++ b/app/controllers/teller/operational_events_controller.rb
@@ -123,7 +123,17 @@ module Teller
     def record_operational_event(attrs, hold_amount_minor_units: nil, hold_idempotency_key: nil, hold_expires_on: nil)
       if attrs[:event_type].to_s == Core::OperationalEvents::Commands::RecordEvent::CHECK_DEPOSIT_ACCEPTED
         payload_perm = params.require(:operational_event).permit(
-          payload: { items: %i[amount_minor_units item_reference serial_number classification] }
+          payload: {
+            items: %i[
+              amount_minor_units
+              item_reference
+              serial_number
+              routing_number
+              account_number
+              check_serial_number
+              classification
+            ]
+          }
         )
         payload_hash =
           if payload_perm[:payload].present?

--- a/app/domains/core/operational_events/services/check_deposit_payload.rb
+++ b/app/domains/core/operational_events/services/check_deposit_payload.rb
@@ -12,6 +12,8 @@ module Core
         MAX_ITEMS = 100
         MAX_SERIALIZED_BYTES = 65_536
         CLASSIFICATIONS = %w[on_us transit unknown].freeze
+        LEGACY_IDENTITY_KEYS = %w[item_reference serial_number].freeze
+        STRUCTURED_IDENTITY_KEYS = %w[routing_number account_number check_serial_number].freeze
 
         module_function
 
@@ -48,7 +50,15 @@ module Core
             item = raw_item.respond_to?(:to_unsafe_h) ? raw_item.to_unsafe_h : raw_item.to_h
             item = item.stringify_keys
 
-            unknown_item_keys = item.keys - %w[amount_minor_units item_reference serial_number classification]
+            unknown_item_keys = item.keys - %w[
+              amount_minor_units
+              item_reference
+              serial_number
+              routing_number
+              account_number
+              check_serial_number
+              classification
+            ]
             if unknown_item_keys.any?
               raise invalid,
                     "payload.items[#{idx}] unknown keys: #{unknown_item_keys.sort.join(", ")}"
@@ -61,41 +71,59 @@ module Core
             amt = item["amount_minor_units"].to_i
             raise invalid, "payload.items[#{idx}].amount_minor_units must be positive" unless amt.positive?
 
-            has_ref = item["item_reference"].present?
-            has_serial = item["serial_number"].present?
-            if has_ref && has_serial
+            legacy_present = LEGACY_IDENTITY_KEYS.select { |key| item[key].present? }
+            structured_present = STRUCTURED_IDENTITY_KEYS.select { |key| item[key].present? }
+
+            if legacy_present.any? && structured_present.any?
               raise invalid,
-                    "payload.items[#{idx}] must set only one of item_reference or serial_number"
-            end
-            unless has_ref || has_serial
-              raise invalid,
-                    "payload.items[#{idx}] must set exactly one of item_reference or serial_number"
+                    "payload.items[#{idx}] must use either legacy identity or structured check identity, not both"
             end
 
+            canonical_item = {
+              "amount_minor_units" => amt
+            }
+
             item_key =
-              if has_ref
-                item["item_reference"].to_s.strip
+              if structured_present.any?
+                unless structured_present.sort == STRUCTURED_IDENTITY_KEYS.sort
+                  missing = STRUCTURED_IDENTITY_KEYS - structured_present
+                  raise invalid,
+                        "payload.items[#{idx}] structured identity requires: #{missing.join(", ")}"
+                end
+
+                routing_number = item["routing_number"].to_s.strip
+                account_number = item["account_number"].to_s.strip
+                check_serial_number = item["check_serial_number"].to_s.strip
+                if [ routing_number, account_number, check_serial_number ].any?(&:blank?)
+                  raise invalid,
+                        "payload.items[#{idx}] structured identity fields cannot be blank"
+                end
+
+                canonical_item["routing_number"] = routing_number
+                canonical_item["account_number"] = account_number
+                canonical_item["check_serial_number"] = check_serial_number
+                [ routing_number, account_number, check_serial_number ].join(":")
               else
-                item["serial_number"].to_s.strip
+                if legacy_present.size != 1
+                  raise invalid,
+                        "payload.items[#{idx}] must set exactly one of item_reference or serial_number, or all structured check identity fields"
+                end
+
+                legacy_key = legacy_present.first
+                legacy_value = item[legacy_key].to_s.strip
+                if legacy_value.blank?
+                  raise invalid,
+                        "payload.items[#{idx}] identity field cannot be blank"
+                end
+
+                canonical_item[legacy_key] = legacy_value
+                legacy_value
               end
-            if item_key.blank?
-              raise invalid,
-                    "payload.items[#{idx}] identity field cannot be blank"
-            end
 
             if seen_keys[item_key]
               raise invalid, "duplicate item identity #{item_key.inspect}"
             end
             seen_keys[item_key] = true
-
-            canonical_item = {
-              "amount_minor_units" => amt
-            }
-            if has_ref
-              canonical_item["item_reference"] = item_key
-            else
-              canonical_item["serial_number"] = item_key
-            end
 
             if item.key?("classification") && item["classification"].present?
               cls = item["classification"].to_s
@@ -153,9 +181,17 @@ module Core
           masked =
             items.map do |it|
               it = it.respond_to?(:stringify_keys) ? it.stringify_keys : it.to_h.stringify_keys
-              ref = it["item_reference"].presence || it["serial_number"].presence
+              if structured_identity?(it)
+                {
+                  "routing_number_masked" => mask_identity(it["routing_number"].to_s),
+                  "account_number_masked" => mask_identity(it["account_number"].to_s),
+                  "check_serial_number_masked" => mask_identity(it["check_serial_number"].to_s)
+                }
+              else
+                ref = it["item_reference"].presence || it["serial_number"].presence
 
-              { "item_reference_masked" => mask_identity(ref.to_s) }
+                { "item_reference_masked" => mask_identity(ref.to_s) }
+              end
             end
           {
             "items_count" => items.size,
@@ -169,6 +205,10 @@ module Core
           return s if s.length <= 4
 
           "#{"*" * (s.length - 4)}#{s[-4..]}"
+        end
+
+        def structured_identity?(item)
+          STRUCTURED_IDENTITY_KEYS.all? { |key| item[key].present? }
         end
       end
     end

--- a/app/javascript/controllers/check_deposit_items_controller.js
+++ b/app/javascript/controllers/check_deposit_items_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["list", "template"]
+
+  add(event) {
+    event.preventDefault()
+    this.listTarget.insertAdjacentHTML("beforeend", this.templateTarget.innerHTML.trim())
+  }
+
+  remove(event) {
+    event.preventDefault()
+    const row = event.target.closest("[data-check-deposit-items-row]")
+    if (!row) return
+
+    const rows = this.listTarget.querySelectorAll("[data-check-deposit-items-row]")
+    if (rows.length === 1) {
+      this.clearRow(row)
+    } else {
+      row.remove()
+    }
+  }
+
+  clearRow(row) {
+    row.querySelectorAll("input").forEach((input) => {
+      input.value = ""
+    })
+    row.querySelectorAll("select").forEach((select) => {
+      select.selectedIndex = 0
+    })
+  }
+}

--- a/app/views/branch/check_deposits/new.html.erb
+++ b/app/views/branch/check_deposits/new.html.erb
@@ -1,5 +1,12 @@
 <% content_for :title, "Accept Check Deposit - BankCORE" %>
 <% normalized = @check_deposit.respond_to?(:to_h) ? @check_deposit.to_h.stringify_keys : @check_deposit.stringify_keys %>
+<% check_items = Array(normalized["items"]).presence || [ {} ] %>
+<% classification_options = [
+  [ "Not specified", "" ],
+  [ "On us", "on_us" ],
+  [ "Transit", "transit" ],
+  [ "Unknown", "unknown" ]
+] %>
 
 <%= render "shared/internal/page_header",
   title: "Accept check deposit",
@@ -47,42 +54,85 @@
     <% end %>
 
     <%= render "shared/internal/form_section",
-      title: "Check details",
-      description: "T1 form captures one check line. The stated total must match the item amount." do %>
-      <div class="grid gap-4 md:grid-cols-2">
-        <div>
-          <%= form.label :amount, "Check total amount", class: "block text-sm font-medium text-slate-700" %>
-          <%= form.text_field :amount, value: normalized["amount"], inputmode: "decimal", placeholder: "10.50", class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
-          <p class="mt-1 text-xs text-slate-500">T1 form: single check line; sum must match this total.</p>
+      title: "Check items",
+      description: "Enter each deposited check separately. The deposit total is calculated from these item amounts." do %>
+      <div data-controller="check-deposit-items">
+        <div class="space-y-4" data-check-deposit-items-target="list">
+          <% check_items.each do |item| %>
+            <% item = item.respond_to?(:to_h) ? item.to_h.stringify_keys : item.stringify_keys %>
+            <div class="rounded-xl border border-slate-200 bg-slate-50 p-4" data-check-deposit-items-row>
+              <div class="flex items-start justify-between gap-4">
+                <p class="text-sm font-medium text-slate-700">Check item</p>
+                <button type="button" class="text-sm font-medium text-red-700 hover:text-red-900" data-action="check-deposit-items#remove">Remove</button>
+              </div>
+              <div class="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+                <div>
+                  <%= label_tag nil, "Amount", class: "block text-sm font-medium text-slate-700" %>
+                  <%= text_field_tag "check_deposit[items][][amount]", item["amount"], id: nil, inputmode: "decimal", placeholder: "10.50", class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+                </div>
+
+                <div>
+                  <%= label_tag nil, "Routing number", class: "block text-sm font-medium text-slate-700" %>
+                  <%= text_field_tag "check_deposit[items][][routing_number]", item["routing_number"], id: nil, autocomplete: "off", inputmode: "numeric", class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+                </div>
+
+                <div>
+                  <%= label_tag nil, "Account number", class: "block text-sm font-medium text-slate-700" %>
+                  <%= text_field_tag "check_deposit[items][][account_number]", item["account_number"], id: nil, autocomplete: "off", class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+                </div>
+
+                <div>
+                  <%= label_tag nil, "Check (serial number)", class: "block text-sm font-medium text-slate-700" %>
+                  <%= text_field_tag "check_deposit[items][][check_serial_number]", item["check_serial_number"], id: nil, autocomplete: "off", class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+                </div>
+
+                <div>
+                  <%= label_tag nil, "Classification", class: "block text-sm font-medium text-slate-700" %>
+                  <%= select_tag "check_deposit[items][][classification]", options_for_select(classification_options, item["classification"]), id: nil, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+                </div>
+              </div>
+            </div>
+          <% end %>
         </div>
 
-        <div>
-          <%= form.label :classification, "Classification (optional)", class: "block text-sm font-medium text-slate-700" %>
-          <%= form.select :classification,
-            [
-              [ "Not specified", "" ],
-              [ "On us", "on_us" ],
-              [ "Transit", "transit" ],
-              [ "Unknown", "unknown" ]
-            ],
-            { selected: normalized["classification"] },
-            class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
-        </div>
+        <template data-check-deposit-items-target="template">
+          <div class="rounded-xl border border-slate-200 bg-slate-50 p-4" data-check-deposit-items-row>
+            <div class="flex items-start justify-between gap-4">
+              <p class="text-sm font-medium text-slate-700">Check item</p>
+              <button type="button" class="text-sm font-medium text-red-700 hover:text-red-900" data-action="check-deposit-items#remove">Remove</button>
+            </div>
+            <div class="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+              <div>
+                <%= label_tag nil, "Amount", class: "block text-sm font-medium text-slate-700" %>
+                <%= text_field_tag "check_deposit[items][][amount]", nil, id: nil, inputmode: "decimal", placeholder: "10.50", class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+              </div>
 
-        <div class="md:col-span-2">
-          <p class="text-sm font-medium text-slate-700">Item identity</p>
-          <div class="mt-2 flex flex-wrap gap-4 text-sm text-slate-700">
-            <label class="inline-flex items-center gap-2">
-              <%= form.radio_button :identity_kind, "reference", checked: normalized["identity_kind"] != "serial" %>
-              Item reference
-            </label>
-            <label class="inline-flex items-center gap-2">
-              <%= form.radio_button :identity_kind, "serial", checked: normalized["identity_kind"] == "serial" %>
-              Serial number
-            </label>
+              <div>
+                <%= label_tag nil, "Routing number", class: "block text-sm font-medium text-slate-700" %>
+                <%= text_field_tag "check_deposit[items][][routing_number]", nil, id: nil, autocomplete: "off", inputmode: "numeric", class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+              </div>
+
+              <div>
+                <%= label_tag nil, "Account number", class: "block text-sm font-medium text-slate-700" %>
+                <%= text_field_tag "check_deposit[items][][account_number]", nil, id: nil, autocomplete: "off", class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+              </div>
+
+              <div>
+                <%= label_tag nil, "Check (serial number)", class: "block text-sm font-medium text-slate-700" %>
+                <%= text_field_tag "check_deposit[items][][check_serial_number]", nil, id: nil, autocomplete: "off", class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+              </div>
+
+              <div>
+                <%= label_tag nil, "Classification", class: "block text-sm font-medium text-slate-700" %>
+                <%= select_tag "check_deposit[items][][classification]", options_for_select(classification_options, ""), id: nil, class: "mt-1 w-full rounded border border-slate-300 px-3 py-2" %>
+              </div>
+            </div>
           </div>
-          <%= form.text_field :identity_value, value: normalized["identity_value"], autocomplete: "off", placeholder: "Reference or serial", class: "mt-2 w-full rounded border border-slate-300 px-3 py-2" %>
-        </div>
+        </template>
+
+        <button type="button" class="mt-4 inline-flex items-center justify-center rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100" data-action="check-deposit-items#add">
+          Add another check
+        </button>
       </div>
     <% end %>
 

--- a/docs/adr/0040-check-deposit-vertical-slice.md
+++ b/docs/adr/0040-check-deposit-vertical-slice.md
@@ -101,11 +101,14 @@ The payload must support multiple deposited items in one customer action. The mi
 - `items[]`
 - per item:
   - `amount_minor_units`
-  - `item_reference` or `serial_number`
+  - structured check identity: `routing_number`, `account_number`, and `check_serial_number`
+  - legacy compatibility identity: `item_reference` or `serial_number`
 
-Optional placeholders such as routing or on-us/transit metadata may be added if needed for the first slice, but T1 does not require full MICR parsing, image capture, or clearing identifiers.
+Optional placeholders such as on-us/transit metadata may be added if needed for the first slice, but T1 does not require full MICR parsing, image capture, or clearing identifiers.
 
 This follows ADR-0002's guidance that instrument-heavy or mixed deposits may use a typed payload or child rows per family, without forcing a global line-item architecture.
+
+**2026-05-06 amendment:** Branch check-deposit intake now prompts for and transmits structured check identity (`routing_number`, `account_number`, `check_serial_number`) per item. The operational-event validator continues accepting the original `item_reference` / `serial_number` item shape for JSON client compatibility, but new Branch-originated check deposits should use the structured shape.
 
 ### 4.5 Posting and GL treatment
 

--- a/docs/concepts/302-teller-transaction-surface.md
+++ b/docs/concepts/302-teller-transaction-surface.md
@@ -26,7 +26,7 @@ For the **bank-wide capability taxonomy** (families **F1–F17**, phased **T1–
 
 **Module mapping (see [module catalog](../architecture/bankcore-module-catalog.md)):** `Teller` owns teller session lifecycle and workstation-facing cash flows; `Branch` is the internal staff HTML workspace over teller and servicing commands; `Core::OperationalEvents` records durable business facts; `Core::Posting` converts eligible financial events into balanced journal entries; `Core::Ledger` stores financial truth; `Accounts` owns deposit account state, holds, restrictions, lifecycle, and available-balance checks; `Cash` owns vault/drawer custody locations, movements, counts, balances, and cash variances; `Products` / `Deposits` own product-driven deposit behavior; `Workspace` / `Organization` own operators, capabilities, and operating-unit scope.
 
-**MVP vs broader scope:** Teller cash deposits, cash withdrawals, account transfers, manual fees, holds, reversals, teller sessions, drawer variance, trial balance, EOD readiness, and internal cash custody movements are MVP-aligned or already shipped in narrow slices. Check deposits, check cashing, official checks, loan payments, GL miscellaneous receipts, generalized approval queues, document-grade receipts, and external channel behavior are phased capabilities that require explicit ADR coverage before implementation.
+**MVP vs broader scope:** Teller cash deposits, accepted check deposits, cash withdrawals, account transfers, manual fees, holds, reversals, teller sessions, drawer variance, trial balance, EOD readiness, and internal cash custody movements are MVP-aligned or already shipped in narrow slices. Check cashing, check clearing/returns, official checks, loan payments, GL miscellaneous receipts, generalized approval queues, document-grade receipts, and external channel behavior are phased capabilities that require explicit ADR coverage before implementation.
 
 **Staff authorized surfaces:** Branch HTML teller line, teller supervisor, CSR, and JSON `/teller` surfaces orchestrate access. They do not own domain state. Capability gates and operating-unit scope remain governed by [ADR-0029](../adr/0029-capability-first-authorization-layer.md), [ADR-0032](../adr/0032-operating-units-and-branch-scope.md), and [ADR-0037](../adr/0037-internal-staff-authorized-surfaces.md).
 
@@ -50,6 +50,7 @@ The current BankCORE teller/branch transaction surface should be treated as the 
 | Teller activity | Primary owner | Evidence | Posting behavior | MVP posture |
 | --- | --- | --- | --- | --- |
 | Cash deposit to deposit account | `Core::OperationalEvents`, `Teller` | `deposit.accepted` | Dr `1110` / Cr `2110` | Shipped |
+| Check deposit to deposit account | `Core::OperationalEvents`, `Accounts`, `Teller` | `check.deposit.accepted`; optional linked hold | Dr `1160` / Cr `2110`; no drawer cash delta | Shipped |
 | Cash withdrawal | `Core::OperationalEvents`, `Accounts`, `Teller` | `withdrawal.posted` or `overdraft.nsf_denied` | Dr `2110` / Cr `1110`; NSF denial is no-GL plus possible fee | Shipped |
 | Account-to-account transfer | `Core::OperationalEvents`, `Accounts` | `transfer.completed` or `overdraft.nsf_denied` | Dr source `2110` / Cr destination `2110` | Shipped |
 | Manual fee assessment | `Core::OperationalEvents`, `Core::Posting` | `fee.assessed` | Dr `2110` / Cr fee income | Shipped |
@@ -76,6 +77,7 @@ Use this matrix to decide whether a teller-facing change belongs in the MVP tran
 | Activity | MVP classification | Command / controller surface | Durable evidence | Acceptance proof |
 | --- | --- | --- | --- | --- |
 | Cash deposit | MVP / shipped | `Branch::DepositsController`, `Teller::OperationalEventsController`, `Core::OperationalEvents::Commands::RecordEvent`, `Core::Posting::Commands::PostEvent` | `deposit.accepted`, posting batch, journal entry | Branch form can record-only and record-and-post; open teller session is required where configured; journal posts Dr `1110` / Cr `2110`; posting applies drawer custody delta for session-linked teller cash per [ADR-0039](../adr/0039-teller-session-drawer-custody-projection.md) |
+| Check deposit | MVP / shipped | `Branch::CheckDepositsController`, `Teller::OperationalEventsController`, `Core::OperationalEvents::Commands::AcceptCheckDeposit` | `check.deposit.accepted`, posting batch, journal entry, optional linked hold | Branch form accepts one or more structured check items; JSON accepts structured and legacy item payloads; journal posts Dr `1160` / Cr `2110`; optional event-level holds constrain availability; no teller drawer cash delta ([ADR-0040](../adr/0040-check-deposit-vertical-slice.md)) |
 | Cash withdrawal | MVP / shipped | `Branch::WithdrawalsController`, `Accounts::Commands::AuthorizeDebit`, `Core::Posting::Commands::PostEvent` | `withdrawal.posted` or `overdraft.nsf_denied`; optional NSF fee event | Branch form can record-and-post; insufficient funds produces NSF denial evidence instead of an invalid withdrawal; posting applies drawer custody delta for session-linked teller cash per [ADR-0039](../adr/0039-teller-session-drawer-custody-projection.md) |
 | Account transfer | MVP / shipped | `Branch::TransfersController`, `Accounts::Commands::AuthorizeDebit`, `Core::Posting::Commands::PostEvent` | `transfer.completed` or `overdraft.nsf_denied` | Transfer posts balanced source/destination `2110` legs; insufficient funds follows the same NSF denial path as withdrawals |
 | Manual fee assessment | MVP / shipped | `Core::OperationalEvents::Commands::RecordEvent`, `Core::Posting::Commands::PostEvent`; Branch/JSON event entry surfaces | `fee.assessed` | Fee event records and posts separately from the customer transaction that triggered it |
@@ -91,7 +93,7 @@ Use this matrix to decide whether a teller-facing change belongs in the MVP tran
 | Cash variance approval | MVP-adjacent cash foundation / shipped | Ops/JSON Cash variance approval surfaces, `Cash::Commands::ApproveCashVariance` | `cash_variance.posted` event and journal when approved | Approved variance posts GL adjustment through `Core::Posting`; no-self-approval and state guards apply |
 | Trial balance / EOD readiness | MVP / shipped | JSON reports, Ops EOD/close package surfaces, `Teller::Queries::EodReadiness`, `Core::Ledger::Queries::TrialBalanceForBusinessDate` | read-only readiness and trial-balance evidence | Readiness exposes pending events, open sessions, trial-balance status, and close evidence without mutating financial truth |
 
-Items not listed above are not part of the teller MVP unless a follow-up ADR explicitly pulls them forward. In particular, check deposits, check cashing, official checks, loan payments, GL miscellaneous receipts, generalized approval queues, durable receipt documents, and denomination-level drawer tickets remain later slices.
+Items not listed above are not part of the teller MVP unless a follow-up ADR explicitly pulls them forward. In particular, check cashing, check clearing/returns, official checks, loan payments, GL miscellaneous receipts, generalized approval queues, durable receipt documents, and denomination-level drawer tickets remain later slices.
 
 ## Near-Term Teller UI Capabilities
 
@@ -335,6 +337,7 @@ The teller MVP should be proven by a focused set of integration and domain tests
 | Teller JSON money flows | `test/integration/teller/teller_requests_test.rb`, operational-event integration tests | Existing JSON `/teller` behavior remains stable while Branch HTML flows wrap the same domain commands |
 | Session cash policy | `test/integration/teller/teller_session_cash_policy_test.rb`, `test/domains/teller/expected_cash_for_session_test.rb` | Expected cash uses opening snapshot plus **posted** teller cash events (pending excluded); deposits increase expected cash and withdrawals decrease it when posted; session-attributed movements participate when configured; missing/closed sessions are rejected where configured |
 | NSF and available balance | `test/integration/teller/overdraft_nsf_test.rb`, `test/domains/accounts/authorize_debit_test.rb` | Insufficient funds create `overdraft.nsf_denied` evidence and forced fee behavior rather than invalid postings |
+| Check deposits | `test/domains/core/operational_events/accept_check_deposit_test.rb`, `test/integration/teller/check_deposit_accepted_test.rb`, `test/integration/branch_check_deposit_test.rb` | Multi-item check deposits post through `AcceptCheckDeposit`, preserve item payload evidence, support optional event-level holds, and do not affect expected teller cash |
 | Holds | `test/integration/teller/holds_deposit_linked_test.rb`, `test/domains/accounts/place_hold_deposit_link_test.rb`, `test/domains/accounts/expire_due_holds_test.rb` | Holds are no-GL, affect available balance, enforce deposit-link rules, and can release/expire through controlled paths |
 | Reversals | `test/domains/core/operational_events/record_reversal_deposit_hold_guard_test.rb`, reversal integration coverage | Reversals create linked compensating events and journals; guarded events are rejected |
 | Fee waiver and servicing controls | `test/integration/branch_customer_servicing_test.rb`, capability tests | Supervisor/capability-gated fee waiver and hold release remain controlled and traceable |
@@ -351,10 +354,11 @@ Minimum end-to-end MVP proof:
 4. Exercise an NSF denial path.
 5. Complete an account transfer.
 6. Place and release a hold.
-7. Reverse an eligible posted event.
-8. Close the teller session with server-computed expected vs operator-supplied actual count.
-9. Move cash between vault and drawer and prove ordinary custody movement is no-GL.
-10. Confirm trial balance/EOD readiness reflects unresolved teller work.
+7. Record and post a multi-item check deposit, with optional event-level hold evidence.
+8. Reverse an eligible posted event.
+9. Close the teller session with server-computed expected vs operator-supplied actual count.
+10. Move cash between vault and drawer and prove ordinary custody movement is no-GL.
+11. Confirm trial balance/EOD readiness reflects unresolved teller work.
 
 Tests should prefer existing domain commands and workspace routes over new generic transaction abstractions. If implementation later adds preview endpoints, tests should assert that previews are advisory and that command execution re-checks state before commit.
 
@@ -364,12 +368,12 @@ The following capabilities are legitimate banking needs, but they veer beyond Ba
 
 | Capability | Likely owner | Why it is not teller MVP |
 | --- | --- | --- |
-| Check deposit, on-us or transit | `Integration`, `Accounts`, possibly future item-processing domain | Requires item lifecycle, availability rules, returns, collection risk, and check metadata |
+| Check clearing, returns, and settlement | `Integration`, `Accounts`, possibly future item-processing domain | Accepted check deposits are shipped, but clearing lifecycle, returns, collection risk, and settlement-specific item state remain outside the narrow intake slice |
 | Check cashing | future `Instruments` or check domain, `Cash`, `Core::Posting` | Requires presenter authority, check item lifecycle, limits, returns, and cash payout risk |
 | Official check / bank draft issuance | future `Instruments` | Requires instrument records, liability account, issue/void/paid/replacement lifecycle, reconciliation |
 | Loan payment | `Loans`, `Core::Posting` | Requires loan servicing, amortization, allocation, delinquency, and loan GL rules |
 | GL miscellaneous receipt | `Core::Ledger` plus a controlled Operations/Admin surface | Non-account GL intake is high-risk and should not be a generic teller shortcut |
-| Multi-check deposit ticket | item-processing domain plus `Integration` | Requires item detail, balancing, holds, return handling, and operational proofing |
+| Item-level check holds, release, and reversal | item-processing domain plus `Integration` / `Accounts` | Multi-item accepted deposits are shipped with event-level holds only; item-specific availability, release, return, and reversal semantics require separate ownership and controls |
 | Full approval queue | `Workflow` | Requires durable approval request/decision model beyond command-specific gates |
 | Document-grade receipt storage | `Documents`, `Reporting` | Requires retention, rendering, storage, reprint policy, and audit rules |
 | Denomination-level drawer activity | `Cash` | Requires denomination models for movements/counts and reconciliation |
@@ -470,6 +474,6 @@ Create or update an ADR before implementing any teller surface slice that:
 
 ## Suggested Summary
 
-BankCORE should treat Teller as a controlled transaction entry surface, not a catch-all banking operations module. The MVP teller surface covers cash deposits, cash withdrawals, account transfers, manual fees and waivers, holds, controlled reversals, teller sessions, drawer variance, receipt/trace evidence, and initiation of internal cash custody movements. The system guarantee is that financial impact flows through operational events and balanced posting, while physical cash custody flows through Cash locations and movements.
+BankCORE should treat Teller as a controlled transaction entry surface, not a catch-all banking operations module. The MVP teller surface covers cash deposits, accepted check deposits, cash withdrawals, account transfers, manual fees and waivers, holds, controlled reversals, teller sessions, drawer variance, receipt/trace evidence, and initiation of internal cash custody movements. The system guarantee is that financial impact flows through operational events and balanced posting, while physical cash custody flows through Cash locations and movements.
 
-Check deposits, check cashing, official checks, loan payments, miscellaneous GL receipts, generalized approval queues, denomination-level activity, and document-grade receipts are valid future capabilities, but they belong to later domain-owned slices with explicit ADR coverage.
+Check clearing/returns, check cashing, official checks, loan payments, miscellaneous GL receipts, generalized approval queues, denomination-level activity, and document-grade receipts are valid future capabilities, but they belong to later domain-owned slices with explicit ADR coverage.

--- a/docs/operational_events/check-deposit-accepted.md
+++ b/docs/operational_events/check-deposit-accepted.md
@@ -45,7 +45,9 @@ Records that the institution **accepted** a **check deposit** ticket against an 
 Each item:
 
 - `amount_minor_units` (positive integer)
-- **Exactly one** of `item_reference` or `serial_number` (non-blank string after strip)
+- Preferred structured identity: **all** of `routing_number`, `account_number`, and `check_serial_number` (non-blank strings after strip)
+- Legacy identity, still accepted for compatibility: **exactly one** of `item_reference` or `serial_number` (non-blank string after strip)
+- Do not mix structured identity fields with legacy identity fields on the same item
 - Optional `classification`: `on_us`, `transit`, or `unknown` only when present
 - **No other keys** at item or payload root (root allows only `items`).
 
@@ -75,7 +77,7 @@ Limits: max **100** items; serialized canonical JSON max **65536** bytes.
 | Surface | Policy |
 | --- | --- |
 | Detail | Full normalized **`payload`** (`items`). |
-| List / search / receipts | **`payload_summary`** only (`items_count`, totals, masked identities) — no full `items` array. |
+| List / search / receipts | **`payload_summary`** only (`items_count`, totals, masked structured or legacy identities) — no full `items` array. |
 
 ## Module ownership
 
@@ -103,8 +105,19 @@ Minimal teller JSON (orchestration entry via `POST /teller/operational_events`):
     "source_account_id": 42,
     "payload": {
       "items": [
-        { "amount_minor_units": 3000, "item_reference": "CHK-A", "classification": "on_us" },
-        { "amount_minor_units": 2000, "serial_number": "987654321" }
+        {
+          "amount_minor_units": 3000,
+          "routing_number": "011000015",
+          "account_number": "0001234500",
+          "check_serial_number": "1001",
+          "classification": "on_us"
+        },
+        {
+          "amount_minor_units": 2000,
+          "routing_number": "021000021",
+          "account_number": "987654321",
+          "check_serial_number": "2055"
+        }
       ]
     },
     "hold_amount_minor_units": 5000,

--- a/test/domains/core/operational_events/accept_check_deposit_test.rb
+++ b/test/domains/core/operational_events/accept_check_deposit_test.rb
@@ -111,6 +111,124 @@ class AcceptCheckDepositTest < ActiveSupport::TestCase
     assert_equal release_on, r[:hold].expires_on
   end
 
+  test "records structured check identity fields" do
+    idem = "chk-structured-#{SecureRandom.hex(6)}"
+    payload = {
+      "items" => [
+        {
+          "amount_minor_units" => 3_000,
+          "routing_number" => "011000015",
+          "account_number" => "0001234500",
+          "check_serial_number" => "1001",
+          "classification" => "on_us"
+        },
+        {
+          "amount_minor_units" => 2_000,
+          "routing_number" => "021000021",
+          "account_number" => "987654321",
+          "check_serial_number" => "2055"
+        }
+      ]
+    }
+
+    r = Core::OperationalEvents::Commands::AcceptCheckDeposit.call(
+      channel: "teller",
+      idempotency_key: idem,
+      amount_minor_units: 5_000,
+      currency: "USD",
+      source_account_id: @account.id,
+      actor_id: @operator.id,
+      payload: payload
+    )
+
+    assert_equal :created, r[:record_outcome]
+    assert_equal payload, r[:operational_event].reload.payload
+
+    summary = Core::OperationalEvents::Services::CheckDepositPayload.payload_summary(payload)
+    assert_equal 2, summary.fetch("items_count")
+    assert_equal 5_000, summary.fetch("amount_minor_units_total")
+    assert_equal "*****0015", summary.fetch("items_masked").first.fetch("routing_number_masked")
+  end
+
+  test "rejects partial structured check identity fields" do
+    idem = "chk-partial-#{SecureRandom.hex(4)}"
+    payload = {
+      "items" => [
+        { "amount_minor_units" => 100, "routing_number" => "011000015", "check_serial_number" => "1001" }
+      ]
+    }
+
+    err = assert_raises(Core::OperationalEvents::Commands::RecordEvent::InvalidRequest) do
+      Core::OperationalEvents::Commands::AcceptCheckDeposit.call(
+        channel: "teller",
+        idempotency_key: idem,
+        amount_minor_units: 100,
+        currency: "USD",
+        source_account_id: @account.id,
+        payload: payload
+      )
+    end
+    assert_match(/structured identity requires/, err.message)
+  end
+
+  test "rejects duplicate structured check identity" do
+    idem = "chk-dup-#{SecureRandom.hex(4)}"
+    payload = {
+      "items" => [
+        {
+          "amount_minor_units" => 100,
+          "routing_number" => "011000015",
+          "account_number" => "0001234500",
+          "check_serial_number" => "1001"
+        },
+        {
+          "amount_minor_units" => 200,
+          "routing_number" => "011000015",
+          "account_number" => "0001234500",
+          "check_serial_number" => "1001"
+        }
+      ]
+    }
+
+    err = assert_raises(Core::OperationalEvents::Commands::RecordEvent::InvalidRequest) do
+      Core::OperationalEvents::Commands::AcceptCheckDeposit.call(
+        channel: "teller",
+        idempotency_key: idem,
+        amount_minor_units: 300,
+        currency: "USD",
+        source_account_id: @account.id,
+        payload: payload
+      )
+    end
+    assert_match(/duplicate item identity/, err.message)
+  end
+
+  test "rejects structured item total mismatch" do
+    idem = "chk-total-#{SecureRandom.hex(4)}"
+    payload = {
+      "items" => [
+        {
+          "amount_minor_units" => 200,
+          "routing_number" => "011000015",
+          "account_number" => "0001234500",
+          "check_serial_number" => "1001"
+        }
+      ]
+    }
+
+    err = assert_raises(Core::OperationalEvents::Commands::RecordEvent::InvalidRequest) do
+      Core::OperationalEvents::Commands::AcceptCheckDeposit.call(
+        channel: "teller",
+        idempotency_key: idem,
+        amount_minor_units: 201,
+        currency: "USD",
+        source_account_id: @account.id,
+        payload: payload
+      )
+    end
+    assert_match(/sum of payload.items amounts/, err.message)
+  end
+
   test "requires distinct hold idempotency key when holding" do
     idem = "chk-same-#{SecureRandom.hex(4)}"
     payload = { "items" => [ { "amount_minor_units" => 100, "item_reference" => "X" } ] }

--- a/test/integration/branch_check_deposit_test.rb
+++ b/test/integration/branch_check_deposit_test.rb
@@ -12,7 +12,7 @@ class BranchCheckDepositIntegrationTest < ActionDispatch::IntegrationTest
     @account = Accounts::Commands::OpenAccount.call(party_record_id: @party.id)
   end
 
-  test "branch accept check deposit posts and shows hold when requested" do
+  test "branch accept check deposit posts multiple structured items and shows hold when requested" do
     internal_login!(username: "chk-branch-html")
 
     idem = "br-int-chk-#{SecureRandom.hex(6)}"
@@ -21,11 +21,23 @@ class BranchCheckDepositIntegrationTest < ActionDispatch::IntegrationTest
     post branch_check_deposits_path, params: {
       check_deposit: {
         deposit_account_number: @account.account_number,
-        amount: "42.75",
         currency: "USD",
-        identity_kind: "reference",
-        identity_value: "BR-CHK-REF",
-        classification: "on_us",
+        items: [
+          {
+            amount: "30.00",
+            routing_number: "011000015",
+            account_number: "0001234500",
+            check_serial_number: "1001",
+            classification: "on_us"
+          },
+          {
+            amount: "12.75",
+            routing_number: "021000021",
+            account_number: "987654321",
+            check_serial_number: "2055",
+            classification: "transit"
+          }
+        ],
         hold_amount: "42.75",
         hold_idempotency_key: hold_idem,
         hold_expires_on: "2026-08-15",
@@ -41,6 +53,27 @@ class BranchCheckDepositIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal "check.deposit.accepted", ev.event_type
     assert_equal "posted", ev.status
     assert_equal 4_275, ev.amount_minor_units
+    assert_equal(
+      {
+        "items" => [
+          {
+            "amount_minor_units" => 3_000,
+            "routing_number" => "011000015",
+            "account_number" => "0001234500",
+            "check_serial_number" => "1001",
+            "classification" => "on_us"
+          },
+          {
+            "amount_minor_units" => 1_275,
+            "routing_number" => "021000021",
+            "account_number" => "987654321",
+            "check_serial_number" => "2055",
+            "classification" => "transit"
+          }
+        ]
+      },
+      ev.payload
+    )
     hold = Accounts::Models::Hold.find_by!(placed_for_operational_event_id: ev.id)
     assert_equal Date.new(2026, 8, 15), hold.expires_on
   end

--- a/test/integration/branch_transaction_forms_test.rb
+++ b/test/integration/branch_transaction_forms_test.rb
@@ -32,7 +32,7 @@ class BranchTransactionFormsTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, "Accept check deposit"
     assert_includes response.body, "Account and session context"
-    assert_includes response.body, "Check details"
+    assert_includes response.body, "Check items"
     assert_includes response.body, "Hold options"
     assert_includes response.body, "Review and submit"
   end

--- a/test/integration/teller/check_deposit_accepted_test.rb
+++ b/test/integration/teller/check_deposit_accepted_test.rb
@@ -31,8 +31,19 @@ class CheckDepositAcceptedIntegrationTest < ActionDispatch::IntegrationTest
         hold_expires_on: "2026-04-28",
         payload: {
           items: [
-            { amount_minor_units: 400, item_reference: "REF-A", classification: "on_us" },
-            { amount_minor_units: 350, serial_number: "SER-B" }
+            {
+              amount_minor_units: 400,
+              routing_number: "011000015",
+              account_number: "0001234500",
+              check_serial_number: "1001",
+              classification: "on_us"
+            },
+            {
+              amount_minor_units: 350,
+              routing_number: "021000021",
+              account_number: "987654321",
+              check_serial_number: "2055"
+            }
           ]
         }
       }
@@ -54,6 +65,40 @@ class CheckDepositAcceptedIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal 2, row["payload_summary"]["items_count"]
     assert_nil row["payload"]
     refute row.key?("items")
+  end
+
+  test "POST operational_events still accepts legacy check item identity" do
+    idem = "chk-http-legacy-#{SecureRandom.hex(6)}"
+    body = {
+      operational_event: {
+        event_type: "check.deposit.accepted",
+        channel: "teller",
+        idempotency_key: idem,
+        amount_minor_units: 750,
+        currency: "USD",
+        source_account_id: @account.id,
+        payload: {
+          items: [
+            { amount_minor_units: 400, item_reference: "REF-A", classification: "on_us" },
+            { amount_minor_units: 350, serial_number: "SER-B" }
+          ]
+        }
+      }
+    }
+
+    post "/teller/operational_events", params: body.to_json, headers: teller_json_headers(@teller_operator)
+    assert_response :created
+
+    ev = Core::OperationalEvents::Models::OperationalEvent.find_by!(channel: "teller", idempotency_key: idem)
+    assert_equal(
+      {
+        "items" => [
+          { "amount_minor_units" => 400, "item_reference" => "REF-A", "classification" => "on_us" },
+          { "amount_minor_units" => 350, "serial_number" => "SER-B" }
+        ]
+      },
+      ev.payload
+    )
   end
 
   test "GET event_types includes check deposit with teller-only channels" do


### PR DESCRIPTION
## Summary
- Adds structured per-check identity fields for check deposits while preserving legacy teller JSON payload compatibility.
- Updates Branch check deposit intake to support multiple check rows and compute the aggregate deposit total server-side.
- Documents the preferred structured payload shape and expands focused coverage for validation, Branch intake, and JSON compatibility.

## Test plan
- docker compose run --rm web bin/rails test test/domains/core/operational_events/accept_check_deposit_test.rb test/integration/teller/check_deposit_accepted_test.rb test/integration/branch_check_deposit_test.rb test/integration/branch_transaction_forms_test.rb
- docker compose run --rm web bin/rails test

Made with [Cursor](https://cursor.com)